### PR TITLE
fix(browse): correct z-index so skill card cover link receives clicks

### DIFF
--- a/src/components/BrowseTab.tsx
+++ b/src/components/BrowseTab.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useMemo } from "preact/hooks";
 import type { Skill } from "../data/skills";
 import { SANS_FONT } from "../data/constants";
 import { CategoryIcon } from "./Icons";
-import CopyButton from "./CopyButton";
 
 interface Props {
   skills: Skill[];
@@ -136,10 +135,10 @@ export default function BrowseTab({ skills }: Props) {
               <a
                 href={`/skills/${skill.name}/`}
                 aria-label={skill.title}
-                style={{ position: "absolute", inset: 0, zIndex: 0, borderRadius: "5px" }}
+                style={{ position: "absolute", inset: 0, zIndex: 1, borderRadius: "5px" }}
               />
-              {/* Content sits above the cover link */}
-              <div style={{ position: "relative", zIndex: 1 }}>
+              {/* Content — buttons must sit above the cover link */}
+              <div style={{ position: "relative" }}>
                 <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "12px" }}>
                   <span style={{
                     fontSize: "18px", width: "36px", height: "36px",
@@ -172,6 +171,7 @@ export default function BrowseTab({ skills }: Props) {
                       color: "var(--text-faint)", flexShrink: 0,
                       background: "var(--bg-card-subtle)",
                       border: "1px solid var(--border-subtle)",
+                      position: "relative", zIndex: 2,
                     }}>
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                       <path d="M8 2v8M4.5 7.5 8 11l3.5-3.5M2.5 13.5h11" />
@@ -187,6 +187,7 @@ export default function BrowseTab({ skills }: Props) {
                       color: "var(--text-faint)", flexShrink: 0,
                       background: "var(--bg-card-subtle)",
                       border: "1px solid var(--border-subtle)",
+                      position: "relative", zIndex: 2,
                     }}>
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
                   </a>


### PR DESCRIPTION
## Problem

Skill cards on `/skills/` were not navigating to the skill detail page when clicked. The cover link pattern introduced in #166 had incorrect z-index values:

- Cover `<a href>`: `zIndex: 0`
- Content wrapper `<div>`: `zIndex: 1`

Since the content div sat on top of the cover link, all pointer events were captured by the content div and the navigation anchor was never reached.

> Note: the cover link was still present in the pre-rendered HTML (so Google could crawl it), but human clicks didn't work.

## Fix

| Element | Before | After |
|---|---|---|
| Cover `<a>` | `zIndex: 0` | `zIndex: 1` |
| Content wrapper `<div>` | `position: relative; zIndex: 1` | `position: relative` (no z-index) |
| Download `<a>` button | — | `position: relative; zIndex: 2` |
| GitHub `<a>` button | — | `position: relative; zIndex: 2` |

The two action buttons are lifted to `zIndex: 2` so they remain independently clickable above the cover link.

Also removes an unused `CopyButton` import.