### PR TITLE
Add AntonioVentilii as CODEOWNER for oisy-wallet-signer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,4 @@
 /skills/multi-canister/          @derlerd-dfinity
 /skills/stable-memory/            @derlerd-dfinity
 /skills/vetkd/                   @andreacerulli
+/skills/oisy-wallet-signer/      @AntonioVentilii


### PR DESCRIPTION
Adds @AntonioVentilii as the domain expert reviewer for the OISY Wallet Signer skill. PRs touching /skills/oisy-wallet-signer/ will auto-request his review.