### PR TITLE
feat: auto-generate README skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,23 @@ The pitfalls section is the highest-value part. Every pitfall documented is a ha
 
 ## Skills
 
+<!-- SKILLS-TABLE-START -->
 | Skill | Category | Description |
 |-------|----------|-------------|
-| [ckbtc](skills/ckbtc/SKILL.md) | DeFi | Accept, send, and manage chain-key Bitcoin |
-| [icrc-ledger](skills/icrc-ledger/SKILL.md) | Tokens | ICRC-1/ICRC-2 token ledger standard |
-| [internet-identity](skills/internet-identity/SKILL.md) | Auth | Passkey authentication with Internet Identity |
-| [multi-canister](skills/multi-canister/SKILL.md) | Architecture | Inter-canister calls and multi-canister design |
-| [stable-memory](skills/stable-memory/SKILL.md) | Architecture | Persistent storage that survives upgrades |
-| [https-outcalls](skills/https-outcalls/SKILL.md) | Integration | HTTP requests from canisters to external APIs |
-| [evm-rpc](skills/evm-rpc/SKILL.md) | Integration | Read/write Ethereum from the IC |
-| [sns-launch](skills/sns-launch/SKILL.md) | Governance | Configure and launch an SNS DAO |
-| [asset-canister](skills/asset-canister/SKILL.md) | Frontend | Deploy frontend assets to the IC |
-| [certified-variables](skills/certified-variables/SKILL.md) | Security | Certified query responses |
-| [vetkd](skills/vetkd/SKILL.md) | Security | Threshold key derivation for encryption |
-| [wallet](skills/wallet/SKILL.md) | Infrastructure | Cycles management and canister lifecycle |
+| [Asset Canister & Frontend](skills/asset-canister/SKILL.md) | Frontend | Deploy frontend assets to the IC. Certified assets, custom domains, SPA routing, and content encoding. |
+| [Certified Variables](skills/certified-variables/SKILL.md) | Security | Serve verified responses from query calls. Merkle tree construction, certificate validation, and certified asset patterns. |
+| [ckBTC Integration](skills/ckbtc/SKILL.md) | DeFi | Accept, send, and manage ckBTC in your canister. Covers minting, transfers, balance checks, and UTXO management. |
+| [Cycles Wallet Management](skills/wallet/SKILL.md) | Infrastructure | Create, fund, and manage cycles wallets. Top-up canisters, check balances, and automate cycle management. |
+| [EVM RPC Integration](skills/evm-rpc/SKILL.md) | Integration | Call Ethereum and EVM chains from IC canisters. JSON-RPC, transaction signing, and cross-chain workflows. |
+| [HTTPS Outcalls](skills/https-outcalls/SKILL.md) | Integration | Make HTTP requests from canisters to external APIs. Consensus-safe request patterns, transform functions, and cost management. |
+| [IC Dashboard APIs](skills/ic-dashboard/SKILL.md) | Integration | Use the public REST APIs that power dashboard.internetcomputer.org. Get data for canisters, ledgers, SNS, and metrics. |
+| [ICRC Ledger Standard](skills/icrc-ledger/SKILL.md) | Tokens | Deploy and interact with ICRC-1/ICRC-2 token ledgers. Minting, approvals, transfers, and metadata. |
+| [Internet Identity Auth](skills/internet-identity/SKILL.md) | Auth | Integrate Internet Identity authentication into frontend and backend canisters. Delegation, session management, and anchor handling. |
+| [Multi-Canister Architecture](skills/multi-canister/SKILL.md) | Architecture | Design and deploy multi-canister dapps with inter-canister calls, shared state patterns, and upgrade strategies. |
+| [SNS DAO Launch](skills/sns-launch/SKILL.md) | Governance | Configure and launch an SNS DAO. Token economics, proposal types, nervous system parameters, and decentralization swap. |
+| [Stable Memory & Upgrades](skills/stable-memory/SKILL.md) | Architecture | Manage canister state across upgrades. Stable structures, pre/post upgrade hooks, and memory-mapped data. |
+| [vetKD Encryption](skills/vetkd/SKILL.md) | Security | Implement on-chain encryption using vetKD. Key derivation, encryption/decryption flows, and access control patterns. |
+<!-- SKILLS-TABLE-END -->
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "validate": "node scripts/validate-skills.js",
-    "generate": "node scripts/generate-skills.js && node scripts/generate-llms-full.js && node scripts/generate-llms.js && node scripts/generate-agent-json.js",
+    "generate": "node scripts/generate-skills.js && node scripts/generate-llms-full.js && node scripts/generate-llms.js && node scripts/generate-agent-json.js && node scripts/generate-readme-table.js",
     "dev": "npm run validate && npm run generate && vite",
     "build": "npm run validate && npm run generate && vite build && node scripts/generate-skill-pages.js && node scripts/generate-sitemap.js",
     "preview": "vite preview"

--- a/scripts/generate-readme-table.js
+++ b/scripts/generate-readme-table.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Generates the skills table in README.md from SKILL.md frontmatter
+// Run: node scripts/generate-readme-table.js
+
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { ROOT, readAllSkills } from "./lib/parse-skill.js";
+
+const README = join(ROOT, "README.md");
+const START = "<!-- SKILLS-TABLE-START -->";
+const END = "<!-- SKILLS-TABLE-END -->";
+
+const skills = readAllSkills()
+  .filter((s) => s.meta.id && s.meta.name)
+  .sort((a, b) => a.meta.name.localeCompare(b.meta.name));
+
+const header = "| Skill | Category | Description |";
+const divider = "|-------|----------|-------------|";
+const rows = skills.map(
+  (s) =>
+    `| [${s.meta.name}](skills/${s.meta.id}/SKILL.md) | ${s.meta.category} | ${s.meta.description.replace(/"/g, "")} |`
+);
+
+const table = [START, header, divider, ...rows, END].join("\n");
+
+const readme = readFileSync(README, "utf-8");
+const re = new RegExp(`${START}[\\s\\S]*?${END}`);
+
+if (!re.test(readme)) {
+  console.error(
+    `ERROR: README.md missing ${START} / ${END} markers. Add them around the skills table.`
+  );
+  process.exit(1);
+}
+
+writeFileSync(README, readme.replace(re, table));
+console.log(`Updated README.md skills table (${skills.length} skills)`);


### PR DESCRIPTION
## Summary
- New `scripts/generate-readme-table.js` auto-generates the skills table in README.md from SKILL.md frontmatter
- Uses `<!-- SKILLS-TABLE-START -->` / `<!-- SKILLS-TABLE-END -->` markers
- Added to `npm run generate` so new skills are automatically included
- Table is alphabetically sorted, now includes all 13 skills (ic-dashboard was missing)