### PR TITLE
Fix round 6 audit: icp.yaml, deprecated APIs, stable-structures across 11 skills

### DIFF
--- a/skills/asset-canister/SKILL.md
+++ b/skills/asset-canister/SKILL.md
@@ -51,23 +51,21 @@ Access patterns:
 
 ## Implementation
 
-### icp.json Configuration
+### icp.yaml Configuration
 
-```json
-{
-  "canisters": {
-    "frontend": {
-      "type": "assets",
-      "source": ["dist"],
-      "build": ["npm run build"],
-      "dependencies": ["backend"]
-    },
-    "backend": {
-      "type": "motoko",
-      "main": "src/backend/main.mo"
-    }
-  }
-}
+```yaml
+canisters:
+  frontend:
+    type: assets
+    source:
+      - dist
+    build:
+      - npm run build
+    dependencies:
+      - backend
+  backend:
+    type: motoko
+    main: src/backend/main.mo
 ```
 
 Key fields:
@@ -279,7 +277,7 @@ icp canister call frontend http_request '(record {
 # Mainnet: https://<frontend-canister-id>.ic0.app
 
 # 6. Get canister ID
-icp canister status frontend --id-only
+icp canister id frontend
 # Expected: prints the canister ID (e.g., "bkyz2-fmaaa-aaaaa-qaaaq-cai")
 
 # 7. Check storage usage

--- a/skills/certified-variables/SKILL.md
+++ b/skills/certified-variables/SKILL.md
@@ -114,7 +114,7 @@ fn update_certified_data() {
     TREE.with(|tree| {
         let tree = tree.borrow();
         // root_hash() returns a 32-byte SHA-256 hash of the entire tree
-        ic_cdk::set_certified_data(&tree.root_hash());
+        ic_cdk::api::set_certified_data(&tree.root_hash());
     });
 }
 
@@ -158,7 +158,7 @@ struct CertifiedResponse {
 #[query]
 fn get(key: String) -> CertifiedResponse {
     // data_certificate() is only available in query calls
-    let certificate = ic_cdk::data_certificate()
+    let certificate = ic_cdk::api::data_certificate()
         .expect("data_certificate only available in query calls");
 
     TREE.with(|tree| {
@@ -247,7 +247,7 @@ fn certify_response(path: &str, response: &HttpResponse) {
         tree.insert(&entry);
 
         // Update canister certified data with tree root hash
-        ic_cdk::set_certified_data(&tree.root_hash());
+        ic_cdk::api::set_certified_data(&tree.root_hash());
     });
 }
 ```

--- a/skills/ckbtc/SKILL.md
+++ b/skills/ckbtc/SKILL.md
@@ -100,30 +100,22 @@ core = "2.0.0"
 icrc2-types = "0.1.0"
 ```
 
-#### icp.json (local development with ckBTC)
+#### icp.yaml (local development with ckBTC)
 
 For local testing, pull the ckBTC canisters:
 
-```json
-{
-  "defaults": {
-    "build": {
-      "packtool": "mops sources"
-    }
-  },
-  "canisters": {
-    "backend": {
-      "type": "motoko",
-      "main": "src/backend/main.mo",
-      "dependencies": []
-    }
-  },
-  "networks": {
-    "local": {
-      "bind": "127.0.0.1:4943"
-    }
-  }
-}
+```yaml
+defaults:
+  build:
+    packtool: mops sources
+canisters:
+  backend:
+    type: motoko
+    main: src/backend/main.mo
+    dependencies: []
+networks:
+  local:
+    bind: 127.0.0.1:4943
 ```
 
 For mainnet, your canister calls the ckBTC ledger and minter directly by principal.
