### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -10,11 +10,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -89,7 +89,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request' && steps.changed.outputs.found == 'true' && always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: skill-validator
           message: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: Post PR comment (no skills changed)
         if: github.event_name == 'pull_request' && steps.changed.outputs.found == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: skill-validator
           recreate: true

--- a/.github/workflows/deploy-ic.yml
+++ b/.github/workflows/deploy-ic.yml
@@ -27,11 +27,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `marocchino/sticky-pull-request-comment@v2` -> `marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2`
  - Version: v2 | Latest: v3.0.3 | Release age: 27d
  - Commit: https://github.com/marocchino/sticky-pull-request-comment/commit/773744901bac0e8cbb5a0dc842800d45e9b2b405
  - Warnings: Latest release v3.0.3 is only 5 day(s) old (< 7 days). Using previous safe release.


### Files modified

- `.github/workflows/_checks.yml`
- `.github/workflows/deploy-ic.yml`

### Security warnings

- Latest release v3.0.3 is only 5 day(s) old (< 7 days). Using previous safe release.