### PR TITLE
fix(internet-identity): add frontend canister split

### DIFF
--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -22,11 +22,12 @@ Internet Identity (II) is the Internet Computer's native authentication system. 
 
 | Canister | ID | URL | Purpose |
 |----------|------------|-----|---------|
-| Internet Identity | `rdmx6-jaaaa-aaaaa-aaadq-cai` | `https://id.ai` | Stores and manages user keys, serves the II web app over HTTPS |
+| Internet Identity (backend) | `rdmx6-jaaaa-aaaaa-aaadq-cai` | `https://backend.id.ai` | Manages user keys and authentication logic |
+| Internet Identity (frontend) | `uqzsh-gqaaa-aaaaq-qaada-cai` | `https://id.ai` | Serves the II web app; identity provider URL points here |
 
 ## Mistakes That Break Your Build
 
-1. **Using the wrong II URL for the environment.** Local development must point to `http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:8000`. Mainnet must use `https://id.ai`. Internet Identity has a well-known canister ID (`rdmx6-jaaaa-aaaaa-aaadq-cai`) that is the same on mainnet and local replicas -- hardcode it rather than doing a dynamic lookup.
+1. **Using the wrong II URL for the environment.** The identity provider URL must point to the **frontend** canister (`uqzsh-gqaaa-aaaaq-qaada-cai`), not the backend. Local development must use `http://uqzsh-gqaaa-aaaaq-qaada-cai.localhost:8000`. Mainnet must use `https://id.ai` (which resolves to the frontend canister). Both canister IDs are well-known and identical on mainnet and local replicas -- hardcode them rather than doing a dynamic lookup.
 
 2. **Setting delegation expiry too long.** Maximum delegation expiry is 30 days (2_592_000_000_000_000 nanoseconds). Longer values are silently clamped, which causes confusing session behavior. Use 8 hours for normal apps, 30 days maximum for "remember me" flows.
 
@@ -70,13 +71,14 @@ let authClient;
 const canisterEnv = safeGetCanisterEnv();
 
 // Determine II URL based on environment.
-// Internet Identity has a well-known canister ID (rdmx6-jaaaa-aaaaa-aaadq-cai) that is
-// the same on mainnet and local replicas (icp-cli pulls the mainnet II wasm).
+// The identity provider URL points to the frontend canister (uqzsh-gqaaa-aaaaq-qaada-cai),
+// not the backend (rdmx6-jaaaa-aaaaa-aaadq-cai). Both are well-known IDs, identical on
+// mainnet and local replicas.
 function getIdentityProviderUrl() {
   const host = window.location.hostname;
   const isLocal = host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost");
   if (isLocal) {
-    return "http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:8000";
+    return "http://uqzsh-gqaaa-aaaaq-qaada-cai.localhost:8000";
   }
   return "https://id.ai";
 }


### PR DESCRIPTION
## Summary
- Internet Identity now has a separate frontend canister (`uqzsh-gqaaa-aaaaq-qaada-cai`) alongside the backend (`rdmx6-jaaaa-aaaaa-aaadq-cai`)
- Updated canister IDs table, identity provider URLs, pitfall guidance, and code example to reflect the split
- `id.ai` resolves to the new frontend canister; `backend.id.ai` resolves to the backend

## Test plan
- [x] Verified both canister IDs exist on mainnet (same controller and subnet)
- [x] Confirmed `id.ai` returns `x-ic-canister-id: uqzsh-gqaaa-aaaaq-qaada-cai` and `backend.id.ai` returns `x-ic-canister-id: rdmx6-jaaaa-aaaaa-aaadq-cai`
- [x] Verified `@icp-sdk/auth@5.0.0` and `@icp-sdk/core@5.2.0` install and all import paths + API methods from the code example resolve correctly
- [x] `skill-validator validate` passes with no errors
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)