@@ -521,7 +513,7 @@ async fn get_deposit_address() -> String {
 
     let subaccount = principal_to_subaccount(&caller);
     let args = GetBtcAddressArgs {
-        owner: Some(ic_cdk::id()),
+        owner: Some(ic_cdk::api::id()),
         subaccount: Some(subaccount.to_vec()),
     };
 
@@ -541,7 +533,7 @@ async fn update_balance() -> UpdateBalanceResult {
 
     let subaccount = principal_to_subaccount(&caller);
     let args = UpdateBalanceArgs {
-        owner: Some(ic_cdk::id()),
+        owner: Some(ic_cdk::api::id()),
         subaccount: Some(subaccount.to_vec()),
     };
 
@@ -561,7 +553,7 @@ async fn get_balance() -> Nat {
 
     let subaccount = principal_to_subaccount(&caller);
     let account = Account {
-        owner: ic_cdk::id(),
+        owner: ic_cdk::api::id(),
         subaccount: Some(subaccount),
     };
 
@@ -755,7 +747,7 @@ icp canister call YOUR-CANISTER updateBalance -e ic
 # Expected: (variant { Ok = vec { variant { Minted = record { ... } } } })
 
 # 4. Check ckBTC balance
-icp canister call YOUR-CANISTER getBalanceUpdate -e ic
+icp canister call YOUR-CANISTER getBalance -e ic
 # Expected: balance reflects minted ckBTC
 ```
 

--- a/skills/evm-rpc/SKILL.md
+++ b/skills/evm-rpc/SKILL.md
@@ -80,28 +80,24 @@ Use `requestCost` to get an exact estimate before calling.
 
 6. **Calling `eth_sendRawTransaction` without signing first.** The EVM RPC canister does not sign transactions. You must sign the transaction yourself (using threshold ECDSA via the IC management canister) and pass the raw signed bytes.
 
-7. **Using `Cycles.add` instead of `await (with cycles = ...)` in mo:core.** In modern Motoko with mo:core, attach cycles using `await (with cycles = AMOUNT) canister.method(args)`. The old `Cycles.add<system>(amount)` pattern from mo:base still works but the inline syntax is preferred for clarity.
+7. **Using `Cycles.add` instead of `await (with cycles = ...)` in mo:core.** In mo:core 2.0, `Cycles.add` does not exist. Attach cycles using `await (with cycles = AMOUNT) canister.method(args)`. This is the only way to attach cycles in mo:core.
 
 ## Implementation
 
-### icp.json Configuration
+### icp.yaml Configuration
 
 #### Option A: Pull from mainnet (recommended for production)
 
-```json
-{
-  "canisters": {
-    "evm_rpc": {
-      "type": "pull",
-      "id": "7hfb6-caaaa-aaaar-qadga-cai"
-    },
-    "backend": {
-      "type": "motoko",
-      "main": "src/backend/main.mo",
-      "dependencies": ["evm_rpc"]
-    }
-  }
-}
+```yaml
+canisters:
+  evm_rpc:
+    type: pull
+    id: 7hfb6-caaaa-aaaar-qadga-cai
+  backend:
+    type: motoko
+    main: src/backend/main.mo
+    dependencies:
+      - evm_rpc
 ```
 
 Then run:
@@ -113,26 +109,20 @@ icp deps deploy
 
 #### Option B: Custom wasm (for local development)
 
-```json
-{
-  "canisters": {
-    "evm_rpc": {
-      "type": "custom",
-      "candid": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.did",
-      "wasm": "https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz",
-      "remote": {
-        "id": {
-          "ic": "7hfb6-caaaa-aaaar-qadga-cai"
-        }
-      }
-    },
-    "backend": {
-      "type": "motoko",
-      "main": "src/backend/main.mo",
-      "dependencies": ["evm_rpc"]
-    }
-  }
-}
+```yaml
+canisters:
+  evm_rpc:
+    type: custom
+    candid: https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.did
+    wasm: https://github.com/internet-computer-protocol/evm-rpc-canister/releases/latest/download/evm_rpc.wasm.gz
+    remote:
+      id:
+        ic: 7hfb6-caaaa-aaaar-qadga-cai
+  backend:
+    type: motoko
+    main: src/backend/main.mo
+    dependencies:
+      - evm_rpc
 ```
 
 ### Motoko
@@ -390,7 +380,7 @@ serde_json = "1"
 
 ```rust
 use candid::{CandidType, Deserialize, Principal};
-use ic_cdk::api::call::call_with_payment128; // Note: ic_cdk::api::call is deprecated in 0.18 but still compiles
+use ic_cdk::call::call_with_payment128;
 use ic_cdk::update;
 
 const EVM_RPC_CANISTER: &str = "7hfb6-caaaa-aaaar-qadga-cai";

--- a/skills/https-outcalls/SKILL.md
+++ b/skills/https-outcalls/SKILL.md
@@ -202,7 +202,7 @@ serde_json = "1"
 ```
 
 ```rust
-use ic_cdk::api::management_canister::http_request::{
+use ic_cdk::management_canister::http_request::{
     http_request, CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse,
     TransformArgs, TransformContext, TransformFunc,
 };
@@ -242,7 +242,7 @@ async fn fetch_price() -> String {
         body: None,
         transform: Some(TransformContext {
             function: TransformFunc(candid::Func {
-                principal: ic_cdk::id(),
+                principal: ic_cdk::api::canister_self(),
                 method: "transform".to_string(),
             }),
             context: vec![],
@@ -318,7 +318,7 @@ async fn post_data(json_payload: String) -> String {
         body: Some(json_payload.into_bytes()),
         transform: Some(TransformContext {
             function: TransformFunc(candid::Func {
-                principal: ic_cdk::id(),
+                principal: ic_cdk::api::canister_self(),
                 method: "transform".to_string(),
             }),
             context: vec![],

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -50,26 +50,20 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 ## Implementation
 
-### icp.json Configuration
+### icp.yaml Configuration
 
 For local development, download the II canister WASM from the [dfinity/internet-identity releases](https://github.com/dfinity/internet-identity/releases). Place the `.wasm.gz` and `.did` files in your project.
 
-```json
-{
-  "canisters": {
-    "internet_identity": {
-      "type": "custom",
-      "candid": "deps/internet-identity/internet_identity.did",
-      "wasm": "deps/internet-identity/internet_identity_dev.wasm.gz",
-      "build": "",
-      "remote": {
-        "id": {
-          "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
-        }
-      }
-    }
-  }
-}
+```yaml
+canisters:
+  internet_identity:
+    type: custom
+    candid: deps/internet-identity/internet_identity.did
+    wasm: deps/internet-identity/internet_identity_dev.wasm.gz
+    build: ""
+    remote:
+      id:
+        ic: rdmx6-jaaaa-aaaaa-aaadq-cai
 ```
 
 The `remote.id.ic` field tells `icp` to skip deploying this canister on mainnet (use the existing one). Locally, `icp` deploys the provided WASM.
@@ -360,10 +354,10 @@ icp canister call backend whoAmI
 # unless you explicitly use --identity anonymous
 
 # 5. Test with explicit anonymous identity
-icp identity default anonymous
+icp identity use anonymous
 icp canister call backend adminAction
 # Expected: Error containing "Anonymous principal not allowed"
-icp identity default default  # Switch back
+icp identity use default  # Switch back
 
 # 6. Open II in browser for local dev
 # Visit: http://<internet_identity_canister_id>.localhost:4943

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -27,7 +27,7 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 | Reason | Threshold |
 |---|---|
-| Storage limits | Each canister: 4GB stable memory + 4GB heap. If your data could exceed this, split storage across canisters. |
+| Storage limits | Each canister: up to hundreds of GB stable memory + 4GB heap. If your data could exceed heap limits or benefit from partitioning, split storage across canisters. |
 | Separation of concerns | Auth service, content service, payment service as independent units. |
 | Independent upgrades | Upgrade the payments canister without touching the user canister. |
 | Access control | Different controllers for different canisters (e.g., DAO controls one, team controls another). |
@@ -62,7 +62,7 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 4. **Not handling rejected calls.** Inter-canister calls can fail (callee trapped, out of cycles, canister stopped). In Motoko use `try/catch`. In Rust, handle the `Result` from `ic_cdk::call`. Unhandled rejections trap your canister.
 
-5. **Deploying canisters in the wrong order.** Canisters with dependencies must be deployed after their dependencies. Declare `"dependencies"` in icp.json so `icp deploy` orders them correctly.
+5. **Deploying canisters in the wrong order.** Canisters with dependencies must be deployed after their dependencies. Declare `dependencies` in icp.yaml so `icp deploy` orders them correctly.
 
 6. **Forgetting to generate type declarations for each backend canister.** Use language-specific tooling (e.g., `didc` for Candid bindings) to generate declarations for each backend canister individually.
 
@@ -80,7 +80,7 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 ```
 my-project/
-  icp.json
+  icp.yaml
   mops.toml
   src/
     shared/
@@ -93,37 +93,31 @@ my-project/
       ...               # Frontend assets
 ```
 
-### icp.json
+### icp.yaml
 
-```json
-{
-  "defaults": {
-    "build": {
-      "packtool": "mops sources"
-    }
-  },
-  "canisters": {
-    "user_service": {
-      "type": "motoko",
-      "main": "src/user_service/main.mo"
-    },
-    "content_service": {
-      "type": "motoko",
-      "main": "src/content_service/main.mo",
-      "dependencies": ["user_service"]
-    },
-    "frontend": {
-      "type": "assets",
-      "source": ["dist"],
-      "dependencies": ["user_service", "content_service"]
-    }
-  },
-  "networks": {
-    "local": {
-      "bind": "127.0.0.1:4943"
-    }
-  }
-}
+```yaml
+defaults:
+  build:
+    packtool: mops sources
+canisters:
+  user_service:
+    type: motoko
+    main: src/user_service/main.mo
+  content_service:
+    type: motoko
+    main: src/content_service/main.mo
+    dependencies:
+      - user_service
+  frontend:
+    type: assets
+    source:
+      - dist
+    dependencies:
+      - user_service
+      - content_service
+networks:
+  local:
+    bind: 127.0.0.1:4943
 ```
 
 ### Motoko
@@ -227,7 +221,7 @@ import Error "mo:core/Error";
 import Principal "mo:core/Principal";
 import Types "../shared/Types";
 
-// Import the other canister — name must match icp.json key
+// Import the other canister — name must match icp.yaml canister key
 import UserService "canister:user_service";
 
 persistent actor {
@@ -316,7 +310,7 @@ persistent actor {
 
 ```
 my-project/
-  icp.json
+  icp.yaml
   Cargo.toml          # workspace
   src/
     user_service/
@@ -337,34 +331,30 @@ members = [
 ]
 ```
 
-#### icp.json (Rust)
+#### icp.yaml (Rust)
 
-```json
-{
-  "canisters": {
-    "user_service": {
-      "type": "rust",
-      "package": "user_service",
-      "candid": "src/user_service/user_service.did"
-    },
-    "content_service": {
-      "type": "rust",
-      "package": "content_service",
-      "candid": "src/content_service/content_service.did",
-      "dependencies": ["user_service"]
-    },
-    "frontend": {
-      "type": "assets",
-      "source": ["dist"],
-      "dependencies": ["user_service", "content_service"]
-    }
-  },
-  "networks": {
-    "local": {
-      "bind": "127.0.0.1:4943"
-    }
-  }
-}
+```yaml
+canisters:
+  user_service:
+    type: rust
+    package: user_service
+    candid: src/user_service/user_service.did
+  content_service:
+    type: rust
+    package: content_service
+    candid: src/content_service/content_service.did
+    dependencies:
+      - user_service
+  frontend:
+    type: assets
+    source:
+      - dist
+    dependencies:
+      - user_service
+      - content_service
+networks:
+  local:
+    bind: 127.0.0.1:4943
 ```
 
 #### src/user_service/Cargo.toml
@@ -860,7 +850,7 @@ fn get_child_canister(owner: Principal) -> Option<Principal> {
 icp deploy user_service
 
 # Rust content_service requires the user_service principal on every upgrade (post_upgrade arg)
-USER_SERVICE_ID=$(icp canister status user_service --id-only)
+USER_SERVICE_ID=$(icp canister id user_service)
 icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
 
 npm run build
@@ -879,7 +869,7 @@ icp network start -d
 icp deploy user_service
 
 # content_service (Rust) requires the user_service canister ID as an init argument
-USER_SERVICE_ID=$(icp canister status user_service --id-only)
+USER_SERVICE_ID=$(icp canister id user_service)
 icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
 
 # Build and deploy frontend

--- a/skills/sns-launch/SKILL.md
+++ b/skills/sns-launch/SKILL.md
@@ -370,10 +370,10 @@ dfx sns propose --network ic --neuron $NEURON_ID sns_init.yaml
 
 ```bash
 # List deployed SNS canisters
-icp canister status sns_governance --id-only
-icp canister status sns_ledger --id-only
-icp canister status sns_root --id-only
-icp canister status sns_swap --id-only
+icp canister id sns_governance
+icp canister id sns_ledger
+icp canister id sns_root
+icp canister id sns_swap
 
 # Verify SNS governance is operational
 icp canister call sns_governance get_nervous_system_parameters '()'

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -164,7 +164,7 @@ thread_local! {
         RefCell::new(ic_stable_structures::StableCell::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),
             0u64,
-        ).expect("Failed to init counter"));
+        ));
 }
 
 #[derive(CandidType, Deserialize, Clone)]
@@ -190,7 +190,7 @@ fn add_user(name: String) -> u64 {
     let id = COUNTER.with(|c| {
         let mut cell = c.borrow_mut();
         let current = *cell.get();
-        cell.set(current + 1).expect("Failed to increment counter");
+        cell.set(current + 1);
         current
     });
 
@@ -260,13 +260,13 @@ thread_local! {
         RefCell::new(StableCell::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(COUNTER_MEM_ID)),
             0u64,
-        ).expect("Failed to init counter"));
+        ));
 
     static AUDIT_LOG: RefCell<StableLog<Vec<u8>, Memory, Memory>> =
         RefCell::new(StableLog::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(LOG_INDEX_MEM_ID)),
             MEMORY_MANAGER.with(|m| m.borrow().get(LOG_DATA_MEM_ID)),
-        ).expect("Failed to init log"));
+        ));
 }
 ```
 

--- a/skills/vetkd/SKILL.md
+++ b/skills/vetkd/SKILL.md
@@ -337,12 +337,12 @@ persistent actor {
     encrypted_key : Blob;
   };
 
-  let managementCanister : actor {
+  transient let managementCanister : actor {
     vetkd_public_key : VetKdPublicKeyRequest -> async VetKdPublicKeyResponse;
     vetkd_derive_key : VetKdDeriveKeyRequest -> async VetKdDeriveKeyResponse;
   } = actor "aaaaa-aa";
 
-  let context : Blob = Text.encodeUtf8("my_app_v1");
+  transient let context : Blob = Text.encodeUtf8("my_app_v1");
 
   // Key names: "dfx_test_key" for local, "test_key_1" for mainnet testing, "key_1" for production
   func keyId() : VetKdKeyId {
@@ -432,12 +432,12 @@ icp canister call backend deriveKey '(blob "\00\01...")'
 # To verify the underlying key is correct, decrypt both blobs with the transport secret and confirm they match.
 
 # 4. Verify isolation: different callers get different keys
-icp identity new test-user-1 --storage-mode=plaintext
-icp identity new test-user-2 --storage-mode=plaintext
-icp identity default test-user-1
+icp identity new test-user-1 --storage plaintext
+icp identity new test-user-2 --storage plaintext
+icp identity use test-user-1
 icp canister call backend deriveKey '(blob "\00\01...")'
 # Note the output
-icp identity default test-user-2
+icp identity use test-user-2
 icp canister call backend deriveKey '(blob "\00\01...")'
 # Expected: DIFFERENT encrypted_key (different caller = different derived key)
 

--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -175,7 +175,7 @@ use candid::Nat;
 
 #[query]
 fn get_balance() -> Nat {
-    Nat::from(ic_cdk::api::canister_balance128())
+    Nat::from(ic_cdk::api::canister_cycle_balance())
 }
 
 #[update]
@@ -202,7 +202,7 @@ use ic_cdk::management_canister::{
 
 #[update]
 async fn create_new_canister() -> Principal {
-    let caller = ic_cdk::api::id(); // capture canister's own principal
+    let caller = ic_cdk::api::canister_self(); // capture canister's own principal
     let user = ic_cdk::caller(); // capture caller before await
 
     let settings = CanisterSettings {


### PR DESCRIPTION
## Summary
- Convert all remaining `icp.json` configs to `icp.yaml` (YAML format) for icp-cli compatibility
- Fix deprecated ic-cdk 0.18 APIs: `canister_balance128()` → `canister_cycle_balance()`, `ic_cdk::id()` → `canister_self()`, `api::management_canister` → `management_canister`
- Remove `.expect()` on ic-stable-structures 0.7 `StableCell::init/set` and `StableLog::init` (return Self/T not Result)
- Fix `--id-only` flag → `icp canister id` across multi-canister, asset-canister, sns-launch
- Fix `--storage-mode` → `--storage plaintext` and `icp identity default` → `icp identity use` in vetkd, internet-identity
- Add missing `transient` markers on actor refs in vetkd
- Correct stable memory limit from "4GB" to "hundreds of GB" in multi-canister

## Context
Round 6 multi-agent verification (6 parallel agents, 2 skills each). 11 of 12 skills had findings; icrc-ledger was the only CLEAN skill.