### PR TITLE
Fix sns-launch YAML schema to match current sns_init v2 format

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -4740,7 +4740,7 @@ name: SNS DAO Launch
 category: Governance
 description: "Configure and launch an SNS DAO. Token economics, proposal types, nervous system parameters, and decentralization swap."
 endpoints: 22
-version: 1.8.1
+version: 1.9.0
 status: stable
 dependencies: [icrc-ledger, multi-canister]
 requires: [icp-cli >= 0.1.0, dfx sns extension, NNS neuron with stake]
@@ -4839,71 +4839,74 @@ dapp_canisters:
 Token:
   name: MyToken
   symbol: MYT
-  transaction_fee: 10_000        # e8s (0.0001 tokens)
+  transaction_fee: 0.0001 tokens
   logo: token_logo.png
 
 # === GOVERNANCE PARAMETERS ===
 Proposals:
-  rejection_fee: 100_000_000              # e8s (1 token)
-  initial_voting_period: 345_600           # seconds (4 days)
-  maximum_wait_for_quiet_deadline_extension: 86_400  # seconds (1 day)
+  rejection_fee: 1 token
+  initial_voting_period: 4 days
+  maximum_wait_for_quiet_deadline_extension: 1 day
 
 Neurons:
-  minimum_creation_stake: 100_000_000      # e8s (1 token)
+  minimum_creation_stake: 1 token
 
 Voting:
-  minimum_dissolve_delay: 2_629_800        # seconds (1 month)
-  MaximumDissolveDelayBonus:
-    duration: 252_288_000                  # seconds (8 years)
-    bonus: 100%            # 2x voting power at max dissolve
-  MaximumAgeBonusPercentage: 25%
+  minimum_dissolve_delay: 1 month
+  MaximumVotingPowerBonuses:
+    DissolveDelay:
+      duration: 8 years
+      bonus: 100%                            # 2x voting power at max dissolve
+    Age:
+      duration: 4 years
+      bonus: 25%
   RewardRate:
     initial: 2.5%
     final: 2.5%
-    transition_duration: 0                  # seconds
+    transition_duration: 0 seconds
 
 # === TOKEN DISTRIBUTION ===
 Distribution:
   Neurons:
     # Developer allocation (with vesting)
     - principal: DEVELOPER_PRINCIPAL
-      stake: 200_000_000_000_000             # e8s (2_000_000 tokens)
+      stake: 2_000_000 tokens
       memo: 0
-      dissolve_delay: 15_778_800             # seconds (6 months)
-      vesting_period: 63_115_200             # seconds (24 months)
+      dissolve_delay: 6 months
+      vesting_period: 24 months
 
     # Seed investors
     - principal: INVESTOR_PRINCIPAL
-      stake: 50_000_000_000_000              # e8s (500_000 tokens)
+      stake: 500_000 tokens
       memo: 1
-      dissolve_delay: 7_889_400              # seconds (3 months)
-      vesting_period: 31_557_600             # seconds (12 months)
+      dissolve_delay: 3 months
+      vesting_period: 12 months
 
   InitialBalances:
-    governance: 500_000_000_000_000  # e8s (5_000_000 tokens) — Treasury (controlled by DAO)
-    swap: 250_000_000_000_000       # e8s (2_500_000 tokens) — Sold during decentralization swap
+    treasury: 5_000_000 tokens               # Treasury (controlled by DAO)
+    swap: 2_500_000 tokens                   # Sold during decentralization swap
 
-  total: 1_000_000_000_000_000     # e8s (10_000_000 tokens) — Must equal sum of all allocations
+  total: 10_000_000 tokens                   # Must equal sum of all allocations
 
 # === DECENTRALIZATION SWAP ===
 Swap:
   minimum_participants: 100
-  minimum_direct_participation_icp: 5_000_000_000_000    # e8s (50_000 ICP)
-  maximum_direct_participation_icp: 50_000_000_000_000   # e8s (500_000 ICP)
-  minimum_participant_icp: 100_000_000                   # e8s (1 ICP)
-  maximum_participant_icp: 2_500_000_000_000             # e8s (25_000 ICP)
-  duration: 604_800                                      # seconds (7 days)
+  minimum_direct_participation_icp: 50_000 tokens
+  maximum_direct_participation_icp: 500_000 tokens
+  minimum_participant_icp: 1 token
+  maximum_participant_icp: 25_000 tokens
+  duration: 7 days
   neurons_fund_participation: true
 
   VestingSchedule:
-    events: 5                      # Neurons unlock in 5 stages
-    interval: 7_889_400              # seconds (3 months)
+    events: 5                                # Neurons unlock in 5 stages
+    interval: 3 months
 
   confirmation_text: >
     I confirm that I am not a resident of a restricted jurisdiction
     and I understand the risks of participating in this token swap.
 
