### PR TITLE
Fix vetkd Option A API and evm-rpc Candid type definitions

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1983,7 +1983,6 @@ enum RpcService {
     BaseMainnet(L2MainnetService),
     OptimismMainnet(L2MainnetService),
     Custom(CustomRpcService),
-    Chain(u64),
     Provider(u64),
 }
 
@@ -2000,8 +1999,10 @@ enum EthMainnetService {
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum EthSepoliaService {
     Alchemy,
+    Ankr,
     BlockPi,
     PublicNode,
+    Sepolia,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -2061,12 +2062,29 @@ enum ProviderError {
     MissingRequiredProvider,
     ProviderNotFound,
     NoPermission,
+    InvalidRpcConfig(String),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum RejectionCode {
+    NoError,
+    CanisterError,
+    SysTransient,
+    DestinationInvalid,
+    Unknown,
+    SysFatal,
+    CanisterReject,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum HttpOutcallError {
-    IcError { code: i32, message: String },
-    InvalidHttpJsonRpcResponse { status: u16, body: String, parsing_error: Option<String> },
+    IcError { code: RejectionCode, message: String },
+    InvalidHttpJsonRpcResponse {
+        status: u16,
+        body: String,
+        #[serde(rename = "parsingError")]
+        parsing_error: Option<String>,
+    },
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -2077,11 +2095,8 @@ struct JsonRpcError {
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum ValidationError {
-    HostNotAllowed(String),
-    UrlParseError(String),
     Custom(String),
-    CredentialPathNotAllowed,
-    CredentialHeaderNotAllowed,
+    InvalidHex(String),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -2117,19 +2132,16 @@ struct Block {
     total_difficulty: Option<candid::Nat>,
     transactions: Vec<String>,
     #[serde(rename = "transactionsRoot")]
-    transactions_root: String,
+    transactions_root: Option<String>,
     uncles: Vec<String>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum SendRawTransactionStatus {
     Ok(Option<String>),
-    InsufficientFunds,
     NonceTooLow,
     NonceTooHigh,
-    InsufficientGas,
-    // NOTE: More variants may exist -- check the EVM RPC canister's latest .did file
-    // for the complete set of SendRawTransactionStatus variants.
+    InsufficientFunds,
 }
 
 // -- Get ETH balance via raw JSON-RPC --
@@ -5634,6 +5646,7 @@ serde_bytes = "0.11"
 # ic-vetkeys = { git = "https://github.com/dfinity/ic-vetkeys" }
 # Or use Option B (raw canister calls) which has no extra dependency.
 ic-vetkeys = "0.6.0"
+ic-stable-structures = "0.7"
 
 # Option B: Call management canister directly (lower level, always works)
 # No extra dependency -- use ic_cdk::call::Call::unbounded_wait(...).with_cycles()
@@ -5643,45 +5656,85 @@ ic-vetkeys = "0.6.0"
 
 ```rust
 use candid::Principal;
-use ic_cdk::update;
+use ic_cdk::{init, update};
+use ic_cdk::management_canister::{VetKDCurve, VetKDKeyId};
+use ic_vetkeys::key_manager::KeyManager;
+use ic_vetkeys::types::AccessRights;
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
 
-// The ic-vetkeys crate provides KeyManager and EncryptedMaps
-// which handle the low-level vetKD API calls for you.
-//
-// ⚠ This crate may not be published on crates.io yet. If `cargo build` fails
-// with "could not find `ic_vetkeys`", switch to the raw management canister
-// approach below (Option B), or add as a git dependency from dfinity/ic-vetkeys.
-//
-// API is under active development — verify function signatures against latest docs.
-use ic_vetkeys::KeyManager;
+// ⚠ ic-vetkeys API is under active development — verify function signatures against
+// https://docs.rs/ic-vetkeys/latest and https://github.com/dfinity/vetkeys.
 
-// Initialize KeyManager in your canister
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
 thread_local! {
-    static KEY_MANAGER: std::cell::RefCell<KeyManager> = std::cell::RefCell::new(
-        KeyManager::new(
-            "key_1".to_string(),          // master key name
-            b"my_app_v1".to_vec(),        // context / domain separator
-        )
-    );
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+    static KEY_MANAGER: RefCell<Option<KeyManager<AccessRights>>> =
+        RefCell::new(None);
+}
+
+fn get_memory(id: u8) -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(id)))
+}
+
+// KeyManager requires 3 stable memory regions (config, access control, shared keys).
+// Call init_key_manager in both #[init] and #[post_upgrade] — StableCell/StableBTreeMap
+// reconnect to existing data on upgrade, so this is safe to call repeatedly.
+fn init_key_manager() {
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        // "dfx_test_key" for local, "test_key_1" for mainnet testing, "key_1" for production
+        name: "key_1".to_string(),
+    };
+    KEY_MANAGER.with(|km| {
+        *km.borrow_mut() = Some(KeyManager::init(
+            "my_app_v1",    // domain separator
+            key_id,
+            get_memory(0),  // config memory
+            get_memory(1),  // access control memory
+            get_memory(2),  // shared keys memory
+        ));
+    });
+}
+
+#[init]
+fn init() {
+    init_key_manager();
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    init_key_manager();
 }
 
 #[update]
-async fn get_encrypted_key(transport_public_key: Vec<u8>) -> Vec<u8> {
-    let caller = ic_cdk::api::msg_caller();  // Capture BEFORE await
-    KEY_MANAGER.with(|km| {
+async fn get_verification_key() -> Vec<u8> {
+    let future = KEY_MANAGER.with(|km| {
         let km = km.borrow();
-        km.derive_key(caller.as_slice().to_vec(), transport_public_key)
-    }).await
-    .expect("vetKD key derivation failed")
+        let km = km.as_ref().expect("KeyManager not initialized");
+        km.get_vetkey_verification_key()
+    });
+    future.await.to_vec()
 }
 
 #[update]
-async fn get_public_key() -> Vec<u8> {
-    KEY_MANAGER.with(|km| {
+async fn get_encrypted_vetkey(transport_public_key: Vec<u8>) -> Vec<u8> {
+    let caller = ic_cdk::api::msg_caller(); // Capture BEFORE await
+
+    // KeyId = (owner_principal, 32-byte key name)
+    let key_id = (caller, [0u8; 32].into());
+
+    let future = KEY_MANAGER.with(|km| {
         let km = km.borrow();
-        km.public_key()
-    }).await
-    .expect("vetKD public key retrieval failed")
+        let km = km.as_ref().expect("KeyManager not initialized");
+        km.get_encrypted_vetkey(caller, key_id, transport_public_key.into())
+    })
+    .expect("Access denied");
+
+    future.await.to_vec()
 }
 ```
 

--- a/skills/evm-rpc/SKILL.md
+++ b/skills/evm-rpc/SKILL.md
@@ -413,7 +413,6 @@ enum RpcService {
     BaseMainnet(L2MainnetService),
     OptimismMainnet(L2MainnetService),
     Custom(CustomRpcService),
-    Chain(u64),
     Provider(u64),
 }
 
@@ -430,8 +429,10 @@ enum EthMainnetService {
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum EthSepoliaService {
     Alchemy,
+    Ankr,
     BlockPi,
     PublicNode,
+    Sepolia,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -491,12 +492,29 @@ enum ProviderError {
     MissingRequiredProvider,
     ProviderNotFound,
     NoPermission,
+    InvalidRpcConfig(String),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+enum RejectionCode {
+    NoError,
+    CanisterError,
+    SysTransient,
+    DestinationInvalid,
+    Unknown,
+    SysFatal,
+    CanisterReject,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum HttpOutcallError {
-    IcError { code: i32, message: String },
-    InvalidHttpJsonRpcResponse { status: u16, body: String, parsing_error: Option<String> },
+    IcError { code: RejectionCode, message: String },
+    InvalidHttpJsonRpcResponse {
+        status: u16,
+        body: String,
+        #[serde(rename = "parsingError")]
+        parsing_error: Option<String>,
+    },
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -507,11 +525,8 @@ struct JsonRpcError {
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum ValidationError {
-    HostNotAllowed(String),
-    UrlParseError(String),
     Custom(String),
-    CredentialPathNotAllowed,
-    CredentialHeaderNotAllowed,
+    InvalidHex(String),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -547,19 +562,16 @@ struct Block {
     total_difficulty: Option<candid::Nat>,
     transactions: Vec<String>,
     #[serde(rename = "transactionsRoot")]
-    transactions_root: String,
+    transactions_root: Option<String>,
     uncles: Vec<String>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug)]
 enum SendRawTransactionStatus {
     Ok(Option<String>),
-    InsufficientFunds,
     NonceTooLow,
     NonceTooHigh,
-    InsufficientGas,
-    // NOTE: More variants may exist -- check the EVM RPC canister's latest .did file
-    // for the complete set of SendRawTransactionStatus variants.
+    InsufficientFunds,
 }
 
 // -- Get ETH balance via raw JSON-RPC --

--- a/skills/vetkd/SKILL.md
+++ b/skills/vetkd/SKILL.md
@@ -133,6 +133,7 @@ serde_bytes = "0.11"
 # ic-vetkeys = { git = "https://github.com/dfinity/ic-vetkeys" }
 # Or use Option B (raw canister calls) which has no extra dependency.
 ic-vetkeys = "0.6.0"
+ic-stable-structures = "0.7"
 
 # Option B: Call management canister directly (lower level, always works)
 # No extra dependency -- use ic_cdk::call::Call::unbounded_wait(...).with_cycles()
@@ -142,45 +143,85 @@ ic-vetkeys = "0.6.0"
 
 ```rust
 use candid::Principal;
-use ic_cdk::update;
+use ic_cdk::{init, update};
+use ic_cdk::management_canister::{VetKDCurve, VetKDKeyId};
+use ic_vetkeys::key_manager::KeyManager;
+use ic_vetkeys::types::AccessRights;
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
 
-// The ic-vetkeys crate provides KeyManager and EncryptedMaps
-// which handle the low-level vetKD API calls for you.
-//
-// ⚠ This crate may not be published on crates.io yet. If `cargo build` fails
-// with "could not find `ic_vetkeys`", switch to the raw management canister
-// approach below (Option B), or add as a git dependency from dfinity/ic-vetkeys.
-//
-// API is under active development — verify function signatures against latest docs.
-use ic_vetkeys::KeyManager;
+// ⚠ ic-vetkeys API is under active development — verify function signatures against
+// https://docs.rs/ic-vetkeys/latest and https://github.com/dfinity/vetkeys.
 
-// Initialize KeyManager in your canister
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
 thread_local! {
-    static KEY_MANAGER: std::cell::RefCell<KeyManager> = std::cell::RefCell::new(
-        KeyManager::new(
-            "key_1".to_string(),          // master key name
-            b"my_app_v1".to_vec(),        // context / domain separator
-        )
-    );
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+    static KEY_MANAGER: RefCell<Option<KeyManager<AccessRights>>> =
+        RefCell::new(None);
+}
+
+fn get_memory(id: u8) -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(id)))
+}
+
+// KeyManager requires 3 stable memory regions (config, access control, shared keys).
+// Call init_key_manager in both #[init] and #[post_upgrade] — StableCell/StableBTreeMap
+// reconnect to existing data on upgrade, so this is safe to call repeatedly.
+fn init_key_manager() {
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        // "dfx_test_key" for local, "test_key_1" for mainnet testing, "key_1" for production
+        name: "key_1".to_string(),
+    };
+    KEY_MANAGER.with(|km| {
+        *km.borrow_mut() = Some(KeyManager::init(
+            "my_app_v1",    // domain separator
+            key_id,
+            get_memory(0),  // config memory
+            get_memory(1),  // access control memory
+            get_memory(2),  // shared keys memory
+        ));
+    });
+}
+
+#[init]
+fn init() {
+    init_key_manager();
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    init_key_manager();
 }
 
 #[update]
-async fn get_encrypted_key(transport_public_key: Vec<u8>) -> Vec<u8> {
-    let caller = ic_cdk::api::msg_caller();  // Capture BEFORE await
-    KEY_MANAGER.with(|km| {
+async fn get_verification_key() -> Vec<u8> {
+    let future = KEY_MANAGER.with(|km| {
         let km = km.borrow();
-        km.derive_key(caller.as_slice().to_vec(), transport_public_key)
-    }).await
-    .expect("vetKD key derivation failed")
+        let km = km.as_ref().expect("KeyManager not initialized");
+        km.get_vetkey_verification_key()
+    });
+    future.await.to_vec()
 }
 
 #[update]
-async fn get_public_key() -> Vec<u8> {
-    KEY_MANAGER.with(|km| {
+async fn get_encrypted_vetkey(transport_public_key: Vec<u8>) -> Vec<u8> {
+    let caller = ic_cdk::api::msg_caller(); // Capture BEFORE await
+
+    // KeyId = (owner_principal, 32-byte key name)
+    let key_id = (caller, [0u8; 32].into());
+
+    let future = KEY_MANAGER.with(|km| {
         let km = km.borrow();
-        km.public_key()
-    }).await
-    .expect("vetKD public key retrieval failed")
+        let km = km.as_ref().expect("KeyManager not initialized");
+        km.get_encrypted_vetkey(caller, key_id, transport_public_key.into())
+    })
+    .expect("Access denied");
+
+    future.await.to_vec()
 }
 ```
 


### PR DESCRIPTION
## Summary

- **vetkd**: Rewrote Option A Rust code to use real `ic-vetkeys` 0.6.0 API (`KeyManager::init()` with 3 stable memory regions, `AccessRights` generic, correct method signatures)
- **evm-rpc**: Fixed 7 Rust type definition mismatches vs the real EVM RPC canister Candid interface (v2.8.0)

## Changes

### vetkd SKILL.md
- `KeyManager::new()` → `KeyManager::init(domain_sep, key_id, mem0, mem1, mem2)` with `AccessRights` generic
- Added `ic-stable-structures = "0.7"` dependency and `MemoryManager` setup
- Added `#[init]` / `#[post_upgrade]` lifecycle handlers
- Updated method names to real API: `get_vetkey_verification_key()`, `get_encrypted_vetkey()`

### evm-rpc SKILL.md
| Type | Fix |
|------|-----|
| `RpcService` | Removed nonexistent `Chain(u64)` variant |
| `EthSepoliaService` | Added `Ankr`, `Sepolia` variants |
| `ProviderError` | Added `InvalidRpcConfig(String)` |
| `HttpOutcallError` | `code: i32` → `code: RejectionCode`, added `RejectionCode` enum, added `parsingError` serde rename |
| `ValidationError` | 5 wrong variants → 2 correct (`Custom`, `InvalidHex`) |
| `Block` | `transactionsRoot: String` → `Option<String>` |
| `SendRawTransactionStatus` | Removed nonexistent `InsufficientGas` |

## Test plan
- [x] Verified type definitions match [evm_rpc.did](https://raw.githubusercontent.com/internet-computer-protocol/evm-rpc-canister/main/candid/evm_rpc.did)
- [x] Verified ic-vetkeys 0.6.0 API against [docs.rs](https://docs.rs/ic-vetkeys/0.6.0/ic_vetkeys/)
- [x] `npm run build` succeeds