### PR TITLE
chore: add jp-dfinity as CODEOWNER for ic-dashboard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,4 @@ package.json                     @JoshDFN @marc0olo
 /skills/stable-memory/           @derlerd-dfinity
 /skills/vetkd/                   @andreacerulli
 /skills/oisy-wallet-signer/      @AntonioVentilii
+/skills/ic-dashboard/            @jp-dfinity


### PR DESCRIPTION
Adds @jp-dfinity as code owner for /skills/ic-dashboard/