-  RestrictedCountries:
+  restricted_countries:
     - US
     - CN
 ```

--- a/skills/sns-launch/SKILL.md
+++ b/skills/sns-launch/SKILL.md
@@ -4,7 +4,7 @@ name: SNS DAO Launch
 category: Governance
 description: "Configure and launch an SNS DAO. Token economics, proposal types, nervous system parameters, and decentralization swap."
 endpoints: 22
-version: 1.8.1
+version: 1.9.0
 status: stable
 dependencies: [icrc-ledger, multi-canister]
 requires: [icp-cli >= 0.1.0, dfx sns extension, NNS neuron with stake]
@@ -103,71 +103,74 @@ dapp_canisters:
 Token:
   name: MyToken
   symbol: MYT
-  transaction_fee: 10_000        # e8s (0.0001 tokens)
+  transaction_fee: 0.0001 tokens
   logo: token_logo.png
 
 # === GOVERNANCE PARAMETERS ===
 Proposals:
-  rejection_fee: 100_000_000              # e8s (1 token)
-  initial_voting_period: 345_600           # seconds (4 days)
-  maximum_wait_for_quiet_deadline_extension: 86_400  # seconds (1 day)
+  rejection_fee: 1 token
+  initial_voting_period: 4 days
+  maximum_wait_for_quiet_deadline_extension: 1 day
 
 Neurons:
-  minimum_creation_stake: 100_000_000      # e8s (1 token)
+  minimum_creation_stake: 1 token
 
 Voting:
-  minimum_dissolve_delay: 2_629_800        # seconds (1 month)
-  MaximumDissolveDelayBonus:
-    duration: 252_288_000                  # seconds (8 years)
-    bonus: 100%            # 2x voting power at max dissolve
-  MaximumAgeBonusPercentage: 25%
+  minimum_dissolve_delay: 1 month
+  MaximumVotingPowerBonuses:
+    DissolveDelay:
+      duration: 8 years
+      bonus: 100%                            # 2x voting power at max dissolve
+    Age:
+      duration: 4 years
+      bonus: 25%
   RewardRate:
     initial: 2.5%
     final: 2.5%
-    transition_duration: 0                  # seconds
+    transition_duration: 0 seconds
 
 # === TOKEN DISTRIBUTION ===
 Distribution:
   Neurons:
     # Developer allocation (with vesting)
     - principal: DEVELOPER_PRINCIPAL
-      stake: 200_000_000_000_000             # e8s (2_000_000 tokens)
+      stake: 2_000_000 tokens
       memo: 0
-      dissolve_delay: 15_778_800             # seconds (6 months)
-      vesting_period: 63_115_200             # seconds (24 months)
+      dissolve_delay: 6 months
+      vesting_period: 24 months
 
     # Seed investors
     - principal: INVESTOR_PRINCIPAL
-      stake: 50_000_000_000_000              # e8s (500_000 tokens)
+      stake: 500_000 tokens
       memo: 1
-      dissolve_delay: 7_889_400              # seconds (3 months)
-      vesting_period: 31_557_600             # seconds (12 months)
+      dissolve_delay: 3 months
+      vesting_period: 12 months
 
   InitialBalances:
-    governance: 500_000_000_000_000  # e8s (5_000_000 tokens) — Treasury (controlled by DAO)
-    swap: 250_000_000_000_000       # e8s (2_500_000 tokens) — Sold during decentralization swap
+    treasury: 5_000_000 tokens               # Treasury (controlled by DAO)
+    swap: 2_500_000 tokens                   # Sold during decentralization swap
 
-  total: 1_000_000_000_000_000     # e8s (10_000_000 tokens) — Must equal sum of all allocations
+  total: 10_000_000 tokens                   # Must equal sum of all allocations
 
 # === DECENTRALIZATION SWAP ===
 Swap:
   minimum_participants: 100
-  minimum_direct_participation_icp: 5_000_000_000_000    # e8s (50_000 ICP)
-  maximum_direct_participation_icp: 50_000_000_000_000   # e8s (500_000 ICP)
-  minimum_participant_icp: 100_000_000                   # e8s (1 ICP)
-  maximum_participant_icp: 2_500_000_000_000             # e8s (25_000 ICP)
-  duration: 604_800                                      # seconds (7 days)
+  minimum_direct_participation_icp: 50_000 tokens
+  maximum_direct_participation_icp: 500_000 tokens
+  minimum_participant_icp: 1 token
+  maximum_participant_icp: 25_000 tokens
+  duration: 7 days
   neurons_fund_participation: true
 
   VestingSchedule:
-    events: 5                      # Neurons unlock in 5 stages
-    interval: 7_889_400              # seconds (3 months)
+    events: 5                                # Neurons unlock in 5 stages
+    interval: 3 months
 
   confirmation_text: >
     I confirm that I am not a resident of a restricted jurisdiction
     and I understand the risks of participating in this token swap.
 
-  RestrictedCountries:
+  restricted_countries:
     - US
     - CN
 ```


### PR DESCRIPTION
Verified against onicai production SNS config. Fixes 4 schema errors:
- MaximumDissolveDelayBonus → MaximumVotingPowerBonuses.DissolveDelay + Age
- InitialBalances.governance → InitialBalances.treasury
- RestrictedCountries → restricted_countries
- Raw e8s/seconds → human-readable units (tokens, days, months, years)