### PR TITLE
fix(ci): skip link validation and bump skill-validator to v1.5.1

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install skill-validator
         env:
-          SKILL_VALIDATOR_VERSION: "1.4.0"
+          SKILL_VALIDATOR_VERSION: "1.5.1"
         run: |
           curl -sL "https://github.com/agent-ecosystem/skill-validator/releases/download/v${SKILL_VALIDATOR_VERSION}/skill-validator_${SKILL_VALIDATOR_VERSION}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin skill-validator
 
@@ -56,7 +56,8 @@ jobs:
         if: steps.changed.outputs.found == 'true'
         run: |
           set +e
-          report=$(skill-validator check ${{ steps.changed.outputs.paths }} -o markdown 2>/dev/null)
+          # TODO: re-enable link checks once https://github.com/agent-ecosystem/skill-validator/issues/45 is resolved
+          report=$(skill-validator check ${{ steps.changed.outputs.paths }} --skip links -o markdown 2>/dev/null)
           exit_code=$?
           echo "$report" >> "$GITHUB_STEP_SUMMARY"
           delimiter=$(openssl rand -hex 8)
@@ -67,7 +68,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           # Re-run with annotations sent to stdout/stderr for GitHub to process
-          skill-validator check ${{ steps.changed.outputs.paths }} --emit-annotations > /dev/null
+          skill-validator check ${{ steps.changed.outputs.paths }} --skip links --emit-annotations > /dev/null
           exit 0
 
       - name: Run project-specific checks

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "validate": "skill-validator check skills/ && node scripts/check-project.js",
+    "validate": "skill-validator check skills/ --skip links && node scripts/check-project.js",
     "dev": "npm run validate && astro dev",
     "build": "npm run validate && astro build",
     "preview": "astro preview"


### PR DESCRIPTION
## Summary

- Temporarily skip link validation in CI and local `npm run validate` — the skill-validator uses HEAD-only requests, causing false positives on sites like crates.io and ledger-api.internetcomputer.org that return 404 for HEAD but 200 for GET
- Bump skill-validator from v1.4.0 to v1.5.1
- Tracked upstream: https://github.com/agent-ecosystem/skill-validator/issues/45

This unblocks the deploy workflow which has been failing on every push to `main` since March 23.