### PR TITLE
Add MKTd03 CVDR skill

### DIFF
--- a/evaluations/mktd03-cvdr.json
+++ b/evaluations/mktd03-cvdr.json
@@ -1,0 +1,77 @@
+{
+  "skill": "mktd03-cvdr",
+  "description": "Evaluation cases for the mktd03-cvdr skill. Tests whether agents integrate MKTd03 as a bounded ICP Rust canister CVDR protocol, avoid invented APIs, avoid PII preimages, distinguish local replica evidence from mainnet proof, and avoid overclaiming GDPR compliance.",
+
+  "output_evals": [
+    {
+      "name": "Bounded host adapter signature",
+      "prompt": "Show only a Rust function signature for a host adapter that issues an MKTd03 CVDR for a tombstoned profile. No imports, no struct definitions, no comments, no implementation body.",
+      "expected_behaviors": [
+        "Uses bounded protocol inputs such as subject_reference, scope_reference, transition_material, and deletion_state_material",
+        "Does NOT pass raw profile records, display names, bios, emails, or owner principals into the MKTd03 layer",
+        "Does NOT invent a receipt_id parameter",
+        "Keeps application-specific semantics in the host adapter rather than the MKTd03 library"
+      ]
+    },
+    {
+      "name": "Local replica warning",
+      "prompt": "Write exactly one UI warning sentence for an MKTd03 CVDR generated on local dfx. No explanation.",
+      "expected_behaviors": [
+        "States that local replica evidence is demo or development evidence only",
+        "Does NOT describe local certificate material as production cryptographic evidence",
+        "Distinguishes local dfx from IC mainnet or subnet certification"
+      ]
+    },
+    {
+      "name": "PII preimage boundary",
+      "prompt": "List only four kinds of material that are safe candidates for a bounded TinyPress-style MKTd03 CVDR input. No prose.",
+      "expected_behaviors": [
+        "Includes bounded protocol or control inputs such as profile_id, scope reference, tombstoned_at, or fixed tombstone marker",
+        "Does NOT include display_name",
+        "Does NOT include bio",
+        "Does NOT include email, owner principal, posts, comments, or raw frontend payloads"
+      ]
+    },
+    {
+      "name": "No GDPR overclaim",
+      "prompt": "In two sentences, explain whether issuing an MKTd03 CVDR makes an ICP application GDPR compliant.",
+      "expected_behaviors": [
+        "Says that a CVDR can support deletion evidence or audit workflows",
+        "Does NOT claim that issuing a CVDR alone makes an application GDPR compliant",
+        "Mentions that compliance depends on the broader system, data model, retention policy, and operational practice"
+      ]
+    },
+    {
+      "name": "No invented lookup API",
+      "prompt": "A developer says they will store an MKTd03 receipt_id and later call get_receipt_by_receipt_id. Give a brief correction.",
+      "expected_behaviors": [
+        "Warns not to invent MKTd03 APIs",
+        "Says to inspect and use the actual pinned MKTd03 host API",
+        "Mentions that lookup or phase flow may use subject_reference or pending issuance identifiers depending on the pinned API",
+        "Does NOT endorse get_receipt_by_receipt_id as if it exists"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "Add cryptographically verifiable deletion receipts to my ICP Rust canister",
+      "Generate a CVDR for a tombstoned user record on ICP",
+      "Integrate MKTd03 into my Internet Computer canister",
+      "How do I produce deletion receipt audit evidence from a sparse Merkle tombstone proof?",
+      "Add verifiable erasure evidence to my ICP app",
+      "Build an MKTd03 adapter for a Rust canister"
+    ],
+    "should_not_trigger": [
+      "Add Internet Identity login to my Vite frontend",
+      "Use StableBTreeMap to persist canister state across upgrades",
+      "Deploy my canister to mainnet",
+      "Create an ICRC-1 token ledger",
+      "Connect a wallet to my ICP dapp",
+      "Set up a custom domain for my asset canister",
+      "Explain how the Internet Computer works",
+      "Write a generic Rust delete_profile function without deletion receipts"
+    ]
+  }
+}

--- a/skills/mktd03-cvdr/SKILL.md
+++ b/skills/mktd03-cvdr/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mktd03-cvdr
+description: "Integrates MKTd03 on the Internet Computer to issue Cryptographically Verifiable Deletion Receipts (CVDRs) from Rust canisters using sparse Merkle tree tombstone evidence. Use for verifiable deletion, CVDRs, tombstone proofs, deletion receipts, audit evidence, erasure evidence, or GDPR-supporting deletion workflows on ICP. Do NOT use for ordinary deletion without receipts, MKTd02 leaf-mode receipts, generic stable memory, Internet Identity, wallet integration, or general canister security hardening."
+license: Apache-2.0
+compatibility: "Rust canister on ICP, dfx or icp-cli available, network access for mainnet deployment and certification verification"
+metadata:
+  title: "MKTd03 CVDR"
+  category: Integration
+---
+
+# MKTd03 CVDR
+
+MKTd03 is a Rust protocol/library for issuing Cryptographically Verifiable Deletion Receipts from Internet Computer canisters. It uses sparse Merkle tree evidence to prove a bounded tombstone transition for a target record relative to pre-state and post-state commitments.
+
+Use this skill when an ICP Rust canister needs verifiable deletion receipts, tombstone evidence, CVDR generation, audit evidence, or GDPR-supporting erasure records.
+
+Do not use this skill for ordinary deletion without receipt generation, generic StableBTreeMap setup, Internet Identity login, wallet integration, or general canister hardening.
+
+## Prerequisites
+
+- Rust ICP canister.
+- dfx or icp-cli available.
+- MKTd03 integrated as a Rust crate dependency.
+- Host canister owns application state and passes bounded protocol inputs to MKTd03.
+- Library and SDK versions must be pinned from the integrating repository before generating final code.
+
+## Integration Boundary
+
+Use MKTd03 as an embedded protocol engine. The host canister decides what application event occurred and supplies bounded protocol inputs.
+
+The host adapter derives subject_reference, scope_reference, transition_material, and deletion_state_material.
+
+Keep raw PII and high-level application semantics outside the MKTd03 preimage unless a later design explicitly authorizes them.
+
+## Local vs Mainnet Evidence
+
+A CVDR generated against local dfx is demo/development evidence only. Local replica certificate material is not production cryptographic evidence and must not be presented as mainnet-grade proof.
+
+For local demos, display: DEMO — local replica evidence only; this CVDR is not cryptographically authenticated by an IC mainnet subnet.
+
+## Common Pitfalls
+
+- Do not invent a receipt_id API. Use the actual MKTd03 host API from the pinned crate version.
+- Do not put raw PII into CVDR preimages.
+- Do not treat local dfx certificate material as production proof.
+- Do not claim GDPR compliance solely from a CVDR.
+- Do not conflate tombstoning with physical erasure.
+- Do not make MKTd03 dApp-specific.
+- Do not expose full receipt payloads publicly by default.
+- Do not skip version pinning.
+
+## Verify It Works
+
+- The host canister builds for wasm32-unknown-unknown.
+- The adapter accepts bounded CVDR inputs, not raw user profile data.
+- The generated receipt path uses the actual pinned MKTd03 API.
+- Local demo receipts are labelled as local/demo evidence.
+- The implementation does not claim GDPR compliance solely from issuing a CVDR.


### PR DESCRIPTION
Adds an agent-readable skill for integrating MKTd03 into ICP Rust canisters to issue Cryptographically Verifiable Deletion Receipts (CVDRs) for tombstoned records using sparse Merkle tree evidence.

The skill focuses on safe host-side integration boundaries, bounded CVDR inputs, local-vs-mainnet evidence caveats, and common hallucination traps, including:

* invented receipt-id APIs
* unsafe PII preimages
* treating local `dfx` evidence as production cryptographic proof
* overclaiming GDPR compliance
* leaking application semantics into the MKTd03 library layer

This adds:

* `skills/mktd03-cvdr/SKILL.md`
* `evaluations/mktd03-cvdr.json`

Validation:

```text
npm run validate: passed
```

Relevant validator result for the new skill:

```text
Validating skill: /home/stef_savanah/projects/icskills/skills/mktd03-cvdr

Structure
  ✓ SKILL.md found

Frontmatter
  ✓ name: "mktd03-cvdr" (valid)
  ✓ description: (504 chars)
  ✓ license: "Apache-2.0"
  ✓ compatibility: (116 chars)
  ✓ metadata: (2 entries)

Markdown
  ✓ no unclosed code fences found

Tokens
  SKILL.md body: 528 tokens
  Total: 528 tokens

Content Analysis
  Word count: 467
  Code block ratio: 0.00
  Imperative ratio: 0.41
  Information density: 0.41
  Instruction specificity: 1.00
  Sections: 5 | List items: 18 | Code blocks: 0

Contamination Analysis
  Contamination level: low (score: 0.00)
  Scope breadth: 0

Result: passed
```

Full validation summary:

```text
23 skills validated: all passed
Total: 12 warnings
```

Note on eval runner:

```text
node scripts/evaluate-skills.js mktd03-cvdr
```

was attempted locally, but the local environment does not have the `claude` CLI installed, so the runner failed with:

```text
[ERROR] spawnSync claude ENOENT
```

The failed generated result file was not committed. The evaluation specification itself is included in `evaluations/mktd03-cvdr.json`.
