### PR TITLE
Migrate @dfinity/* packages to @icp-sdk/*

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -29,7 +29,7 @@ The asset canister hosts static files (HTML, CSS, JS, images) directly on the In
 
 - icp-cli >= 0.1.0 (`brew install dfinity/tap/icp-cli`)
 - Node.js >= 18 (for building frontend assets)
-- `@dfinity/assets` npm package (for programmatic uploads)
+- `@icp-sdk/canisters` npm package (for programmatic uploads)
 
 ## Canister IDs
 
@@ -54,7 +54,7 @@ Access patterns:
 
 5. **Deploying to the wrong canister name.** If icp.json has `"frontend"` but you run `icp deploy assets`, it creates a new canister instead of updating the existing one.
 
-6. **Exceeding canister storage limits.** The asset canister uses stable memory, which can hold well over 4GB. However, individual assets are limited by the 2MB ingress message size (the `@dfinity/assets` library handles chunking automatically for uploads >1.9MB). The practical concern is total cycle cost for storage -- large media files (videos, datasets) become expensive. Use a dedicated storage solution for large files.
+6. **Exceeding canister storage limits.** The asset canister uses stable memory, which can hold well over 4GB. However, individual assets are limited by the 2MB ingress message size (the asset manager in `@icp-sdk/canisters` handles chunking automatically for uploads >1.9MB). The practical concern is total cycle cost for storage -- large media files (videos, datasets) become expensive. Use a dedicated storage solution for large files.
 
 7. **Not configuring `allow_raw_access` for API responses.** By default, the asset canister serves certified responses through the `ic0.app` domain. If you need raw (uncertified) access for specific assets, configure it in `.ic-assets.json5`.
 
@@ -158,13 +158,13 @@ _canister-id.yourdomain.com.  TXT  "<your-canister-id>"
 
 4. Wait for the boundary nodes to pick up the registration and provision the TLS certificate. This typically takes a few minutes. You can verify by visiting `https://yourdomain.com` once DNS has propagated.
 
-### Programmatic Uploads with @dfinity/assets
+### Programmatic Uploads with @icp-sdk/canisters
 
 For uploading files from code (not just via `icp deploy`):
 
 ```javascript
-import { AssetManager } from "@dfinity/assets";
-import { HttpAgent, Actor } from "@dfinity/agent";
+import { AssetManager } from "@icp-sdk/canisters/assets";
+import { HttpAgent, Actor } from "@icp-sdk/core/agent";
 
 // Create an agent with an authorized identity
 const agent = new HttpAgent({ host: "http://localhost:4943" });
@@ -320,7 +320,7 @@ Query responses on the Internet Computer come from a single replica and are NOT 
 - `icp-cli` >= 0.1.0 (install: `brew install dfinity/tap/icp-cli`)
 - Rust: `ic-certified-map` crate (for Merkle tree), `ic-cdk` (for `set_certified_data` / `data_certificate`)
 - Motoko: `CertifiedData` module (included in mo:core/mo:base), `sha2` package (`mops add sha2`) for hashing
-- Frontend: `@dfinity/certificate-verification` or `@dfinity/agent` (includes verification)
+- Frontend: `@icp-sdk/core/agent` (includes certificate verification)
 
 ## Canister IDs
 
@@ -654,10 +654,10 @@ persistent actor {
 
 ### Frontend Verification (TypeScript)
 
-The `@dfinity/agent` library handles certificate verification automatically for certified query responses. For manual verification:
+The `@icp-sdk/core/agent` library handles certificate verification automatically for certified query responses. For manual verification:
 
 ```typescript
-import { Certificate, HttpAgent, lookup_path } from "@dfinity/agent";
+import { Certificate, HttpAgent, lookup_path } from "@icp-sdk/core/agent";
 
 async function verifyCertifiedResponse(
   agent: HttpAgent,
@@ -696,7 +696,7 @@ async function verifyCertifiedResponse(
 }
 ```
 
-For asset canisters, the `@dfinity/agent` service worker handles verification transparently -- no manual code needed.
+For asset canisters, the `@icp-sdk/core/agent` service worker handles verification transparently -- no manual code needed.
 
 ## Deploy & Test
 
@@ -3359,13 +3359,13 @@ name: Internet Identity Auth
 category: Auth
 description: "Integrate Internet Identity authentication into frontend and backend canisters. Delegation, session management, and anchor handling."
 endpoints: 6
-version: 4.0.0
+version: 5.0.0
 status: stable
 dependencies: [asset-canister]
 ---
 
 # Internet Identity Authentication
-> version: 4.0.0 | requires: [icp-cli >= 0.1.0, @dfinity/auth-client >= 3.0]
+> version: 5.0.0 | requires: [icp-cli >= 0.1.0, @icp-sdk/auth >= 5.0, @icp-sdk/core >= 5.0]
 
 ## What This Is
 
@@ -3375,10 +3375,8 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 - icp-cli >= 0.1.0 (`brew install dfinity/tap/icp-cli`)
 - Node.js >= 18 (for frontend)
-- `@dfinity/auth-client` npm package (>= 3.0.0)
-- `@dfinity/agent` npm package
-- `@dfinity/identity` npm package
-- `@dfinity/principal` npm package
+- `@icp-sdk/auth` npm package (>= 5.0.0)
+- `@icp-sdk/core` npm package (>= 5.0.0)
 
 ## Canister IDs
 
@@ -3436,8 +3434,8 @@ The `remote.id.ic` field tells `icp` to skip deploying this canister on mainnet 
 This is framework-agnostic. Adapt the DOM manipulation to your framework.
 
 ```javascript
-import { AuthClient } from "@dfinity/auth-client";
-import { HttpAgent, Actor } from "@dfinity/agent";
+import { AuthClient } from "@icp-sdk/auth/client";
+import { HttpAgent, Actor } from "@icp-sdk/core/agent";
 
 // 1. Create the auth client
 const authClient = await AuthClient.create();

--- a/skills/asset-canister/SKILL.md
+++ b/skills/asset-canister/SKILL.md
@@ -20,7 +20,7 @@ The asset canister hosts static files (HTML, CSS, JS, images) directly on the In
 
 - icp-cli >= 0.1.0 (`brew install dfinity/tap/icp-cli`)
 - Node.js >= 18 (for building frontend assets)
-- `@dfinity/assets` npm package (for programmatic uploads)
+- `@icp-sdk/canisters` npm package (for programmatic uploads)
 
 ## Canister IDs
 
@@ -45,7 +45,7 @@ Access patterns:
 
 5. **Deploying to the wrong canister name.** If icp.json has `"frontend"` but you run `icp deploy assets`, it creates a new canister instead of updating the existing one.
 
-6. **Exceeding canister storage limits.** The asset canister uses stable memory, which can hold well over 4GB. However, individual assets are limited by the 2MB ingress message size (the `@dfinity/assets` library handles chunking automatically for uploads >1.9MB). The practical concern is total cycle cost for storage -- large media files (videos, datasets) become expensive. Use a dedicated storage solution for large files.
+6. **Exceeding canister storage limits.** The asset canister uses stable memory, which can hold well over 4GB. However, individual assets are limited by the 2MB ingress message size (the asset manager in `@icp-sdk/canisters` handles chunking automatically for uploads >1.9MB). The practical concern is total cycle cost for storage -- large media files (videos, datasets) become expensive. Use a dedicated storage solution for large files.
 
 7. **Not configuring `allow_raw_access` for API responses.** By default, the asset canister serves certified responses through the `ic0.app` domain. If you need raw (uncertified) access for specific assets, configure it in `.ic-assets.json5`.
 
@@ -149,13 +149,13 @@ _canister-id.yourdomain.com.  TXT  "<your-canister-id>"
 
 4. Wait for the boundary nodes to pick up the registration and provision the TLS certificate. This typically takes a few minutes. You can verify by visiting `https://yourdomain.com` once DNS has propagated.
 
-### Programmatic Uploads with @dfinity/assets
+### Programmatic Uploads with @icp-sdk/canisters
 
 For uploading files from code (not just via `icp deploy`):
 
 ```javascript
-import { AssetManager } from "@dfinity/assets";
-import { HttpAgent, Actor } from "@dfinity/agent";
+import { AssetManager } from "@icp-sdk/canisters/assets";
+import { HttpAgent, Actor } from "@icp-sdk/core/agent";
 
 // Create an agent with an authorized identity
 const agent = new HttpAgent({ host: "http://localhost:4943" });

--- a/skills/certified-variables/SKILL.md
+++ b/skills/certified-variables/SKILL.md
@@ -21,7 +21,7 @@ Query responses on the Internet Computer come from a single replica and are NOT 
 - `icp-cli` >= 0.1.0 (install: `brew install dfinity/tap/icp-cli`)
 - Rust: `ic-certified-map` crate (for Merkle tree), `ic-cdk` (for `set_certified_data` / `data_certificate`)
 - Motoko: `CertifiedData` module (included in mo:core/mo:base), `sha2` package (`mops add sha2`) for hashing
-- Frontend: `@dfinity/certificate-verification` or `@dfinity/agent` (includes verification)
+- Frontend: `@icp-sdk/core/agent` (includes certificate verification)
 
 ## Canister IDs
 
@@ -355,10 +355,10 @@ persistent actor {
 
 ### Frontend Verification (TypeScript)
 
-The `@dfinity/agent` library handles certificate verification automatically for certified query responses. For manual verification:
+The `@icp-sdk/core/agent` library handles certificate verification automatically for certified query responses. For manual verification:
 
 ```typescript
-import { Certificate, HttpAgent, lookup_path } from "@dfinity/agent";
+import { Certificate, HttpAgent, lookup_path } from "@icp-sdk/core/agent";
 
 async function verifyCertifiedResponse(
   agent: HttpAgent,
@@ -397,7 +397,7 @@ async function verifyCertifiedResponse(
 }
 ```
 
-For asset canisters, the `@dfinity/agent` service worker handles verification transparently -- no manual code needed.
+For asset canisters, the `@icp-sdk/core/agent` service worker handles verification transparently -- no manual code needed.
 
 ## Deploy & Test
 

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -4,13 +4,13 @@ name: Internet Identity Auth
 category: Auth
 description: "Integrate Internet Identity authentication into frontend and backend canisters. Delegation, session management, and anchor handling."
 endpoints: 6
-version: 4.0.0
+version: 5.0.0
 status: stable
 dependencies: [asset-canister]
 ---
 
 # Internet Identity Authentication
-> version: 4.0.0 | requires: [icp-cli >= 0.1.0, @dfinity/auth-client >= 3.0]
+> version: 5.0.0 | requires: [icp-cli >= 0.1.0, @icp-sdk/auth >= 5.0, @icp-sdk/core >= 5.0]
 
 ## What This Is
 
@@ -20,10 +20,8 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 - icp-cli >= 0.1.0 (`brew install dfinity/tap/icp-cli`)
 - Node.js >= 18 (for frontend)
-- `@dfinity/auth-client` npm package (>= 3.0.0)
-- `@dfinity/agent` npm package
-- `@dfinity/identity` npm package
-- `@dfinity/principal` npm package
+- `@icp-sdk/auth` npm package (>= 5.0.0)
+- `@icp-sdk/core` npm package (>= 5.0.0)
 
 ## Canister IDs
 
@@ -81,8 +79,8 @@ The `remote.id.ic` field tells `icp` to skip deploying this canister on mainnet 
 This is framework-agnostic. Adapt the DOM manipulation to your framework.
 
 ```javascript
-import { AuthClient } from "@dfinity/auth-client";
-import { HttpAgent, Actor } from "@dfinity/agent";
+import { AuthClient } from "@icp-sdk/auth/client";
+import { HttpAgent, Actor } from "@icp-sdk/core/agent";
 
 // 1. Create the auth client
 const authClient = await AuthClient.create();


### PR DESCRIPTION
## Summary

Migrates all deprecated `@dfinity/*` npm package references to the new `@icp-sdk/*` packages (released Dec 2025, now at v5.0.0).

**Changes:**
- **internet-identity**: `@dfinity/auth-client` → `@icp-sdk/auth/client`, `@dfinity/agent` → `@icp-sdk/core/agent`
- **asset-canister**: `@dfinity/assets` → `@icp-sdk/canisters/assets`, `@dfinity/agent` → `@icp-sdk/core/agent`
- **certified-variables**: `@dfinity/agent` → `@icp-sdk/core/agent`, `@dfinity/certificate-verification` → `@icp-sdk/core/agent`
- **vetkd**: No change — `@dfinity/vetkeys` is domain-specific and hasn't migrated yet

Addresses issue #1 item 5 (deprecated packages).

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Verify no `@dfinity/agent`, `@dfinity/auth-client`, `@dfinity/assets` references remain
- [ ] Only `@dfinity/vetkeys` (domain-specific) should remain