### PR TITLE
improve: update skill categories and titles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,7 +78,7 @@ Results are saved to `evaluations/results/` (gitignored). See `evaluations/icp-c
 
 ## Categories
 
-Known categories: DeFi, Tokens, Auth, Architecture, Integration, Governance, Frontend, Security, Infrastructure, Wallet. New categories are allowed — the validator warns but does not block.
+Known categories: Auth, Core, DeFi, Frontend, Governance, Infrastructure, Integration, Security. New categories are allowed — the validator warns but does not block.
 
 ## Tech Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,6 @@ The website auto-generates from SKILL.md frontmatter — no need to edit any sou
 
 Use an existing category when possible. The validator warns on unknown categories to catch typos, but new categories are not blocked.
 
-Current categories: **DeFi**, **Tokens**, **Auth**, **Architecture**, **Integration**, **Governance**, **Frontend**, **Security**, **Infrastructure**, **Wallet**
+Current categories: **Auth**, **Core**, **DeFi**, **Frontend**, **Governance**, **Infrastructure**, **Integration**, **Security**
 
 To add a new category: update the enum in `skills/skill.schema.json` and the icon in `src/components/Icons.tsx`.

--- a/scripts/check-project.js
+++ b/scripts/check-project.js
@@ -9,16 +9,14 @@ import { join } from "path";
 import { listSkillDirs, readSkill, SKILLS_DIR } from "./lib/parse-skill.js";
 
 const KNOWN_CATEGORIES = [
-  "DeFi",
-  "Tokens",
   "Auth",
-  "Architecture",
-  "Integration",
-  "Governance",
+  "Core",
+  "DeFi",
   "Frontend",
-  "Security",
+  "Governance",
   "Infrastructure",
-  "Wallet",
+  "Integration",
+  "Security",
 ];
 
 const evalsDir = join(SKILLS_DIR, "..", "evaluations");

--- a/skills/asset-canister/SKILL.md
+++ b/skills/asset-canister/SKILL.md
@@ -4,11 +4,11 @@ description: "Deploy frontend assets to the IC. Covers certified assets, SPA rou
 license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2, Node.js >= 22"
 metadata:
-  title: "Asset Canister & Frontend"
+  title: Asset Canister
   category: Frontend
 ---
 
-# Asset Canister & Frontend Hosting
+# Asset Canister
 
 ## What This Is
 

--- a/skills/ckbtc/SKILL.md
+++ b/skills/ckbtc/SKILL.md
@@ -4,7 +4,7 @@ description: "Accept, send, and manage ckBTC (chain-key Bitcoin). Covers BTC dep
 license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2"
 metadata:
-  title: ckBTC Integration
+  title: ckBTC (chain-key Bitcoin)
   category: DeFi
 ---
 

--- a/skills/evm-rpc/SKILL.md
+++ b/skills/evm-rpc/SKILL.md
@@ -4,7 +4,7 @@ description: "Call Ethereum and EVM chains from IC canisters (Rust) via the EVM 
 license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2"
 metadata:
-  title: EVM RPC Integration
+  title: EVM RPC
   category: Integration
 ---
 

--- a/skills/icrc-ledger/SKILL.md
+++ b/skills/icrc-ledger/SKILL.md
@@ -4,8 +4,8 @@ description: "Deploy and interact with ICRC-1/ICRC-2 token ledgers (ICP, ckBTC, 
 license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2"
 metadata:
-  title: ICRC Ledger Standard
-  category: Tokens
+  title: ICRC Token Ledgers
+  category: DeFi
 ---
 
 # ICRC Ledger Standards

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -4,7 +4,7 @@ description: "Integrate Internet Identity authentication. Covers passkey and Ope
 license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2, Node.js >= 22"
 metadata:
-  title: Internet Identity Auth
+  title: Internet Identity
   category: Auth
 ---
 

--- a/skills/motoko/SKILL.md
+++ b/skills/motoko/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: "moc >= 1.0.0, mops with core >= 2.0.0"
 metadata:
   title: Motoko Language
-  category: Architecture
+  category: Core
 ---
 
 # Motoko Language

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2"
 metadata:
   title: Multi-Canister Architecture
-  category: Architecture
+  category: Core
 ---
 
 # Multi-Canister Architecture

--- a/skills/skill.schema.json
+++ b/skills/skill.schema.json
@@ -36,7 +36,7 @@
         "category": {
           "type": "string",
           "minLength": 1,
-          "description": "Skill category for browsing/filtering. Use an existing category when possible: DeFi, Tokens, Auth, Architecture, Integration, Governance, Frontend, Security, Infrastructure, Wallet."
+          "description": "Skill category for browsing/filtering. Use an existing category when possible: Auth, Core, DeFi, Frontend, Governance, Infrastructure, Integration, Security."
         }
       },
       "additionalProperties": false

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: "icp-cli >= 0.2.2"
 metadata:
   title: "Stable Memory & Upgrades"
-  category: Architecture
+  category: Core
 ---
 
 # Stable Memory & Canister Upgrades

--- a/skills/wallet-integration/SKILL.md
+++ b/skills/wallet-integration/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: "Node.js >= 22"
 metadata:
   title: Wallet Integration
-  category: Wallet
+  category: DeFi
 ---
 
 # Wallet Integration

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -7,7 +7,7 @@ export function CategoryIcon({ category, size = 18 }: { category: string; size?:
     "stroke-linecap": "round" as const, "stroke-linejoin": "round" as const,
   };
   switch (category) {
-    case "Architecture":
+    case "Core":
       return (<svg {...common}><path d="M9 2L2 6l7 4 7-4z" /><path d="M2 9l7 4 7-4" /><path d="M2 12l7 4 7-4" /></svg>);
     case "Auth":
       return (<svg {...common}><path d="M6 8V5.5a3 3 0 016 0V8" /><path d="M4 8h10a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1V9a1 1 0 011-1z" /></svg>);
@@ -23,10 +23,6 @@ export function CategoryIcon({ category, size = 18 }: { category: string; size?:
       return (<svg {...common}><path d="M7 11L5 13a2.8 2.8 0 01-4-4l2-2" /><path d="M11 7l2-2a2.8 2.8 0 014 4l-2 2" /><path d="M7 11l4-4" /></svg>);
     case "Security":
       return (<svg {...common}><path d="M9 1.5L3 4.5v4c0 4 2.5 7 6 8.5 3.5-1.5 6-4.5 6-8.5v-4z" /></svg>);
-    case "Tokens":
-      return (<svg {...common}><path d="M9 2a7 7 0 100 14A7 7 0 009 2z" /><path d="M9 5v8" /><path d="M7 7.5h4" /><path d="M7 10.5h4" /></svg>);
-    case "Wallet":
-      return (<svg {...common}><path d="M3 5a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" /><path d="M13 9h2v3h-2a1.5 1.5 0 010-3z" /></svg>);
     default:
       return null;
   }


### PR DESCRIPTION
## Changes

### Category restructure
- **Architecture → Core** — better reflects the mix of language (Motoko), pattern (Multi-Canister), and runtime concern (Stable Memory)
- **Tokens + Wallet → DeFi** — removes two single-skill categories; DeFi now groups all financial primitives: ckBTC, ICRC Token Ledgers, Wallet Integration

### Title updates
| Skill | Before | After |
|---|---|---|
| ckbtc | ckBTC Integration | ckBTC (chain-key Bitcoin) |
| icrc-ledger | ICRC Ledger Standard | ICRC Token Ledgers |
| evm-rpc | EVM RPC Integration | EVM RPC |
| internet-identity | Internet Identity Auth | Internet Identity |
| asset-canister | Asset Canister & Frontend | Asset Canister |

### Supporting changes
- `Icons.tsx`: renamed `"Architecture"` case to `"Core"`, removed `"Tokens"` and `"Wallet"` cases (DeFi icon covers those skills now)
- `scripts/check-project.js`: updated `KNOWN_CATEGORIES`
- `skills/skill.schema.json`: updated category description
- `CLAUDE.md` + `CONTRIBUTING.md`: updated known categories lists
- `skills/asset-canister/SKILL.md`: updated H1 body heading to match new title

### Resulting categories
Auth · Core · DeFi · Frontend · Governance · Infrastructure · Integration · Security