### PR TITLE
fix: fetch full git history for correct skill dates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

- The deploy workflow used a shallow clone (depth=1 by default), which caused `git log -1 --format=%cs -- <file>` to return the HEAD commit date for **every** file — making all skills show the same "last updated" date on the site.
- Adding `fetch-depth: 0` to the checkout step fetches full git history so each skill resolves to its actual last-commit date.
- Dates are computed at build time, so this fix corrects all existing wrong dates on the next deploy.