### PR TITLE
fix(ci): decouple validate from build and dev scripts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,8 +27,8 @@ No rigid structure — organize content to best serve agents. The validator warn
 ```bash
 npm install          # Install dependencies
 npm run validate     # Runs skill-validator check + project-specific checks
-npm run dev          # Validate + start Astro dev server
-npm run build        # Validate + Astro production build
+npm run dev          # Start Astro dev server
+npm run build        # Astro production build
 ```
 
 ## Workflow

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "scripts": {
     "validate": "skill-validator check skills/ --skip links && node scripts/check-project.js",
-    "dev": "npm run validate && astro dev",
-    "build": "npm run validate && astro build",
+    "dev": "astro dev",
+    "build": "astro build",
     "preview": "astro preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Remove `npm run validate` from `build` and `dev` scripts — validation is a separate concern handled by CI (`_checks.yml`) and run explicitly by developers (`npm run validate`)
- The deploy job was failing because `npm run build` triggered `skill-validator` which is only installed in the checks job
- Update CLAUDE.md to reflect the decoupled scripts

Validation still runs on both PRs and main pushes via the `_checks.yml` reusable workflow.