### PR TITLE
draft: example skills for proposed catalog restructuring

### DIFF
--- a/_drafts/canister-security/SKILL.md
+++ b/_drafts/canister-security/SKILL.md
@@ -7,8 +7,6 @@ metadata:
   title: Canister Security
   category: Security
   version: 1.0.0
-  status: stable
-  dependencies: ""
 ---
 
 # Canister Security
@@ -19,7 +17,7 @@ IC canisters face security challenges that don't exist in traditional web develo
 
 ## Prerequisites
 
-- `icp-cli` >= 0.2.0 — see [icp-cli](../icp-cli/SKILL.md) for setup
+- `icp-cli` >= 0.2.0 (install: `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`)
 - For Motoko: `mops` package manager, `core = "2.0.0"` in mops.toml
 - For Rust: `ic-cdk = "0.19"`, `candid = "0.10"`
 
@@ -29,13 +27,13 @@ IC canisters face security challenges that don't exist in traditional web develo
 
 2. **Forgetting to reject the anonymous principal.** Every endpoint that requires authentication must check `caller != Principal.anonymous()`. Without this, unauthenticated requests silently succeed. This is the most common IC security bug.
 
-3. **Reading state before an async call and assuming it's unchanged after.** When your canister `await`s an inter-canister call, other messages can interleave and mutate state. This TOCTOU pattern is the #1 source of DeFi exploits on IC. For detailed async atomicity patterns and saga-based compensation, see [inter-canister-calls](../inter-canister-calls/SKILL.md).
+3. **Reading state before an async call and assuming it's unchanged after.** When your canister `await`s an inter-canister call, other messages can interleave and mutate state. This TOCTOU pattern is the #1 source of DeFi exploits on IC. Always deduct/lock state before the `await`, then compensate on failure (saga pattern).
 
 4. **Not setting a freezing threshold.** Without it, a canister silently runs out of cycles and gets deleted — all state lost permanently. Set `freezing_threshold` to at least 30 days (2,592,000 seconds):
    ```bash
    icp canister settings update backend --freezing-threshold 2592000 -e ic
    ```
-   Verify with `icp canister settings show backend -e ic` (see [icp-cli](../icp-cli/SKILL.md) for CLI details).
+   Verify with `icp canister settings show backend -e ic`.
 
 5. **Single controller with no backup.** If you lose the controller identity's PEM file, the canister becomes unupgradeable forever. Always add a backup controller or governance canister:
    ```bash
@@ -46,7 +44,7 @@ IC canisters face security challenges that don't exist in traditional web develo
 
 7. **Exposing admin methods without guards.** Every update method is callable by anyone on the internet. Admin methods (migration, config, minting) must explicitly check the caller against an allowlist.
 
-8. **Storing secrets in canister state.** Canister memory on standard application subnets is readable by node operators. Never store private keys, API secrets, or passwords. For on-chain secret management, use vetKD (see [vetkd-encryption](../vetkd-encryption/SKILL.md) when available).
+8. **Storing secrets in canister state.** Canister memory on standard application subnets is readable by node operators. Never store private keys, API secrets, or passwords. For on-chain secret management, use vetKD (threshold key derivation).
 
 ## How It Works
 
@@ -326,7 +324,7 @@ icp canister call backend admin_action '()' --identity attacker
 
 ### Mainnet Security Checklist
 
-Run these checks after every mainnet deployment (see [icp-cli](../icp-cli/SKILL.md) for CLI details):
+Run these checks after every mainnet deployment:
 
 ```bash
 # 1. Verify controllers include a backup

--- a/_drafts/icp-cli/SKILL.md
+++ b/_drafts/icp-cli/SKILL.md
@@ -7,8 +7,6 @@ metadata:
   title: ICP CLI
   category: Infrastructure
   version: 1.0.0
-  status: stable
-  dependencies: ""
 ---
 
 # ICP CLI
