### PR TITLE
fix: mobile responsive — nav tabs and install commands

### DIFF
--- a/src/components/BrowseTab.tsx
+++ b/src/components/BrowseTab.tsx
@@ -215,7 +215,8 @@ export default function BrowseTab({ skills }: Props) {
                   whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
                   minWidth: 0,
                 }}>
-                  {installCmd}
+                  <span className="install-cmd-full">{installCmd}</span>
+                  <span className="install-cmd-short" style={{ display: "none" }}>--skill {skill.name}</span>
                 </code>
                 <CopyButton text={installCmd} />
               </div>

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -45,7 +45,7 @@ const tabs = [
         <div style="display:flex;align-items:baseline;gap:14px;flex-shrink:0;">
           <a href="/" style="font-family:'Inter',system-ui,sans-serif;font-weight:600;font-size:18px;letter-spacing:-0.02em;color:var(--text-primary);line-height:1;text-decoration:none;">Internet Computer (ICP) Skills</a>
         </div>
-        <div style="display:flex;gap:4px;align-items:center;flex-wrap:wrap;">
+        <div class="nav-tabs-row" style="display:flex;gap:4px;align-items:center;">
           {tabs.map((tab) => (
             <a
               href={tab.href}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -444,6 +444,11 @@ a:focus-visible {
     padding: 0 16px !important;
   }
 
+  .nav-tabs-row a {
+    padding: 6px 10px !important;
+    font-size: 13px !important;
+  }
+
   main {
     padding: 20px 16px 48px !important;
   }
@@ -484,8 +489,12 @@ a:focus-visible {
     padding: 16px !important;
   }
 
-  .skill-card .card-agent-url {
+  .install-cmd-full {
     display: none !important;
+  }
+
+  .install-cmd-short {
+    display: inline !important;
   }
 
   .step-grid {
@@ -531,7 +540,7 @@ a:focus-visible {
   }
 
   .endpoint-hint {
-    display: none !important;
+    flex: 1 1 100% !important;
   }
 
   .endpoint-desc {


### PR DESCRIPTION
## Summary

- Fix nav tabs wrapping theme toggle to 2nd row on mobile (caused by longer "Get Started" label from #85)
- Show install commands on browse cards at mobile — short form `--skill <name>` displayed, full command copied
- Show hero `npx skills add` hint full-width below search instead of hiding it on small screens