### PR TITLE
Remove misleading hardcoded Endpoints stat

### DIFF
--- a/src/components/BrowseTab.tsx
+++ b/src/components/BrowseTab.tsx
@@ -62,7 +62,6 @@ export default function BrowseTab({ skills }: Props) {
           {[
             { val: skills.length, label: "Skills" },
             { val: TOTAL_ENDPOINTS, label: "Operations" },
-            { val: "5", label: "Endpoints" },
             { val: "0", label: "Hallucinations" },
           ].map(({ val, label }) => (
             <div key={label}>


### PR DESCRIPTION
## Summary

- Removed the hardcoded "5 Endpoints" hero stat — it referred to site-level access URLs, not skill operations
- Hero now shows 3 stats: Skills (dynamic count), Operations (sum across skills), Hallucinations (0)

Follow-up to PR #41.