### PR TITLE
feat: serve /.well-known/webmcp.json — WebMCP manifest endpoint

### DIFF
--- a/src/pages/.well-known/webmcp.json.ts
+++ b/src/pages/.well-known/webmcp.json.ts
@@ -1,0 +1,96 @@
+// Generates /.well-known/webmcp.json at build time.
+// Implements the WebMCP manifest format consumed by @dfinity/webmcp and
+// Chrome 146+ navigator.modelContext to expose IC canister tools to AI agents.
+//
+// Set SKILLS_CANISTER_ID at build time to embed the deployed canister principal.
+// Without it the manifest is generated with a placeholder and must be rebuilt
+// after the skills canister is deployed.
+//
+// Example:
+//   SKILLS_CANISTER_ID=abcde-efghi-... npm run build
+import type { APIRoute } from "astro";
+
+const CANISTER_ID: string =
+  (import.meta.env.SKILLS_CANISTER_ID as string | undefined) ?? "";
+
+const DESCRIPTION =
+  "Query Internet Computer skill documentation. Covers Motoko, Rust canisters, " +
+  "ckBTC, Internet Identity, stable memory, HTTPS outcalls, EVM RPC, SNS, " +
+  "asset canisters, WebMCP, custom domains, and more.";
+
+const manifest = {
+  schema_version: "1.0",
+  canister: {
+    ...(CANISTER_ID ? { id: CANISTER_ID } : {}),
+    name: "IC Skills",
+    description: DESCRIPTION,
+  },
+  tools: [
+    {
+      name: "list_skills",
+      description:
+        "List all available Internet Computer skill topics with their names, " +
+        "titles, descriptions, and categories.",
+      canister_method: "list_skills",
+      method_type: "query",
+      certified: true,
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "get_skill",
+      description:
+        "Get the full documentation for a specific IC skill by name " +
+        "(e.g. 'motoko', 'asset-canister', 'internet-identity'). " +
+        "Returns the complete SKILL.md content plus metadata.",
+      canister_method: "get_skill",
+      method_type: "query",
+      certified: true,
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description:
+              "Skill name in lowercase-hyphenated format, " +
+              "e.g. 'motoko', 'ckbtc', 'https-outcalls', 'webmcp'",
+          },
+        },
+        required: ["name"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "search_skills",
+      description:
+        "Search Internet Computer skill documentation by keyword. " +
+        "Matches against skill names, titles, descriptions, and full content. " +
+        "Returns summaries of matching skills.",
+      canister_method: "search_skills",
+      method_type: "query",
+      certified: true,
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Keyword to match against skill names, titles, descriptions, " +
+              "and full content",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  ],
+};
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(manifest, null, 2), {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
## Summary

Adds a statically-generated `/.well-known/webmcp.json` endpoint that exposes the three skills canister query methods as callable AI agent tools.

**Manifest exposes three tools** (WebMCP 1.0 schema):
- `list_skills` — `list_skills()` — All skill topics with metadata
- `get_skill` — `get_skill(name)` — Full SKILL.md + frontmatter for one skill
- `search_skills` — `search_skills(query)` — Keyword search across all skills

All three are `query` methods with `"certified": true`.

**Canister ID injection** — set `SKILLS_CANISTER_ID` at build time:

```
SKILLS_CANISTER_ID=abcde-efghi-... npm run build
```

When unset the manifest omits `canister.id`. This is intentional: PR #148 (skills canister) must be deployed first to obtain the real principal, then the site is rebuilt with it set.

**CORS headers** are already handled by the existing `.ic-assets.json5` rule for `.well-known/**/*.json` (Access-Control-Allow-Origin: \*, max-age=300).

**Consumers of this manifest:**
- Chrome 146+ `navigator.modelContext` (native WebMCP)
- `@dfinity/webmcp` polyfill (follow-up PR 3 — adds polyfill to site)
- `ic-webmcp-codegen dfx` (the `webmcp` section in `dfx.json` from PR #148 maps directly to this manifest)

## Test plan

- [ ] `npm run build` succeeds (verified locally)
- [ ] `dist/.well-known/webmcp.json` exists and contains all three tools
- [ ] `SKILLS_CANISTER_ID=ryjl3-tyaaa-aaaaa-aaaba-cai npm run build` — `canister.id` appears in manifest
- [ ] Without env var — `canister.id` is omitted (not `null`, not `""`), no build error

This extends PR [148](https://github.com/dfinity/icskills/pull/148), and that should be merged first.
This optionally can (and probably should) be followed by PR [150](https://github.com/dfinity/icskills/pull/150) as well.