### PR TITLE
fix: correct msg_caller() explanation across skills

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -2866,7 +2866,7 @@ name: ICRC Ledger Standard
 category: Tokens
 description: "Deploy and interact with ICRC-1/ICRC-2 token ledgers. Minting, approvals, transfers, and metadata."
 endpoints: 11
-version: 2.3.1
+version: 2.3.2
 status: stable
 dependencies: []
 requires: [icp-cli >= 0.1.0, mops, ic-cdk >= 0.19]
@@ -3050,7 +3050,7 @@ persistent actor {
 
   // ICRC-2: Approve a spender
   public shared ({ caller }) func approveSpender(spender : Principal, amount : Nat) : async Nat {
-    // caller is captured before await -- critical for security
+    // caller is captured at function entry in Motoko -- safe across await
     let now = Nat64.fromNat(Int.abs(Time.now()));
     let result = await icpLedger.icrc2_approve({
       from_subaccount = null;
@@ -3391,7 +3391,7 @@ name: Internet Identity Auth
 category: Auth
 description: "Integrate Internet Identity authentication into frontend and backend canisters. Delegation, session management, and anchor handling."
 endpoints: 6
-version: 5.0.1
+version: 5.0.2
 status: stable
 dependencies: [asset-canister]
 requires: [icp-cli >= 0.1.0, @icp-sdk/auth >= 5.0, @icp-sdk/core >= 5.0]
@@ -3428,7 +3428,7 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 4. **Not handling auth callbacks.** The `authClient.login()` call requires `onSuccess` and `onError` callbacks. Without them, login failures are silently swallowed.
 
-5. **Reading `ic_cdk::api::msg_caller()` after an await in Rust.** After any `.await` point, `msg_caller()` returns the canister's own principal, not the original caller. Capture the caller into a variable BEFORE any await.
+5. **Defensive practice: bind `msg_caller()` before `.await` in Rust.** The current ic-cdk executor preserves the caller across `.await` points, but capturing it early guards against future executor changes. Always bind `let caller = ic_cdk::api::msg_caller();` at the top of async update functions.
 
 6. **Passing principal as string to backend.** The `AuthClient` gives you an `Identity` object. Backend canister methods receive the caller principal automatically via the IC protocol -- you do not pass it as a function argument. Use `shared(msg) { msg.caller }` in Motoko or `ic_cdk::api::msg_caller()` in Rust.
 
@@ -3644,8 +3644,7 @@ fn require_auth() -> Principal {
 
 #[update]
 fn init_owner() -> String {
-    // IMPORTANT: Capture caller BEFORE any .await calls.
-    // After .await, ic_cdk::caller() returns the canister's own principal.
+    // Defensive: capture caller before any .await calls.
     let caller = require_auth();
 
     OWNER.with(|owner| {
@@ -3687,20 +3686,16 @@ fn who_am_i() -> String {
     }
 }
 
-// For async functions, ALWAYS capture caller before await:
+// For async functions, capture caller before await as defensive practice:
 #[update]
 async fn protected_async_action() -> String {
-    let caller = require_auth(); // Capture HERE, before any await
-
-    // After this await, ic_cdk::caller() would return wrong principal
-    let _result = some_async_operation().await; // (pseudocode -- replace with your actual async call)
-
-    // Use the captured `caller` variable, NOT ic_cdk::caller()
+    let caller = require_auth(); // Capture before any await
+    let _result = some_async_operation().await;
     format!("Action completed by {}", caller)
 }
 ```
 
-**Rust critical rule:** In any `async` update function, `ic_cdk::api::msg_caller()` returns the correct value only before the first `.await`. After any `.await`, it returns the canister's own principal. Always bind `let caller = ic_cdk::api::msg_caller();` at the top of the function.
+**Rust defensive practice:** Bind `let caller = ic_cdk::api::msg_caller();` at the top of async update functions. The current ic-cdk executor preserves caller across `.await` points via protected tasks, but capturing it early guards against future executor changes.
 
 ## Deploy & Test
 
@@ -3766,7 +3761,7 @@ name: Multi-Canister Architecture
 category: Architecture
 description: "Design and deploy multi-canister dapps with inter-canister calls, shared state patterns, and upgrade strategies."
 endpoints: 8
-version: 3.0.2
+version: 3.0.3
 status: stable
 dependencies: [stable-memory]
 requires: [icp-cli >= 0.1.0, mops, ic-cdk >= 0.19]
@@ -3800,20 +3795,13 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 ## Mistakes That Break Your Build
 
-1. **`ic_cdk::api::msg_caller()` changes after `await` in Rust (CRITICAL).** In Rust, `ic_cdk::api::msg_caller()` returns the **callee** principal after an `await` point, not the original caller. Always capture the caller into a variable BEFORE any `await`. **Motoko is safe:** `public shared ({ caller }) func` captures `caller` as an immutable binding at function entry -- it does NOT change after await.
+1. **Defensive practice: bind `msg_caller()` before `.await` in Rust.** The current ic-cdk executor preserves caller across `.await` points via protected tasks, but capturing it early guards against future executor changes. **Motoko is safe:** `public shared ({ caller }) func` captures `caller` as an immutable binding at function entry.
 
     ```rust
-    // WRONG (Rust) — caller() is wrong after await:
+    // Recommended (Rust) — capture caller before await:
     #[update]
     async fn do_thing() {
-        let _ = some_canister_call().await;
-        let who = ic_cdk::api::msg_caller(); // THIS IS NOW THE CALLEE, NOT THE ORIGINAL CALLER
-    }
-
-    // CORRECT (Rust) — capture before await:
-    #[update]
-    async fn do_thing() {
-        let original_caller = ic_cdk::api::msg_caller(); // Capture BEFORE await
+        let original_caller = ic_cdk::api::msg_caller(); // Defensive: capture before await
         let _ = some_canister_call().await;
         let who = original_caller; // Safe
     }
@@ -4327,10 +4315,10 @@ fn get_user_service_id() -> Principal {
     })
 }
 
-// CRITICAL: capture caller BEFORE any await
+// Defensive: capture caller before any await
 #[update]
 async fn create_post(title: String, body: String) -> Result<Post, String> {
-    // Capture caller BEFORE the await -- caller() is wrong after await
+    // Capture caller before the await as defensive practice
     let original_caller = ic_cdk::api::msg_caller();
 
     if original_caller == Principal::anonymous() {
@@ -5527,7 +5515,7 @@ name: vetKD Encryption
 category: Security
 description: "Implement on-chain encryption using vetKD. Key derivation, encryption/decryption flows, and access control patterns."
 endpoints: 5
-version: 0.9.1
+version: 0.9.2
 status: beta
 dependencies: [internet-identity]
 requires: [icp-cli >= 0.1.0]
@@ -5588,7 +5576,7 @@ The management canister is not a real canister -- it is a system-level API endpo
 
 5. **Putting secret data in the `input` field.** The input is sent to the management canister in plaintext. It is a key identifier, not encrypted payload. Use it for IDs (principal, document ID), never for the actual secret data.
 
-6. **Forgetting that `vetkd_derive_key` is an async inter-canister call.** It costs cycles and requires `await`. Capture `caller` before the await -- after the await, `caller()` returns the canister's own principal.
+6. **Forgetting that `vetkd_derive_key` is an async inter-canister call.** It costs cycles and requires `await`. Capture `caller` before the await as defensive practice.
 
 7. **Using `context` inconsistently.** If the backend uses `b"my_app_v1"` as context but the frontend verification uses `b"my_app"`, the derived keys will not match and decryption will silently fail.
 

--- a/skills/icrc-ledger/SKILL.md
+++ b/skills/icrc-ledger/SKILL.md
@@ -4,7 +4,7 @@ name: ICRC Ledger Standard
 category: Tokens
 description: "Deploy and interact with ICRC-1/ICRC-2 token ledgers. Minting, approvals, transfers, and metadata."
 endpoints: 11
-version: 2.3.1
+version: 2.3.2
 status: stable
 dependencies: []
 requires: [icp-cli >= 0.1.0, mops, ic-cdk >= 0.19]
@@ -188,7 +188,7 @@ persistent actor {
 
   // ICRC-2: Approve a spender
   public shared ({ caller }) func approveSpender(spender : Principal, amount : Nat) : async Nat {
-    // caller is captured before await -- critical for security
+    // caller is captured at function entry in Motoko -- safe across await
     let now = Nat64.fromNat(Int.abs(Time.now()));
     let result = await icpLedger.icrc2_approve({
       from_subaccount = null;

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -4,7 +4,7 @@ name: Internet Identity Auth
 category: Auth
 description: "Integrate Internet Identity authentication into frontend and backend canisters. Delegation, session management, and anchor handling."
 endpoints: 6
-version: 5.0.1
+version: 5.0.2
 status: stable
 dependencies: [asset-canister]
 requires: [icp-cli >= 0.1.0, @icp-sdk/auth >= 5.0, @icp-sdk/core >= 5.0]
@@ -41,7 +41,7 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 4. **Not handling auth callbacks.** The `authClient.login()` call requires `onSuccess` and `onError` callbacks. Without them, login failures are silently swallowed.
 
-5. **Reading `ic_cdk::api::msg_caller()` after an await in Rust.** After any `.await` point, `msg_caller()` returns the canister's own principal, not the original caller. Capture the caller into a variable BEFORE any await.
+5. **Defensive practice: bind `msg_caller()` before `.await` in Rust.** The current ic-cdk executor preserves the caller across `.await` points, but capturing it early guards against future executor changes. Always bind `let caller = ic_cdk::api::msg_caller();` at the top of async update functions.
 
 6. **Passing principal as string to backend.** The `AuthClient` gives you an `Identity` object. Backend canister methods receive the caller principal automatically via the IC protocol -- you do not pass it as a function argument. Use `shared(msg) { msg.caller }` in Motoko or `ic_cdk::api::msg_caller()` in Rust.
 
@@ -257,8 +257,7 @@ fn require_auth() -> Principal {
 
 #[update]
 fn init_owner() -> String {
-    // IMPORTANT: Capture caller BEFORE any .await calls.
-    // After .await, ic_cdk::caller() returns the canister's own principal.
+    // Defensive: capture caller before any .await calls.
     let caller = require_auth();
 
     OWNER.with(|owner| {
@@ -300,20 +299,16 @@ fn who_am_i() -> String {
     }
 }
 
-// For async functions, ALWAYS capture caller before await:
+// For async functions, capture caller before await as defensive practice:
 #[update]
 async fn protected_async_action() -> String {
-    let caller = require_auth(); // Capture HERE, before any await
-
-    // After this await, ic_cdk::caller() would return wrong principal
-    let _result = some_async_operation().await; // (pseudocode -- replace with your actual async call)
-
-    // Use the captured `caller` variable, NOT ic_cdk::caller()
+    let caller = require_auth(); // Capture before any await
+    let _result = some_async_operation().await;
     format!("Action completed by {}", caller)
 }
 ```
 
-**Rust critical rule:** In any `async` update function, `ic_cdk::api::msg_caller()` returns the correct value only before the first `.await`. After any `.await`, it returns the canister's own principal. Always bind `let caller = ic_cdk::api::msg_caller();` at the top of the function.
+**Rust defensive practice:** Bind `let caller = ic_cdk::api::msg_caller();` at the top of async update functions. The current ic-cdk executor preserves caller across `.await` points via protected tasks, but capturing it early guards against future executor changes.
 
 ## Deploy & Test
 

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -4,7 +4,7 @@ name: Multi-Canister Architecture
 category: Architecture
 description: "Design and deploy multi-canister dapps with inter-canister calls, shared state patterns, and upgrade strategies."
 endpoints: 8
-version: 3.0.2
+version: 3.0.3
 status: stable
 dependencies: [stable-memory]
 requires: [icp-cli >= 0.1.0, mops, ic-cdk >= 0.19]
@@ -38,20 +38,13 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 ## Mistakes That Break Your Build
 
-1. **`ic_cdk::api::msg_caller()` changes after `await` in Rust (CRITICAL).** In Rust, `ic_cdk::api::msg_caller()` returns the **callee** principal after an `await` point, not the original caller. Always capture the caller into a variable BEFORE any `await`. **Motoko is safe:** `public shared ({ caller }) func` captures `caller` as an immutable binding at function entry -- it does NOT change after await.
+1. **Defensive practice: bind `msg_caller()` before `.await` in Rust.** The current ic-cdk executor preserves caller across `.await` points via protected tasks, but capturing it early guards against future executor changes. **Motoko is safe:** `public shared ({ caller }) func` captures `caller` as an immutable binding at function entry.
 
     ```rust
-    // WRONG (Rust) — caller() is wrong after await:
+    // Recommended (Rust) — capture caller before await:
     #[update]
     async fn do_thing() {
-        let _ = some_canister_call().await;
-        let who = ic_cdk::api::msg_caller(); // THIS IS NOW THE CALLEE, NOT THE ORIGINAL CALLER
-    }
-
-    // CORRECT (Rust) — capture before await:
-    #[update]
-    async fn do_thing() {
-        let original_caller = ic_cdk::api::msg_caller(); // Capture BEFORE await
+        let original_caller = ic_cdk::api::msg_caller(); // Defensive: capture before await
         let _ = some_canister_call().await;
         let who = original_caller; // Safe
     }
@@ -565,10 +558,10 @@ fn get_user_service_id() -> Principal {
     })
 }
 
-// CRITICAL: capture caller BEFORE any await
+// Defensive: capture caller before any await
 #[update]
 async fn create_post(title: String, body: String) -> Result<Post, String> {
-    // Capture caller BEFORE the await -- caller() is wrong after await
+    // Capture caller before the await as defensive practice
     let original_caller = ic_cdk::api::msg_caller();
 
     if original_caller == Principal::anonymous() {

--- a/skills/vetkd/SKILL.md
+++ b/skills/vetkd/SKILL.md
@@ -4,7 +4,7 @@ name: vetKD Encryption
 category: Security
 description: "Implement on-chain encryption using vetKD. Key derivation, encryption/decryption flows, and access control patterns."
 endpoints: 5
-version: 0.9.1
+version: 0.9.2
 status: beta
 dependencies: [internet-identity]
 requires: [icp-cli >= 0.1.0]
@@ -65,7 +65,7 @@ The management canister is not a real canister -- it is a system-level API endpo
 
 5. **Putting secret data in the `input` field.** The input is sent to the management canister in plaintext. It is a key identifier, not encrypted payload. Use it for IDs (principal, document ID), never for the actual secret data.
 
-6. **Forgetting that `vetkd_derive_key` is an async inter-canister call.** It costs cycles and requires `await`. Capture `caller` before the await -- after the await, `caller()` returns the canister's own principal.
+6. **Forgetting that `vetkd_derive_key` is an async inter-canister call.** It costs cycles and requires `await`. Capture `caller` before the await as defensive practice.
 
 7. **Using `context` inconsistently.** If the backend uses `b"my_app_v1"` as context but the frontend verification uses `b"my_app"`, the derived keys will not match and decryption will silently fail.
 


### PR DESCRIPTION
## Summary
- Downgrade incorrect "critical rule" about `msg_caller()` after `.await` to defensive practice
- The current ic-cdk executor preserves caller across `.await` via protected tasks — the previous explanation was inaccurate
- Updated 4 skills: internet-identity, multi-canister, vetkd, icrc-ledger

Fixes #21