### PR TITLE
chore: replace CODEOWNERS catch-all with specific infra paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,12 @@
 # IC Skills — Code Owners
 # PRs touching these paths auto-request review from the listed GitHub users.
 
-# Default — Josh reviews everything
-* @JoshDFN
+# Infra & build
+/.github/                        @JoshDFN @marc0olo
+/.claude/                        @JoshDFN @marc0olo
+/scripts/                        @JoshDFN @marc0olo
+/src/                            @JoshDFN @marc0olo
+package.json                     @JoshDFN @marc0olo
 
 # Skill files — domain experts
 /skills/asset-canister/          @raymondk
@@ -15,6 +19,6 @@
 /skills/sns-launch/              @bjoernek
 /skills/https-outcalls/          @derlerd-dfinity
 /skills/multi-canister/          @derlerd-dfinity
-/skills/stable-memory/            @derlerd-dfinity
+/skills/stable-memory/           @derlerd-dfinity
 /skills/vetkd/                   @andreacerulli
 /skills/oisy-wallet-signer/      @AntonioVentilii


### PR DESCRIPTION
## Summary
- Remove `* @JoshDFN` catch-all so skill domain experts can approve their own PRs
- Add specific infra path ownership for @JoshDFN and @marc0olo (`.github/`, `.claude/`, `scripts/`, `src/`, `package.json`)
- `public/` left unowned since it's auto-generated and shouldn't block PRs