### PR TITLE
fix: paste in agent copies the URL instead of a curl command

### DIFF
--- a/src/components/BrowseTab.tsx
+++ b/src/components/BrowseTab.tsx
@@ -132,11 +132,13 @@ export default function BrowseTab({ skills }: Props) {
       }}>
         {filtered.map((skill) => {
           const rawUrl = `https://raw.githubusercontent.com/dfinity/icskills/main/skills/${skill.id}/SKILL.md`;
-          const fetchCmd = `curl -sL ${rawUrl}`;
           return (
-            <a
+            <div
               key={skill.id}
-              href={`${BASE_PATH}/skills/${skill.id}/`}
+              role="link"
+              tabIndex={0}
+              onClick={() => { window.location.href = `${BASE_PATH}/skills/${skill.id}/`; }}
+              onKeyDown={(e) => { if (e.key === "Enter") window.location.href = `${BASE_PATH}/skills/${skill.id}/`; }}
               className="skill-card"
               style={{
                 padding: "24px",
@@ -144,7 +146,6 @@ export default function BrowseTab({ skills }: Props) {
                 border: "1px solid var(--border-default)",
                 borderRadius: "12px",
                 cursor: "pointer",
-                textDecoration: "none",
                 color: "inherit",
                 display: "block",
               }}
@@ -213,11 +214,11 @@ export default function BrowseTab({ skills }: Props) {
                   whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
                   minWidth: 0,
                 }}>
-                  {fetchCmd}
+                  {rawUrl}
                 </code>
-                <CopyButton text={fetchCmd} />
+                <CopyButton text={rawUrl} />
               </div>
-            </a>
+            </div>
           );
         })}
       </div>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -9,6 +9,7 @@ export default function CopyButton({ text, label }: Props) {
   const [copied, setCopied] = useState(false);
   const onClick = (e: Event) => {
     e.stopPropagation();
+    e.preventDefault();
     navigator.clipboard.writeText(text).catch(() => {});
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -110,9 +110,9 @@ export default function SkillHeader({ skillId, skillName, category, lastUpdated 
             whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
             minWidth: 0,
           }}>
-            curl -sL {rawUrl}
+            {rawUrl}
           </code>
-          <CopyButton text={`curl -sL ${rawUrl}`} />
+          <CopyButton text={`${rawUrl}`} />
         </div>
       </div>
     </>


### PR DESCRIPTION
* changes the `copy` button to copy the link to the skill instead of a curl command. The URL is sufficient for the agent and it will know how to read the skill.
* Fix a navigation - clicking on the "copy" button on a tile would propagate the event and navigate away from the page. There were also a bunch of improperly nested tags.