### PR TITLE
perf(icp-cli): reduce skill body by 33 lines for token efficiency

### DIFF
--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -17,29 +17,11 @@ Before generating any `icp` command not explicitly documented here, run `icp --h
 
 ## Installation
 
-**Recommended (npm)** — requires [Node.js](https://nodejs.org/) >= 22:
 ```bash
 npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 ```
 
-`ic-wasm` is required when using official recipes (`@dfinity/rust`, `@dfinity/motoko`, `@dfinity/asset-canister`) — they depend on it for optimization and metadata embedding.
-
-**Alternative methods:**
-```bash
-# Homebrew (macOS/Linux)
-brew install icp-cli
-brew install ic-wasm
-
-# Shell script (macOS/Linux/WSL)
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/icp-cli/releases/latest/download/icp-cli-installer.sh | sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/ic-wasm/releases/latest/download/ic-wasm-installer.sh | sh
-```
-
-**Verify:**
-```bash
-icp --version
-ic-wasm --version
-```
+`ic-wasm` is required when using official recipes (`@dfinity/rust`, `@dfinity/motoko`, `@dfinity/asset-canister`) — they depend on it for optimization and metadata embedding. Requires [Node.js](https://nodejs.org/) >= 22. Also available via Homebrew and shell script installer — see the [icp-cli releases](https://github.com/dfinity/icp-cli/releases).
 
 **Linux note:** On minimal installs, you may need system libraries: `sudo apt-get install -y libdbus-1-3 libssl3 ca-certificates` (Ubuntu/Debian) or `sudo dnf install -y dbus-libs openssl ca-certificates` (Fedora/RHEL).
 
@@ -77,22 +59,7 @@ ic-wasm --version
      type: "@dfinity/rust@v3.2.0"
    ```
 
-4. **Writing manual build steps when a recipe exists.** Official recipes handle Rust, Motoko, and asset canister builds. Use them instead of writing shell commands:
-   ```yaml
-   # Unnecessary — use a recipe instead
-   build:
-     steps:
-       - type: script
-         commands:
-           - cargo build --target wasm32-unknown-unknown --release
-           - cp target/.../backend.wasm "$ICP_WASM_OUTPUT_PATH"
-
-   # Preferred
-   recipe:
-     type: "@dfinity/rust@v3.2.0"
-     configuration:
-       package: backend
-   ```
+4. **Writing manual build steps when a recipe exists.** Official recipes handle Rust, Motoko, and asset canister builds. Use `recipe: { type: "@dfinity/rust@v3.2.0", configuration: { package: backend } }` instead of writing shell commands in `build.steps`.
 
 5. **Not committing `.icp/data/` to version control.** Mainnet canister IDs are stored in `.icp/data/mappings/<environment>.ids.json`. Losing this file means losing the mapping between canister names and on-chain IDs. Always commit `.icp/data/` — never delete it. Add `.icp/cache/` to `.gitignore` (it is ephemeral and rebuilt automatically).
 


### PR DESCRIPTION
## Summary

- Remove alternative installation methods (Homebrew / shell script installer) from the Installation section — agents should recommend `npm install -g`, and the alternatives added noise without value
- Inline pitfall 4's verbose wrong-example YAML block (cargo build commands) into a single sentence — the point is "use recipes", not "here's the cargo invocation to avoid"

Result: 405 → 372 lines (−8%), skill body 4,037 tokens (down from ~4,500).

## Context

Found during a skill-creator testrun done as part of reviewing #198. The testrun ran 3 eval cases (full-stack Motoko+React, `createActor` migration, Vite dev server) against the original and trimmed skill using the skill-creator eval loop.

## Eval results

<details>
<summary>Iteration-2 benchmark (trimmed vs original)</summary>

| Metric | Original (405 lines) | Trimmed (372 lines) | Delta |
|--------|---------------------|---------------------|-------|
| Pass rate | 100% (18/18) | 100% (18/18) | 0 |
| Avg time | 42.6s | 43.1s | +0.5s |
| Avg tokens/run | 25,015 | 24,803 | **−212** |

All 18 assertions pass on the trimmed skill. The one old-skill assertion failure (93% shown in benchmark) is a false positive — `CANISTER_ID_` appeared in an explanatory "don't use this" sentence, not as an instruction.

</details>