### PR TITLE
fix(icrc-ledger): fix deploy config, add pitfalls, and evaluations

### DIFF
--- a/evaluations/icrc-ledger.json
+++ b/evaluations/icrc-ledger.json
@@ -1,0 +1,73 @@
+{
+  "skill": "icrc-ledger",
+  "description": "Evaluation cases for the icrc-ledger skill. Tests whether agents produce correct ICRC-1/ICRC-2 code with proper types, fee handling, error handling, and deployment config.",
+
+  "output_evals": [
+    {
+      "name": "ICRC-1 transfer in Motoko",
+      "prompt": "Write a Motoko function that transfers ICP tokens from the calling canister to a given principal. Just the function, no actor boilerplate, no deploy steps.",
+      "expected_behaviors": [
+        "Uses Account type with owner and subaccount fields (not a bare Principal) for the 'to' argument",
+        "Sets created_at_time for deduplication",
+        "Handles the Result return type — matches on #Ok and at least #Err(#InsufficientFunds) or propagates the error",
+        "Handles #Err(#BadFee) explicitly rather than silently dropping it",
+        "Uses the correct ICP ledger canister ID ryjl3-tyaaa-aaaaa-aaaba-cai"
+      ]
+    },
+    {
+      "name": "ICRC-2 approve and transferFrom in Rust",
+      "prompt": "Show me the Rust functions for an ICRC-2 approve-then-transferFrom flow. Just the two endpoint functions with proper error handling, no Cargo.toml or deploy steps.",
+      "expected_behaviors": [
+        "Two separate functions: one for approve, one for transfer_from",
+        "Uses types from icrc-ledger-types crate (ApproveArgs, TransferFromArgs)",
+        "Sets created_at_time for deduplication",
+        "Handles InsufficientAllowance error variant in the transfer_from function",
+        "Handles BadFee error variant rather than silently dropping it"
+      ]
+    },
+    {
+      "name": "Burn fee semantics",
+      "prompt": "My canister transfers ICP tokens to a recipient principal passed as an argument. It works for most recipients but fails with BadFee expected 0 for one specific principal. The fee I'm passing is 10000 which is correct for ICP. What's going on? Just explain the cause and fix, no full code.",
+      "expected_behaviors": [
+        "Identifies that the recipient is likely the minting account, making the transfer a burn",
+        "Explains that burns (transfers to minting account) require fee = null or fee = 0, not the regular transfer fee",
+        "Does NOT suggest the fee value 10000 is wrong for regular ICP transfers"
+      ]
+    },
+    {
+      "name": "Deploy an ICRC-1 ledger",
+      "prompt": "Show me the icp.yaml config and init args file to deploy an ICRC-1 ledger canister with ICRC-2 enabled. I want to fund two accounts at genesis. Just the config files, no code.",
+      "expected_behaviors": [
+        "Uses build.steps with type: pre-built and a URL (not recipe type: custom)",
+        "Uses init_args with path and format fields (not init_arg_file)",
+        "minting_account uses a different principal than the ones in initial_balances",
+        "initial_balances contains two entries with different principals",
+        "Includes feature_flags with icrc2 = true"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I transfer ICP tokens from my canister?",
+      "What are the ICRC-1 ledger canister IDs for ICP, ckBTC, and ckETH?",
+      "Implement ICRC-2 approve and transferFrom",
+      "Deploy an ICRC-1 ledger",
+      "Check a user's token balance on IC",
+      "What fee should I use for ICP transfers?",
+      "How does the ICRC-1 Account type work?",
+      "I need to do a token allowance flow like ERC-20"
+    ],
+    "should_not_trigger": [
+      "How do I mint ckBTC from a BTC deposit?",
+      "Set up Internet Identity login",
+      "Deploy my canister to mainnet",
+      "Add access control to my canister",
+      "How do I make inter-canister calls?",
+      "Connect a wallet to my frontend",
+      "How does stable memory work?",
+      "What's the icp.yaml config for a Rust canister?"
+    ]
+  }
+}

--- a/skills/icrc-ledger/SKILL.md
+++ b/skills/icrc-ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icrc-ledger
-description: "Deploy and interact with ICRC-1/ICRC-2 token ledgers (ICP, ckBTC, ckETH). Covers transfers, balances, approve/transferFrom allowances, fee handling, and local test ledger deployment. Use when working with ICP transfers, token transfers, balances, ICRC-1, ICRC-2, approve, allowance, or any fungible token on IC. Do NOT use for ckBTC minting or BTC deposit/withdrawal flows — use ckbtc instead."
+description: "Deploy and interact with ICRC-1/ICRC-2 token ledgers (ICP, ckBTC, ckETH). Covers transfers, balances, approve/transferFrom allowances, fee handling, and ledger deployment. Use when working with ICP transfers, token transfers, balances, ICRC-1, ICRC-2, approve, allowance, or any fungible token on IC. Do NOT use for ckBTC minting or BTC deposit/withdrawal flows — use ckbtc instead."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.1.0"
 metadata:
@@ -15,25 +15,27 @@ ICRC-1 is the fungible token standard on Internet Computer, defining transfer, b
 
 ## Prerequisites
 
-- For Motoko: mops with `core = "2.0.0"` in mops.toml
+- For Motoko: mops with `core = "2.3.1"` in mops.toml
 - For Rust: `ic-cdk = "0.19"`, `candid = "0.10"`, `icrc-ledger-types = "0.1"` in Cargo.toml
 
 ## Canister IDs
 
-| Token | Ledger Canister ID | Fee | Decimals |
-|-------|-------------------|-----|----------|
-| ICP | `ryjl3-tyaaa-aaaaa-aaaba-cai` | 10000 e8s (0.0001 ICP) | 8 |
-| ckBTC | `mxzaz-hqaaa-aaaar-qaada-cai` | 10 satoshis | 8 |
-| ckETH | `ss2fx-dyaaa-aaaar-qacoq-cai` | 2000000000000 wei (0.000002 ETH) | 18 |
+| Token | Ledger Canister ID | Decimals |
+|-------|-------------------|----------|
+| ICP | `ryjl3-tyaaa-aaaaa-aaaba-cai` | 8 |
+| ckBTC | `mxzaz-hqaaa-aaaar-qaada-cai` | 8 |
+| ckETH | `ss2fx-dyaaa-aaaar-qacoq-cai` | 18 |
 
 Index canisters (for transaction history):
 - ICP Index: `qhbym-qaaaa-aaaaa-aaafq-cai`
 - ckBTC Index: `n5wcd-faaaa-aaaar-qaaea-cai`
 - ckETH Index: `s3zol-vqaaa-aaaar-qacpa-cai`
 
-## Mistakes That Break Your Build
+All ICRC-1 ledgers expose `icrc1_fee : () -> (nat) query` to return the current transfer fee. Fees are denominated in the token's smallest unit (e8s for ICP where 1 ICP = 10⁸ e8s, satoshis for ckBTC, wei for ckETH). Each ledger sets its own fee, and fees can change at runtime.
 
-1. **Wrong fee amount** -- ICP fee is 10000 e8s, NOT 10000 ICP. ckBTC fee is 10 satoshis, NOT 10 ckBTC. Using the wrong unit drains your entire balance in one transfer.
+## Common Pitfalls
+
+1. **Assuming all ledgers share the same fee** -- Each ledger sets its own fee (e.g., ICP = 10000 e8s, ckBTC = 10 satoshis). Never copy a fee value from one ledger and use it for another. Look up the fee via `icrc1_fee` (on-chain query or `icp canister call <ledger> icrc1_fee '()'` via CLI). Fees can also change at runtime, so always handle `BadFee { expected_fee }` — the ledger tells you the correct fee in the error response.
 
 2. **Forgetting approve before transferFrom** -- ICRC-2 transferFrom will reject with `InsufficientAllowance` if the token owner has not called `icrc2_approve` first. This is a two-step flow: owner approves, then spender calls transferFrom.
 
@@ -47,7 +49,12 @@ Index canisters (for transaction history):
 
 7. **Calling ledger from frontend** -- ICRC-1 transfers should originate from a backend canister, not directly from the frontend. Frontend-initiated transfers expose the user to reentrancy and can bypass business logic. Use a backend canister as the intermediary.
 
-8. **Shell substitution in `--argument-file` / `init_arg_file`** -- Expressions like `$(icp identity principal)` do NOT expand inside files referenced by `init_arg_file` or `--argument-file`. The file is read as literal text. Either use `--argument` on the command line (where the shell expands variables), or pre-generate the file with `envsubst` / `sed` before deploying.
+8. **Shell substitution in `--argument-file` / `init_args.path`** -- Expressions like `$(icp identity principal)` do NOT expand inside files referenced by `init_args: { path: ... }` or `--argument-file`. The file is read as literal text. Either use `--argument` on the command line (where the shell expands variables), or pre-generate the file with `envsubst` / `sed` before deploying.
+
+9. **Minting account cannot call `icrc2_approve`** -- If the ledger's `minting_account` and `initial_balances` use the same principal, that principal cannot call `icrc2_approve` — the ledger traps with "the minting account cannot delegate mints." Always use a **separate** principal for `minting_account` and different ones for `initial_balances`. In production, the minting account is typically a dedicated minter canister (e.g., the ckBTC minter); for local development, any principal that differs from your funded accounts works.
+
+10. **Transfers to/from the minting account have zero fee** -- A transfer TO the minting account is a **burn**, and a transfer FROM the minting account is a **mint**. Both require `fee = null` (or `fee = ?0`). Passing the regular transfer fee (e.g., `fee = ?10000` for ICP) will fail with `BadFee { expected_fee = 0 }`. The error message gives no indication that burn/mint semantics are involved — it just says the expected fee is 0.
+
 
 ## Implementation
 
@@ -141,6 +148,13 @@ persistent actor {
     #GenericError : { error_code : Nat; message : Text };
   };
 
+  type Value = {
+    #Nat : Nat;
+    #Int : Int;
+    #Text : Text;
+    #Blob : Blob;
+  };
+
   // Remote ledger actor reference (ICP ledger shown; swap canister ID for other tokens)
   transient let icpLedger = actor ("ryjl3-tyaaa-aaaaa-aaaba-cai") : actor {
     icrc1_balance_of : shared query (Account) -> async Nat;
@@ -149,7 +163,12 @@ persistent actor {
     icrc2_transfer_from : shared (TransferFromArg) -> async { #Ok : Nat; #Err : TransferFromError };
     icrc1_fee : shared query () -> async Nat;
     icrc1_decimals : shared query () -> async Nat8;
+    icrc1_metadata : shared query () -> async [(Text, Value)];
+    icrc1_supported_standards : shared query () -> async [{ name : Text; url : Text }];
   };
+
+  // Fee for the ICP ledger — look up via icrc1_fee if targeting a different ledger
+  transient let icpFee : Nat = 10000;
 
   // Check balance
   public func getBalance(who : Principal) : async Nat {
@@ -167,7 +186,7 @@ persistent actor {
       from_subaccount = null;
       to = { owner = to; subaccount = null };
       amount = amount;
-      fee = ?10000; // ICP fee: 10000 e8s
+      fee = ?icpFee;
       memo = null;
       created_at_time = ?now;
     });
@@ -193,7 +212,7 @@ persistent actor {
       amount = amount;
       expected_allowance = null;
       expires_at = null;
-      fee = ?10000;
+      fee = ?icpFee;
       memo = null;
       created_at_time = ?now;
     });
@@ -212,7 +231,7 @@ persistent actor {
       from = { owner = from; subaccount = null };
       to = { owner = to; subaccount = null };
       amount = amount;
-      fee = ?10000;
+      fee = ?icpFee;
       memo = null;
       created_at_time = ?now;
     });
@@ -259,7 +278,8 @@ use ic_cdk::update;
 use ic_cdk::call::Call;
 
 const ICP_LEDGER: &str = "ryjl3-tyaaa-aaaaa-aaaba-cai";
-const ICP_FEE: u64 = 10_000; // 10000 e8s
+// Fee for the ICP ledger — look up via icrc1_fee if targeting a different ledger
+const ICP_FEE: u64 = 10_000;
 
 fn ledger_id() -> Principal {
     Principal::from_text(ICP_LEDGER).unwrap()
@@ -285,6 +305,7 @@ async fn get_balance(who: Principal) -> Nat {
 // WARNING: Add access control in production — this allows any caller to transfer tokens
 #[update]
 async fn send_tokens(to: Principal, amount: Nat) -> Result<Nat, String> {
+    let fee = Nat::from(ICP_FEE);
     let transfer_arg = TransferArg {
         from_subaccount: None,
         to: Account {
@@ -292,7 +313,7 @@ async fn send_tokens(to: Principal, amount: Nat) -> Result<Nat, String> {
             subaccount: None,
         },
         amount,
-        fee: Some(Nat::from(ICP_FEE)),
+        fee: Some(fee),
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),
     };
@@ -319,6 +340,7 @@ async fn send_tokens(to: Principal, amount: Nat) -> Result<Nat, String> {
 // ICRC-2: Approve a spender
 #[update]
 async fn approve_spender(spender: Principal, amount: Nat) -> Result<Nat, String> {
+    let fee = Nat::from(ICP_FEE);
     let args = ApproveArgs {
         from_subaccount: None,
         spender: Account {
@@ -328,7 +350,7 @@ async fn approve_spender(spender: Principal, amount: Nat) -> Result<Nat, String>
         amount,
         expected_allowance: None,
         expires_at: None,
-        fee: Some(Nat::from(ICP_FEE)),
+        fee: Some(fee),
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),
     };
@@ -347,6 +369,7 @@ async fn approve_spender(spender: Principal, amount: Nat) -> Result<Nat, String>
 // WARNING: Add access control in production — this allows any caller to transfer tokens
 #[update]
 async fn transfer_from(from: Principal, to: Principal, amount: Nat) -> Result<Nat, String> {
+    let fee = Nat::from(ICP_FEE);
     let args = TransferFromArgs {
         spender_subaccount: None,
         from: Account {
@@ -358,7 +381,7 @@ async fn transfer_from(from: Principal, to: Principal, amount: Nat) -> Result<Na
             subaccount: None,
         },
         amount,
-        fee: Some(Nat::from(ICP_FEE)),
+        fee: Some(fee),
         memo: None,
         created_at_time: Some(ic_cdk::api::time()),
     };
@@ -374,41 +397,45 @@ async fn transfer_from(from: Principal, to: Principal, amount: Nat) -> Result<Na
 }
 ```
 
-## Deploy & Test
-
-### Deploy a Local ICRC-1 Ledger for Testing
+## Deploy
 
 Add to `icp.yaml`:
 
-Pin the release version before deploying: get the latest release tag from https://github.com/dfinity/ic/releases?q=%22ledger-suite-icrc%22&expanded=false, then substitute it for `<RELEASE_TAG>` in both URLs below.
+Pin the release version before deploying: get the latest release tag from https://github.com/dfinity/ic/releases?q=%22ledger-suite-icrc%22&expanded=false, then substitute it for `<RELEASE_TAG>` in the URL below.
 
 ```yaml
 canisters:
-  icrc1_ledger:
-    name: icrc1_ledger
-    recipe:
-      type: custom
-      candid: "https://github.com/dfinity/ic/releases/download/<RELEASE_TAG>/ledger.did"
-      wasm: "https://github.com/dfinity/ic/releases/download/<RELEASE_TAG>/ic-icrc1-ledger.wasm.gz"
-    config:
-      init_arg_file: "icrc1_ledger_init.args"
+  - name: icrc1_ledger
+    build:
+      steps:
+        - type: pre-built
+          url: https://github.com/dfinity/ic/releases/download/<RELEASE_TAG>/ic-icrc1-ledger.wasm.gz
+    init_args:
+      path: icrc1_ledger_init.args
+      format: candid
 ```
 
-Create `icrc1_ledger_init.args` (replace `YOUR_PRINCIPAL` with the output of `icp identity principal`):
+Create `icrc1_ledger_init.args`, replacing `YOUR_PRINCIPAL` with the output of `icp identity principal`.
 
-> **Pitfall:** Shell substitutions like `$(icp identity principal)` will NOT expand inside this file. You must paste the literal principal string.
+The `minting_account` **must** be a different principal than any principal in `initial_balances` (see pitfall #9). `initial_balances` accepts multiple entries to fund several accounts at genesis.
+
+> **Pitfall:** Shell substitutions like `$(icp identity principal)` will NOT expand inside this file. You must paste the literal principal strings.
 
 ```
 (variant { Init = record {
   token_symbol = "TEST";
   token_name = "Test Token";
-  minting_account = record { owner = principal "YOUR_PRINCIPAL" };
+  minting_account = record { owner = principal "MINTER_PRINCIPAL" };
   transfer_fee = 10_000 : nat;
   metadata = vec {};
   initial_balances = vec {
     record {
-      record { owner = principal "YOUR_PRINCIPAL" };
+      record { owner = principal "PRINCIPAL_A" };
       100_000_000_000 : nat;
+    };
+    record {
+      record { owner = principal "PRINCIPAL_B" };
+      50_000_000_000 : nat;
     };
   };
   archive_options = record {
@@ -423,96 +450,6 @@ Create `icrc1_ledger_init.args` (replace `YOUR_PRINCIPAL` with the output of `ic
 Deploy:
 
 ```bash
-# Start local replica
 icp network start -d
-
-# Deploy the ledger
 icp deploy icrc1_ledger
-
-# Verify it deployed
-icp canister id icrc1_ledger
-```
-
-### Interact with Mainnet Ledgers
-
-```bash
-# Check ICP balance
-icp canister call ryjl3-tyaaa-aaaaa-aaaba-cai icrc1_balance_of \
-  "(record { owner = principal \"$(icp identity principal)\"; subaccount = null })" \
-  -e ic
-
-# Check token metadata
-icp canister call ryjl3-tyaaa-aaaaa-aaaba-cai icrc1_metadata '()' -e ic
-
-# Check fee
-icp canister call ryjl3-tyaaa-aaaaa-aaaba-cai icrc1_fee '()' -e ic
-
-# Transfer ICP (amount in e8s: 100000000 = 1 ICP)
-icp canister call ryjl3-tyaaa-aaaaa-aaaba-cai icrc1_transfer \
-  "(record {
-    to = record { owner = principal \"TARGET_PRINCIPAL_HERE\"; subaccount = null };
-    amount = 100_000_000 : nat;
-    fee = opt (10_000 : nat);
-    memo = null;
-    from_subaccount = null;
-    created_at_time = null;
-  })" -e ic
-```
-
-## Verify It Works
-
-### Local Ledger Verification
-
-```bash
-# 1. Check your balance (should show initial minted amount)
-icp canister call icrc1_ledger icrc1_balance_of \
-  "(record { owner = principal \"$(icp identity principal)\"; subaccount = null })"
-# Expected: (100_000_000_000 : nat)
-
-# 2. Check fee
-icp canister call icrc1_ledger icrc1_fee '()'
-# Expected: (10_000 : nat)
-
-# 3. Check decimals
-icp canister call icrc1_ledger icrc1_decimals '()'
-# Expected: (8 : nat8)
-
-# 4. Check symbol
-icp canister call icrc1_ledger icrc1_symbol '()'
-# Expected: ("TEST")
-
-# 5. Transfer to another identity
-icp identity new test-recipient --storage plaintext 2>/dev/null
-RECIPIENT=$(icp identity principal --identity test-recipient)
-icp canister call icrc1_ledger icrc1_transfer \
-  "(record {
-    to = record { owner = principal \"$RECIPIENT\"; subaccount = null };
-    amount = 1_000_000 : nat;
-    fee = opt (10_000 : nat);
-    memo = null;
-    from_subaccount = null;
-    created_at_time = null;
-  })"
-# Expected: (variant { Ok = 0 : nat })
-
-# 6. Verify recipient balance
-icp canister call icrc1_ledger icrc1_balance_of \
-  "(record { owner = principal \"$RECIPIENT\"; subaccount = null })"
-# Expected: (1_000_000 : nat)
-```
-
-### Mainnet Verification
-
-```bash
-# Verify ICP ledger is reachable
-icp canister call ryjl3-tyaaa-aaaaa-aaaba-cai icrc1_symbol '()' -e ic
-# Expected: ("ICP")
-
-# Verify ckBTC ledger is reachable
-icp canister call mxzaz-hqaaa-aaaar-qaada-cai icrc1_symbol '()' -e ic
-# Expected: ("ckBTC")
-
-# Verify ckETH ledger is reachable
-icp canister call ss2fx-dyaaa-aaaar-qacoq-cai icrc1_symbol '()' -e ic
-# Expected: ("ckETH")
 ```


### PR DESCRIPTION
## Summary

Closes #106

- **Fix broken deploy config**: Replace invalid `type: custom` recipe with `build.steps` + `type: pre-built` and `init_args: { path, format }` syntax (verified with actual deployment)
- **Fix minting account pitfalls**: Separate minting/funded principals in init args, document `icrc2_approve` trap (`#9`) and burn/mint zero-fee semantics (`#10`)
- **Rewrite fee guidance**: Per-ledger fees, `icrc1_fee` lookup, `BadFee` handling (pitfall `#1`)
- **Add evaluations**: 4 output evals (Motoko transfer, Rust ICRC-2, burn fee semantics, deploy config) + 16 trigger evals — all verified with eval runs showing clear skill uplift
- **Clean up**: Remove low-value verification sections, rename to "Common Pitfalls", bump core to 2.3.1, add `icrc1_metadata`/`icrc1_supported_standards` to actor interface, show multiple `initial_balances` entries

### Eval results

| Eval | With skill | Without | Delta |
|---|---|---|---|
| ICRC-1 transfer in Motoko | 5/5 | 2/5 | **+3** |
| ICRC-2 approve+transferFrom in Rust | 5/5 | 3/5 | **+2** |
| Burn fee semantics | 3/3 | 3/3 | 0 |
| Deploy an ICRC-1 ledger | 5/5 | 3/5 | **+2** |
| Triggers | 16/16 | — | perfect |

### Not in scope

The frontend ICRC-2 approval flow (inline IDL factories, calling ledgers from JavaScript) is deferred — it's a generic canister interaction pattern that belongs in a future `canister-calls` skill. The token custody pattern (approve flow vs subaccount deposits) was evaluated but dropped since agents already know it without the skill (3/3 baseline).