### PR TITLE
fix: use asset-canister-404-support for proper 404 handling

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -3,6 +3,7 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister@v2.1.0"
       configuration:
+        version: asset-canister-404-support
         dir: dist
         build:
           - npm install


### PR DESCRIPTION
## Summary

- Updates `icp.yaml` to use `version: asset-canister-404-support` for the asset canister recipe
- Enables the asset canister to serve the existing `src/pages/404.astro` page for unmatched routes
- Mirrors the same change made in dfinity/icp-cli#516