### PR TITLE
feat: add Matomo analytics (site ID 22)

### DIFF
--- a/public/.ic-assets.json5
+++ b/public/.ic-assets.json5
@@ -38,6 +38,13 @@
     }
   },
   {
+    // Matomo analytics
+    "match": "matomo.js",
+    "headers": {
+      "Cache-Control": "public, max-age=300"
+    }
+  },
+  {
     // Agent-readable skill indices
     "match": "llms*.txt",
     "headers": {

--- a/public/matomo.js
+++ b/public/matomo.js
@@ -1,0 +1,16 @@
+var _paq = (window._paq = window._paq || []);
+_paq.push(["disableCookies"]);
+_paq.push(["enableLinkTracking"]);
+_paq.push(["trackPageView"]);
+
+(function () {
+  var u = "https://internetcomputer.matomo.cloud/";
+  _paq.push(["setTrackerUrl", u + "matomo.php"]);
+  _paq.push(["setSiteId", "22"]);
+  var d = document,
+    g = d.createElement("script"),
+    s = d.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = "https://cdn.matomo.cloud/internetcomputer.matomo.cloud/matomo.js";
+  s.parentNode.insertBefore(g, s);
+})();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -84,6 +84,8 @@ const defaultJsonLd = JSON.stringify({
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+
+  <script is:inline src="/matomo.js" async></script>
 </head>
 <body>
   <script is:inline>


### PR DESCRIPTION
## Summary
- Add cookie-free Matomo analytics tracking (site ID 22) via `internetcomputer.matomo.cloud`
- Loaded async on every page via `BaseLayout.astro`
- Asset canister config for `matomo.js` with 5-minute cache