@@ -51,7 +49,7 @@ The `icp` CLI (successor to `dfx`) manages the full lifecycle of Internet Comput
 
 5. **Hardcoding canister IDs.** Canister IDs are managed per environment. Managed networks (local) store IDs in `.icp/cache/mappings/<env>.ids.json` (ephemeral — deleted when network stops). Connected networks (mainnet) store IDs in `.icp/data/mappings/<env>.ids.json` (persistent). **Commit `.icp/data/` to source control** — losing it means losing track of deployed mainnet canisters.
 
-6. **Deploying to mainnet without checking cycles.** Canister creation costs ~2T cycles by default. Check balance with `icp cycles balance -e ic`. A canister that runs out of cycles freezes and eventually gets deleted — see [canister-security](../canister-security/SKILL.md) for freezing threshold configuration.
+6. **Deploying to mainnet without checking cycles.** Canister creation costs ~2T cycles by default. Check balance with `icp cycles balance -e ic`. A canister that runs out of cycles freezes and eventually gets deleted. Set `freezing_threshold` to at least 30 days (2,592,000 seconds) via `icp canister settings update <name> --freezing-threshold 2592000 -e ic`.
 
 7. **Forgetting to start the local network.** `icp deploy` without a running local network gives a confusing connection error. Run `icp network start -d` first (`-d` for background mode). Note: local networks are **project-specific** (unlike dfx which shared one network across projects).
 
@@ -196,7 +194,7 @@ icp identity list
 icp identity export my-identity
 ```
 
-**Security**: Identity keys are stored in platform-specific directories (macOS: `~/Library/Application Support/org.dfinity.icp-cli/identity/`, Linux: `~/.local/share/icp-cli/identity/`). Never commit these to version control. See [canister-security](../canister-security/SKILL.md) for controller management and backup identity patterns.
+**Security**: Identity keys are stored in platform-specific directories (macOS: `~/Library/Application Support/org.dfinity.icp-cli/identity/`, Linux: `~/.local/share/icp-cli/identity/`). Never commit these to version control. Always add a backup controller: `icp canister settings update <name> --add-controller <backup-principal> -e ic`.
 
 ### Cycles Management
 


### PR DESCRIPTION
## Context

This PR contains two draft SKILL.md files that demonstrate the proposed skill structure from the skills catalog restructuring analysis — see **RFC Issue #52** for the full analysis and discussion.

These are **not ready to merge** into `skills/` — the frontmatter uses the new [Agent Skills spec](https://agentskills.io/specification)-compliant format (`metadata:`, `license`, `compatibility`) which requires #45 to be resolved first.

## What's included

### `_drafts/icp-cli/SKILL.md` (273 lines)
- Tier 1 foundation skill for CLI tooling
- Covers: project creation, recipes, environments, canister operations, identity, cycles
- Uses `icp-cli` v0.2.0 command syntax

### `_drafts/canister-security/SKILL.md` (366 lines)
- Tier 1 foundation skill for security patterns
- Covers: access control, `inspect_message`, anonymous caller rejection, async TOCTOU, freezing threshold, controller backup, root key handling (`ic_env` cookie, `icp network status --json`)
- Both Motoko and Rust implementations including `system func inspect` and `#[inspect_message]`

## Key design decisions demonstrated

1. **Spec-compliant frontmatter** — custom fields under `metadata:`, `license: Apache-2.0`, `compatibility` replaces `requires`. Lean metadata: only `title`, `category`, `version` (dropped `status`, `dependencies`, `endpoints`, `tags`)
2. **Self-contained skills** — no cross-skill file links. Essential info is inlined where previously a link existed. Follows the same pattern as [Anthropic's official skills](https://github.com/anthropics/skills)
3. **Under 500 lines** — both skills stay within the recommended limit
4. **"Use when... Do NOT use for..."** — descriptions include agent routing trigger phrases
5. **Pitfalls-first** — the highest-value content is the "Mistakes That Break Your Build" section
6. **Consistent prerequisite format** — follows existing skill convention: `tool >= version (install: \`command\`)`

## Related

- **RFC Analysis**: #52
- **Frontmatter alignment**: #45 (prerequisite for moving to `skills/`)
- **Build simplification**: #50