### PR TITLE
Restore skill reuse instruction in llms.txt

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -12,7 +12,8 @@ export const GET: APIRoute = () => {
 1. Fetch the skills index and remember each skill's name, description, and url:
    ${SITE_URL}/.well-known/skills/index.json
 
-2. When a task matches a skill's description, fetch the skill content from its url.
+2. When a task matches a skill's description, use it if already loaded in your
+   context. Otherwise, fetch the skill content from its url.
    Do not construct skill URLs manually.
 
    Example: for the skill named "internet-identity", its url is:


### PR DESCRIPTION
## Summary

The previous PR (#138) accidentally dropped the "use it if already loaded in your context" instruction from `llms.txt`. This tells agents to skip re-fetching skills they already have, avoiding unnecessary network calls.

Also updated the recommended instructions in #137, dfinity/icp-cli#478, and dfinity/icp-cli-templates#24 to include this clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)