### PR TITLE
fix(ci): add missing permissions to deploy workflow

### DIFF
--- a/.github/workflows/deploy-ic.yml
+++ b/.github/workflows/deploy-ic.yml
@@ -9,9 +9,16 @@ concurrency:
   group: ic-deploy
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   checks:
     uses: ./.github/workflows/_checks.yml
+    permissions:
+      contents: read
+      pull-requests: write
 
   deploy:
     needs: checks


### PR DESCRIPTION
## Summary

- The deploy workflow has been failing with `startup_failure` on every push to `main` since #115 added `pull-requests: write` to `_checks.yml`
- `deploy-ic.yml` calls `_checks.yml` as a reusable workflow but never granted the required `pull-requests: write` permission
- Adds top-level and job-level permissions to match `ci.yml`

Last successful deploy: March 21. All 6 deploys to `main` since March 23 have failed.