### PR TITLE
feat: add deploy-to-cloud-engine skill

### DIFF
--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -1,16 +1,16 @@
 {
   "skill": "deploy-to-cloud-engine",
-  "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), ask for the console origin and subnet id instead of guessing, and avoid the documented pitfalls.",
+  "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), use the default console origin https://opencloud.org unless the user names another, ask for the subnet id instead of guessing, and avoid the documented pitfalls.",
 
   "output_evals": [
     {
       "name": "Deploy a built project to a cloud engine",
       "prompt": "My ICP app already builds. How do I deploy it to my cloud engine? Just the steps and commands, no canister code.",
       "expected_behaviors": [
-        "States that it needs the console origin and the engine's subnet id, and asks for them if not provided (does not guess)",
+        "Uses `https://opencloud.org` as the default console origin, stating it and offering an override, and asks for the engine's subnet id if not provided (does not guess it)",
         "Links the CLI with `icp identity link web <name> --auth <console-origin>`",
         "Notes the user must complete the Internet Identity sign-in in the browser",
-        "Sets the identity as default with `icp default <name>` using the same name",
+        "Sets the identity as default with `icp identity default <name>` using the same name",
         "Deploys with `icp deploy -e ic --subnet <subnet-id>`",
         "Does NOT use dfx commands"
       ]
@@ -33,6 +33,16 @@
         "Explains the mismatched origin derived a different principal that does not administer the engine",
         "Tells the user to relink with `icp identity link web <name> --auth https://opencloud.org`",
         "Does NOT attribute the failure to insufficient cycles or a wrong subnet id"
+      ]
+    },
+    {
+      "name": "Override: non-default console origin",
+      "prompt": "I sign in to my engine console at https://console.other-engine.dev, not opencloud.org. Link my icp CLI and deploy my built app to subnet abc12-3defg.",
+      "expected_behaviors": [
+        "Uses the user's console origin in the link command: `icp identity link web <name> --auth https://console.other-engine.dev`",
+        "Does NOT substitute the default https://opencloud.org once the user has named a different console",
+        "Deploys with `icp deploy -e ic --subnet abc12-3defg`",
+        "Does NOT use dfx"
       ]
     },
     {

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -55,6 +55,26 @@
       ]
     },
     {
+      "name": "Agent pitfall: link command stalls non-interactively",
+      "prompt": "I ran `icp identity link web admin --auth https://opencloud.org` as a background process and it has been hanging for minutes — no browser tab ever opened. What is wrong?",
+      "expected_behaviors": [
+        "Identifies that the command waits at a 'Press Enter to log in' prompt before opening the browser",
+        "Suggests running it interactively, or supplying the Enter keypress (e.g. piping an empty line) when it must run non-interactively",
+        "Notes the user must still complete the Internet Identity sign-in in the browser afterwards",
+        "Does NOT attribute the hang to the engine, the subnet, or the --auth origin"
+      ]
+    },
+    {
+      "name": "Adversarial: deploying as anonymous",
+      "prompt": "`icp deploy -e ic --subnet <my-subnet-id>` fails saying the anonymous principal is not authorized on my cloud engine. How do I fix this?",
+      "expected_behaviors": [
+        "Explains the active identity is the default anonymous one, which does not administer the engine",
+        "Tells the user to link their console identity with `icp identity link web <name> --auth <console-origin>` and set it active with `icp identity default <name>`",
+        "Does NOT suggest creating a plain local identity (`icp identity new`) — a local key is not the engine admin principal",
+        "Does NOT use dfx"
+      ]
+    },
+    {
       "name": "Adversarial: dfx to the engine",
       "prompt": "Can I just run `dfx deploy --network ic` to push my app to my cloud engine?",
       "expected_behaviors": [
@@ -78,6 +98,7 @@
       "My agent should deploy straight to my engine"
     ],
     "should_not_trigger": [
+      "Package my app as a .icp archive so others can install it on their engines from the marketplace",
       "Deploy my canister to mainnet",
       "Set up icp.yaml for my Rust canister",
       "Add Internet Identity login to my frontend",

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -1,6 +1,6 @@
 {
   "skill": "deploy-to-cloud-engine",
-  "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), use the default console origin https://opencloud.org unless the user names another, ask for the subnet id instead of guessing, and avoid the documented pitfalls.",
+  "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), use the default console origin https://opencloud.org unless the user names another, ask for the subnet id instead of guessing, set the `__META_*` environment variables so the console shows a named app with labelled canisters, and avoid the documented pitfalls.",
 
   "output_evals": [
     {
@@ -83,6 +83,28 @@
         "Gives the correct deploy: `icp deploy -e ic --subnet <subnet-id>`",
         "Does NOT endorse the dfx command or the --network flag"
       ]
+    },
+    {
+      "name": "Name the app in the engine console",
+      "prompt": "I deployed my app to my cloud engine but in the console it shows up as bare canister principals. How do I make it appear as one named app with a clear backend and frontend?",
+      "expected_behaviors": [
+        "Explains the console reads canister environment variables and sets them via `settings.environment_variables` in each canister.yaml (or under the canister entries in icp.yaml)",
+        "Sets the SAME `__META_PROJECT` value (the app name) on every canister so they group into one named app",
+        "Sets a per-canister `__META_NAME` label (e.g. Backend, Frontend)",
+        "Marks the entry-point/frontend canister with `__META_MAIN_CANISTER: \"true\"` for the Open button and public URL",
+        "Notes these merge with the auto-injected `PUBLIC_CANISTER_ID:*` variables and are applied on `icp deploy` (re-deploy to apply)",
+        "Does NOT claim canisters have a built-in name field or invent a different mechanism (e.g. a WASM metadata section or an `icp canister rename` command)"
+      ]
+    },
+    {
+      "name": "Adversarial: named app but no Open button",
+      "prompt": "I set __META_PROJECT and __META_NAME on both my canisters and the app is named in the console now, but there is no Open button. What did I miss?",
+      "expected_behaviors": [
+        "Identifies that one canister must carry `__META_MAIN_CANISTER` set to the exact string \"true\" (the frontend / entry point)",
+        "Notes it is matched as the literal string \"true\" (not a boolean or \"True\"), and exactly one canister should be marked",
+        "Tells the user to set it and re-run `icp deploy` so the setting is applied",
+        "Does NOT attribute the missing button to the subnet, the identity, or the --auth origin"
+      ]
     }
   ],
 
@@ -95,7 +117,9 @@
       "Deploy to my engine on a specific subnet",
       "How do I authorize the icp CLI for my cloud engine?",
       "Ship this project to my cloud engine",
-      "My agent should deploy straight to my engine"
+      "My agent should deploy straight to my engine",
+      "Make my deployed app show up with a name in the cloud engine console",
+      "Label my backend and frontend canisters in the engine console instead of bare principal ids"
     ],
     "should_not_trigger": [
       "Package my app as a .icp archive so others can install it on their engines from the marketplace",

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -16,8 +16,8 @@
       ]
     },
     {
-      "name": "Just the link command",
-      "prompt": "Give me only the command to link my icp CLI to my cloud engine console at https://opencloud.org. No deploy steps.",
+      "name": "Link command and what to expect",
+      "prompt": "Give me the command to link my icp CLI to my cloud engine console at https://opencloud.org, and what to expect when I run it. No deploy steps.",
       "expected_behaviors": [
         "Produces `icp identity link web <your-identity-name> --auth https://opencloud.org` (a chosen local name plus the exact console origin)",
         "Mentions a browser tab opens and the user completes the Internet Identity sign-in there",
@@ -59,7 +59,7 @@
       "prompt": "I ran `icp identity link web admin --auth https://opencloud.org` as a background process and it has been hanging for minutes — no browser tab ever opened. What is wrong?",
       "expected_behaviors": [
         "Identifies that the command waits at a 'Press Enter to log in' prompt before opening the browser",
-        "Suggests running it interactively, or supplying the Enter keypress (e.g. piping an empty line) when it must run non-interactively",
+        "Suggests running it interactively, or piping a real newline (`printf '\\n' | icp identity link web ...`) when it must run non-interactively — and does NOT suggest redirecting stdin from /dev/null",
         "Notes the user must still complete the Internet Identity sign-in in the browser afterwards",
         "Does NOT attribute the hang to the engine, the subnet, or the --auth origin"
       ]
@@ -102,7 +102,7 @@
       "expected_behaviors": [
         "Identifies that one canister must carry `__META_MAIN_CANISTER` set to the exact string \"true\" (the frontend / entry point)",
         "Notes it is matched as the literal string \"true\" (not a boolean or \"True\"), and exactly one canister should be marked",
-        "Tells the user to set it and re-run `icp deploy` so the setting is applied",
+        "Tells the user to set it and re-deploy by explicitly naming the `icp deploy` command (not just saying 'redeploy')",
         "Does NOT attribute the missing button to the subnet, the identity, or the --auth origin"
       ]
     }

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -1,0 +1,80 @@
+{
+  "skill": "deploy-to-cloud-engine",
+  "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), ask for the console origin and subnet id instead of guessing, and avoid the documented pitfalls.",
+
+  "output_evals": [
+    {
+      "name": "Deploy a built project to a cloud engine",
+      "prompt": "My ICP app already builds. How do I deploy it to my cloud engine? Just the steps and commands, no canister code.",
+      "expected_behaviors": [
+        "States that it needs the console origin and the engine's subnet id, and asks for them if not provided (does not guess)",
+        "Links the CLI with `icp identity link web <name> --auth <console-origin>`",
+        "Notes the user must complete the Internet Identity sign-in in the browser",
+        "Sets the identity as default with `icp default <name>` using the same name",
+        "Deploys with `icp deploy -e ic --subnet <subnet-id>`",
+        "Does NOT use dfx commands"
+      ]
+    },
+    {
+      "name": "Just the link command",
+      "prompt": "Give me only the command to link my icp CLI to my cloud engine console at https://opencloud.org. No deploy steps.",
+      "expected_behaviors": [
+        "Produces `icp identity link web <your-identity-name> --auth https://opencloud.org` (a chosen local name plus the exact console origin)",
+        "Mentions a browser tab opens and the user completes the Internet Identity sign-in there",
+        "Does NOT invent a different flag than --auth for the origin",
+        "Does NOT use dfx"
+      ]
+    },
+    {
+      "name": "Adversarial: wrong --auth origin",
+      "prompt": "I linked with `icp identity link web admin --auth https://example.com`, but my engine console is opencloud.org, and now `icp deploy` says I'm not authorized on the engine. Why?",
+      "expected_behaviors": [
+        "Identifies that --auth must match the console origin the user signs in with (https://opencloud.org), not an unrelated URL",
+        "Explains the mismatched origin derived a different principal that does not administer the engine",
+        "Tells the user to relink with `icp identity link web <name> --auth https://opencloud.org`",
+        "Does NOT attribute the failure to insufficient cycles or a wrong subnet id"
+      ]
+    },
+    {
+      "name": "Adversarial: guessing the subnet id",
+      "prompt": "Just deploy my app to my cloud engine for me, I don't know the subnet id.",
+      "expected_behaviors": [
+        "Does NOT invent or hardcode a subnet id",
+        "Tells the user the subnet id is on the engine's App Center / Applications page in the console and asks for it",
+        "Only then runs `icp deploy -e ic --subnet <subnet-id>`"
+      ]
+    },
+    {
+      "name": "Adversarial: dfx to the engine",
+      "prompt": "Can I just run `dfx deploy --network ic` to push my app to my cloud engine?",
+      "expected_behaviors": [
+        "Corrects the user: this ecosystem uses icp, not dfx",
+        "Explains the engine needs the CLI linked to the console identity first (`icp identity link web <name> --auth <console-origin>`)",
+        "Gives the correct deploy: `icp deploy -e ic --subnet <subnet-id>`",
+        "Does NOT endorse the dfx command or the --network flag"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I deploy this app to my cloud engine?",
+      "Push my canisters to my OpenCloud engine",
+      "Link the icp CLI to my engine console",
+      "Deploy to my engine on a specific subnet",
+      "How do I authorize the icp CLI for my cloud engine?",
+      "Ship this project to my cloud engine",
+      "My agent should deploy straight to my engine"
+    ],
+    "should_not_trigger": [
+      "Deploy my canister to mainnet",
+      "Set up icp.yaml for my Rust canister",
+      "Add Internet Identity login to my frontend",
+      "How does stable memory work in Rust canisters?",
+      "Implement an ICRC-1 token transfer",
+      "Generate TypeScript bindings for my canister",
+      "Add access control to my Motoko canister"
+    ]
+  }
+}

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -2,7 +2,7 @@
 name: deploy-to-cloud-engine
 description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), and running `icp deploy` against that subnet. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, or linking the icp CLI to an engine console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
 license: Apache-2.0
-compatibility: "icp-cli >= 0.1.0, a cloud engine console account, a browser for the Internet Identity sign-in"
+compatibility: "icp-cli >= 0.3.0 (commands verified against 0.3.0), a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
   title: Deploy to Cloud Engine
   category: Infrastructure
@@ -37,21 +37,38 @@ Record both so you do not re-ask within the session.
 
 ## Step 1 — Link the CLI to your engine identity (once per machine)
 
-The CLI must sign as the **same identity that administers the engine** — that is the principal you log in to the console with. Run this, substituting a name the user picks (any local label, reused in the commands below):
+The CLI must sign as the **same identity that administers the engine** — that is the principal you log in to the console with.
+
+First check what already exists:
+
+```bash
+icp identity list      # names + principals; * marks the active identity
+```
+
+The list does **not** show which console (if any) an identity was linked against — that cannot be determined from the CLI. Decide like this:
+
+- **Only `anonymous` (or plain local identities) listed** — no web-linked identity exists; run the link command below.
+- **An identity the user recognizes as their engine identity** (by name or principal) — set it active (below) and skip to Step 2.
+- **Unsure** — ask the user, or simply relink under a new name; linking again is cheap and safe.
+
+To link, run this, substituting a name the user picks (any local label, reused in the commands below):
 
 ```bash
 icp identity link web <your-identity-name> --auth <console-origin>
 ```
 
-- Use `https://opencloud.org` as `<console-origin>` unless the user named a different console.
-- This opens a **browser tab**. The **user** completes the Internet Identity sign-in there. Wait for them to confirm before continuing — you cannot complete the sign-in for them.
+- Use `https://opencloud.org` as `<console-origin>` unless the user named a different console. Never omit `--auth`: the flag has a built-in default (`https://id.ai`) that is **not** your console and silently derives the wrong principal.
+- The command first waits at a **"Press Enter to log in"** prompt before anything happens. Run it interactively when you can; in a non-interactive shell (e.g. a background process) supply the Enter keypress (pipe an empty line), or it stalls with no browser ever opening.
+- After Enter it opens a **browser tab**. The **user** completes the Internet Identity sign-in there. Wait for them to confirm before continuing — you cannot complete the sign-in for them.
 - `--auth` must be the **exact** console origin (scheme + host), e.g. `https://opencloud.org`. A mismatched origin derives a *different* principal, and the engine will reject the deploy as unauthorized.
-- This is a **one-time, per-machine** step. If the machine is already linked, skip to Step 2.
+- This is a **one-time, per-machine** step.
 
-Then make it the active identity:
+Then make it the active identity and verify:
 
 ```bash
 icp identity default <your-identity-name>
+icp identity default     # prints the active identity name
+icp identity principal   # prints the principal the deploy will sign as
 ```
 
 ## Step 2 — Deploy to the engine's subnet
@@ -70,13 +87,14 @@ icp deploy -e ic --subnet <subnet-id>
 ## Step 3 — Verify
 
 - The `icp deploy` output reports the deployed canister ids.
-- The canisters appear on the engine's **Applications** page in the console.
+- The canisters appear on the engine's **Applications** page in the console; each canister's detail view offers an "Open in browser" link.
+- A frontend (asset) canister is served at `https://<frontend-canister-id>.icp0.io`.
 
 Report the deployed canister ids (and the frontend URL, if any) back to the user.
 
 ## Common Pitfalls
 
-1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished.
+1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished. If no browser ever opened, the command is stalled at the "Press Enter to log in" prompt (see Step 1).
 2. **Wrong `--auth` origin.** Using any URL other than the console origin the user signs in with derives a different principal, and the engine rejects the deploy as not authorized. Relink with the exact console URL. If the deploy is rejected as unauthorized after linking against the default `https://opencloud.org`, ask the user for the exact URL they sign in with and relink.
 3. **Guessing the subnet id.** Never invent it — the deploy fails or targets the wrong subnet. It is on the engine's App Center / Applications page; ask the user.
 4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp identity default`, and any later command.

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-cloud-engine
-description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, obtaining the engine's console origin and subnet id (asking the user when they are unknown), and running `icp deploy` against that subnet. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, or linking the icp CLI to an engine console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
+description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), and running `icp deploy` against that subnet. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, or linking the icp CLI to an engine console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.1.0, a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
@@ -12,19 +12,20 @@ metadata:
 
 ## What This Is
 
-A **cloud engine** is a user-owned slice of Internet Computer capacity, administered from a web console (for example `https://opencloud.org`). Each engine runs on a single **subnet**. This skill takes a project that already builds and gets it deployed onto that engine, from a coding agent.
+A **cloud engine** is a user-owned slice of Internet Computer capacity, administered from a web console (by default `https://opencloud.org`). Each engine runs on a single **subnet**. This skill takes a project that already builds and gets it deployed onto that engine, from a coding agent.
 
 This skill only covers the cloud-engine-specific steps: linking the CLI to the engine's console identity, and a subnet-targeted deploy. For everything else about the CLI (`icp.yaml`, recipes, environments, bindings, identities), load the **`icp-cli`** skill.
 
 Before running any `icp` command you are unsure of, run `icp <subcommand> --help` (e.g. `icp identity link --help`, `icp deploy --help`) to confirm the command and flags exist. Do not infer flags. Authoritative reference: https://cli.internetcomputer.org/llms.txt
 
-## What You Need (ask the user when unknown)
+## What You Need
 
-Two values, neither of which you can guess. Look for them first in `icp.yaml` or earlier in the conversation; if absent, **ask the user and do not proceed without them**:
+Two values. Look for them first in `icp.yaml` or earlier in the conversation. One has a default; the other you must ask for:
 
-1. **Console origin** — the URL the user signs in to their cloud engine console with (commonly `https://opencloud.org`). It is used as the `--auth` origin in Step 1 so the linked CLI identity derives the **same principal that administers the engine**.
-   - Ask: "What URL do you sign in to your cloud engine console with?"
-2. **Subnet id** — the subnet the engine deploys to, required by `icp deploy --subnet`. The user finds it on the engine's **App Center / Applications** page in the console.
+1. **Console origin** — the URL the user signs in to their cloud engine console with. **Defaults to `https://opencloud.org`** (the main OpenCloud console). It is used as the `--auth` origin in Step 1 so the linked CLI identity derives the **same principal that administers the engine**. Use the default, but say so and give the user a chance to override before linking:
+   - Say: "I'll link the CLI against `https://opencloud.org`, the default console. If you sign in to your engine console at a different URL, tell me now."
+   - Only use a different origin when the user names one — never substitute another URL on your own; the `--auth` origin determines the derived principal (see Pitfall 2).
+2. **Subnet id** — the subnet the engine deploys to, required by `icp deploy --subnet`. There is **no default**; never guess it. The user finds it on the engine's **App Center / Applications** page in the console. If absent, **ask and do not proceed without it**:
    - Ask: "What is your engine's subnet id? It is shown on your engine's App Center / Applications page."
 
 Record both so you do not re-ask within the session.
@@ -42,6 +43,7 @@ The CLI must sign as the **same identity that administers the engine** — that 
 icp identity link web <your-identity-name> --auth <console-origin>
 ```
 
+- Use `https://opencloud.org` as `<console-origin>` unless the user named a different console.
 - This opens a **browser tab**. The **user** completes the Internet Identity sign-in there. Wait for them to confirm before continuing — you cannot complete the sign-in for them.
 - `--auth` must be the **exact** console origin (scheme + host), e.g. `https://opencloud.org`. A mismatched origin derives a *different* principal, and the engine will reject the deploy as unauthorized.
 - This is a **one-time, per-machine** step. If the machine is already linked, skip to Step 2.
@@ -49,7 +51,7 @@ icp identity link web <your-identity-name> --auth <console-origin>
 Then make it the active identity:
 
 ```bash
-icp default <your-identity-name>
+icp identity default <your-identity-name>
 ```
 
 ## Step 2 — Deploy to the engine's subnet
@@ -75,10 +77,10 @@ Report the deployed canister ids (and the frontend URL, if any) back to the user
 ## Common Pitfalls
 
 1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished.
-2. **Wrong `--auth` origin.** Using any URL other than the console origin derives a different principal, and the engine rejects the deploy as not authorized. Relink with the exact console URL the user signs in with.
+2. **Wrong `--auth` origin.** Using any URL other than the console origin the user signs in with derives a different principal, and the engine rejects the deploy as not authorized. Relink with the exact console URL. If the deploy is rejected as unauthorized after linking against the default `https://opencloud.org`, ask the user for the exact URL they sign in with and relink.
 3. **Guessing the subnet id.** Never invent it — the deploy fails or targets the wrong subnet. It is on the engine's App Center / Applications page; ask the user.
-4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp default`, and any later command.
-5. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp default <your-identity-name>` first.
+4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp identity default`, and any later command.
+5. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp identity default <your-identity-name>` first.
 6. **Using `dfx`.** This ecosystem uses `icp`, never `dfx`. See the `icp-cli` skill.
 
 ## Related Skills

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -32,7 +32,7 @@ Record both so you do not re-ask within the session.
 
 ## Prerequisites
 
-- `icp` on `$PATH`. Install with `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm` (requires Node.js >= 22), or see the [icp-cli releases](https://github.com/dfinity/icp-cli/releases). Some preview builds ship as `demo-icp`; prefer `icp` and fall back to `demo-icp`. Verify with `icp --version`.
+- `icp` on `$PATH` — see the **`icp-cli`** skill to install. Verify with `icp --version` (this skill's commands are verified against 0.3.0).
 - A project that already builds. If it does not build or package yet, set that up first (see the `icp-cli` skill), then return here.
 
 ## Step 1 — Link the CLI to your engine identity (once per machine)
@@ -51,14 +51,20 @@ The list does **not** show which console (if any) an identity was linked against
 - **An identity the user recognizes as their engine identity** (by name or principal) — set it active (below) and skip to Step 2.
 - **Unsure** — ask the user, or simply relink under a new name; linking again is cheap and safe.
 
-To link, run this, substituting a name the user picks (any local label, reused in the commands below):
+To link, run this, substituting a name the user picks — `<your-identity-name>` is any local label, not a fixed value (do not hardcode something like `my-engine-admin`); reuse the **same** name in every command below:
 
 ```bash
 icp identity link web <your-identity-name> --auth <console-origin>
 ```
 
 - Use `https://opencloud.org` as `<console-origin>` unless the user named a different console. Never omit `--auth`: the flag has a built-in default (`https://id.ai`) that is **not** your console and silently derives the wrong principal.
-- The command first waits at a **"Press Enter to log in"** prompt before anything happens. Run it interactively when you can; in a non-interactive shell (e.g. a background process) supply the Enter keypress (pipe an empty line), or it stalls with no browser ever opening.
+- The command first waits at a **"Press Enter to log in"** prompt before anything happens. Run it interactively when you can; in a non-interactive shell (e.g. a background process) pipe a real newline:
+
+  ```bash
+  printf '\n' | icp identity link web <your-identity-name> --auth <console-origin>
+  ```
+
+  Do **not** redirect stdin from `/dev/null` — the bare EOF does not satisfy the prompt, and the command sits on "Press Enter to log in" indefinitely with no browser ever opening.
 - After Enter it opens a **browser tab**. The **user** completes the Internet Identity sign-in there. Wait for them to confirm before continuing — you cannot complete the sign-in for them.
 - `--auth` must be the **exact** console origin (scheme + host), e.g. `https://opencloud.org`. A mismatched origin derives a *different* principal, and the engine will reject the deploy as unauthorized.
 - This is a **one-time, per-machine** step.
@@ -111,7 +117,25 @@ settings:
     __META_NAME: "Backend"
 ```
 
-For a single inline `icp.yaml` (canisters defined there directly), put the same `settings.environment_variables` block under each canister entry instead.
+For a single inline `icp.yaml` (canisters defined there directly), put the same `settings.environment_variables` block under each canister entry. Note the inline form: `canisters` is an **array** of `{name, recipe, settings}` items, not a map keyed by canister name:
+
+```yaml
+# icp.yaml — canisters defined inline
+canisters:
+  - name: frontend
+    recipe: # … as in the canister.yaml example above
+    settings:
+      environment_variables:
+        __META_PROJECT: "My App"
+        __META_NAME: "Frontend"
+        __META_MAIN_CANISTER: "true"
+  - name: backend
+    recipe: # … as in the canister.yaml example above
+    settings:
+      environment_variables:
+        __META_PROJECT: "My App"
+        __META_NAME: "Backend"
+```
 
 Notes:
 - icp-cli **merges** these with the `PUBLIC_CANISTER_ID:<name>` variables it injects automatically at deploy time — the asset canister keeps serving and the app keeps working. (Verified against icp-cli 0.3.0.)
@@ -142,14 +166,13 @@ Report the deployed canister ids (and the frontend URL, if any) back to the user
 
 ## Common Pitfalls
 
-1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished. If no browser ever opened, the command is stalled at the "Press Enter to log in" prompt (see Step 1).
+1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished. If no browser ever opened, the command is stalled at the "Press Enter to log in" prompt — relaunch with a piped newline, `printf '\n' | icp identity link web …`, never `< /dev/null` (see Step 1).
 2. **Wrong `--auth` origin.** Using any URL other than the console origin the user signs in with derives a different principal, and the engine rejects the deploy as not authorized. Relink with the exact console URL. If the deploy is rejected as unauthorized after linking against the default `https://opencloud.org`, ask the user for the exact URL they sign in with and relink.
 3. **Guessing the subnet id.** Never invent it — the deploy fails or targets the wrong subnet. It is on the engine's App Center / Applications page; ask the user.
-4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp identity default`, and any later command.
-5. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp identity default <your-identity-name>` first.
-6. **Using `dfx`.** This ecosystem uses `icp`, never `dfx`. See the `icp-cli` skill.
-7. **Skipping the app metadata.** Without `__META_PROJECT` (Step 2), the canisters still deploy and work but render as bare, unnamed principal rows in the console. Setting `__META_*` is what produces a named app with labelled canisters and an "Open" button.
-8. **Wrong `__META_MAIN_CANISTER` value.** It is matched as the exact string `"true"`. A boolean, `"True"`, or marking more than one canister means no (or the wrong) "Open" button. Mark exactly one entry-point canister.
+4. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp identity default <your-identity-name>` first.
+5. **Using `dfx`.** This ecosystem uses `icp`, never `dfx`. The correct sequence is `icp identity link web <name> --auth <console-origin>` (Step 1), then `icp deploy -e ic --subnet <subnet-id>` (Step 3). See the `icp-cli` skill.
+6. **Skipping the app metadata.** Without `__META_PROJECT` (Step 2), the canisters still deploy and work but render as bare, unnamed principal rows in the console. Setting `__META_*` is what produces a named app with labelled canisters and an "Open" button.
+7. **Wrong `__META_MAIN_CANISTER` value.** It is matched as the exact string `"true"`. A boolean, `"True"`, or marking more than one canister means no (or the wrong) "Open" button. Mark exactly one entry-point canister.
 
 ## Related Skills
 

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: deploy-to-cloud-engine
+description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, obtaining the engine's console origin and subnet id (asking the user when they are unknown), and running `icp deploy` against that subnet. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, or linking the icp CLI to an engine console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
+license: Apache-2.0
+compatibility: "icp-cli >= 0.1.0, a cloud engine console account, a browser for the Internet Identity sign-in"
+metadata:
+  title: Deploy to Cloud Engine
+  category: Infrastructure
+---
+
+# Deploy to Cloud Engine
+
+## What This Is
+
+A **cloud engine** is a user-owned slice of Internet Computer capacity, administered from a web console (for example `https://opencloud.org`). Each engine runs on a single **subnet**. This skill takes a project that already builds and gets it deployed onto that engine, from a coding agent.
+
+This skill only covers the cloud-engine-specific steps: linking the CLI to the engine's console identity, and a subnet-targeted deploy. For everything else about the CLI (`icp.yaml`, recipes, environments, bindings, identities), load the **`icp-cli`** skill.
+
+Before running any `icp` command you are unsure of, run `icp <subcommand> --help` (e.g. `icp identity link --help`, `icp deploy --help`) to confirm the command and flags exist. Do not infer flags. Authoritative reference: https://cli.internetcomputer.org/llms.txt
+
+## What You Need (ask the user when unknown)
+
+Two values, neither of which you can guess. Look for them first in `icp.yaml` or earlier in the conversation; if absent, **ask the user and do not proceed without them**:
+
+1. **Console origin** — the URL the user signs in to their cloud engine console with (commonly `https://opencloud.org`). It is used as the `--auth` origin in Step 1 so the linked CLI identity derives the **same principal that administers the engine**.
+   - Ask: "What URL do you sign in to your cloud engine console with?"
+2. **Subnet id** — the subnet the engine deploys to, required by `icp deploy --subnet`. The user finds it on the engine's **App Center / Applications** page in the console.
+   - Ask: "What is your engine's subnet id? It is shown on your engine's App Center / Applications page."
+
+Record both so you do not re-ask within the session.
+
+## Prerequisites
+
+- `icp` on `$PATH`. Install with `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm` (requires Node.js >= 22), or see the [icp-cli releases](https://github.com/dfinity/icp-cli/releases). Some preview builds ship as `demo-icp`; prefer `icp` and fall back to `demo-icp`. Verify with `icp --version`.
+- A project that already builds. If it does not build or package yet, set that up first (see the `icp-cli` skill), then return here.
+
+## Step 1 — Link the CLI to your engine identity (once per machine)
+
+The CLI must sign as the **same identity that administers the engine** — that is the principal you log in to the console with. Run this, substituting a name the user picks (any local label, reused in the commands below):
+
+```bash
+icp identity link web <your-identity-name> --auth <console-origin>
+```
+
+- This opens a **browser tab**. The **user** completes the Internet Identity sign-in there. Wait for them to confirm before continuing — you cannot complete the sign-in for them.
+- `--auth` must be the **exact** console origin (scheme + host), e.g. `https://opencloud.org`. A mismatched origin derives a *different* principal, and the engine will reject the deploy as unauthorized.
+- This is a **one-time, per-machine** step. If the machine is already linked, skip to Step 2.
+
+Then make it the active identity:
+
+```bash
+icp default <your-identity-name>
+```
+
+## Step 2 — Deploy to the engine's subnet
+
+From the project root:
+
+```bash
+icp deploy -e ic --subnet <subnet-id>
+```
+
+- `-e ic` targets mainnet (the engine runs on an IC subnet); `--subnet <subnet-id>` pins the deploy to **your engine's** subnet. Confirm the exact flags with `icp deploy --help` before running if unsure.
+- Deploying consumes capacity on the engine; make sure the engine has room.
+
+**Alternative — packaged upload.** If the project is distributed as a built `.icp` package and a direct `icp deploy` is not available, upload the bundle on the console's App Center via **"Upload a custom app"** instead.
+
+## Step 3 — Verify
+
+- The `icp deploy` output reports the deployed canister ids.
+- The canisters appear on the engine's **Applications** page in the console.
+
+Report the deployed canister ids (and the frontend URL, if any) back to the user.
+
+## Common Pitfalls
+
+1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished.
+2. **Wrong `--auth` origin.** Using any URL other than the console origin derives a different principal, and the engine rejects the deploy as not authorized. Relink with the exact console URL the user signs in with.
+3. **Guessing the subnet id.** Never invent it — the deploy fails or targets the wrong subnet. It is on the engine's App Center / Applications page; ask the user.
+4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp default`, and any later command.
+5. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp default <your-identity-name>` first.
+6. **Using `dfx`.** This ecosystem uses `icp`, never `dfx`. See the `icp-cli` skill.
+
+## Related Skills
+
+- **icp-cli** — general icp CLI usage (`icp.yaml`, recipes, environments, bindings, identities). Load it for anything beyond this cloud-engine deploy flow.
+- **internet-identity** — details of the Internet Identity sign-in that Step 1 triggers in the browser.

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-cloud-engine
-description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), and running `icp deploy` against that subnet. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, or linking the icp CLI to an engine console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
+description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), running `icp deploy` against that subnet, and tagging the canisters with `__META_*` environment variables so the engine console shows a named app with labelled backend/frontend canisters. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, linking the icp CLI to an engine console, or giving a deployed app a name in the console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.3.0 (commands verified against 0.3.0), a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
@@ -71,7 +71,54 @@ icp identity default     # prints the active identity name
 icp identity principal   # prints the principal the deploy will sign as
 ```
 
-## Step 2 — Deploy to the engine's subnet
+## Step 2 — Name the app in the console (recommended)
+
+By default, CLI-deployed canisters appear on the engine console's Applications page as bare rows labelled only by their principal id. Three **canister environment variables** make the console group them into a single named application with readable per-canister labels and an "Open" button. Set them once in your project config:
+
+- `__META_PROJECT` — the application name. Canisters that share the **same** value are grouped into one named app, so set an identical value on every canister of the app.
+- `__META_NAME` — the per-canister display label (e.g. `Backend`, `Frontend`).
+- `__META_MAIN_CANISTER` — the literal string `"true"` on the single entry-point canister (usually the frontend/asset canister). That canister gets the "Open" button and the app's public URL.
+
+Set them under each canister's `settings.environment_variables` — this is valid alongside a recipe. With per-canister `canister.yaml` files:
+
+```yaml
+# frontend/canister.yaml
+name: frontend
+recipe:
+  type: "@dfinity/asset-canister@v2.2.1"
+  configuration:
+    build:
+      - npm install
+      - npm run build
+    dir: dist
+settings:
+  environment_variables:
+    __META_PROJECT: "My App"
+    __META_NAME: "Frontend"
+    __META_MAIN_CANISTER: "true"
+```
+
+```yaml
+# backend/canister.yaml
+name: backend
+recipe:
+  type: "@dfinity/motoko@v4.1.0"
+  configuration:
+    main: src/main.mo
+settings:
+  environment_variables:
+    __META_PROJECT: "My App"
+    __META_NAME: "Backend"
+```
+
+For a single inline `icp.yaml` (canisters defined there directly), put the same `settings.environment_variables` block under each canister entry instead.
+
+Notes:
+- icp-cli **merges** these with the `PUBLIC_CANISTER_ID:<name>` variables it injects automatically at deploy time — the asset canister keeps serving and the app keeps working. (Verified against icp-cli 0.3.0.)
+- All values are strings; `__META_MAIN_CANISTER` must be the exact string `"true"`.
+- They are applied during `icp deploy` (the "Setting environment variables" step). After deploy, confirm with `icp canister settings show <name> -e ic`.
+
+## Step 3 — Deploy to the engine's subnet
 
 From the project root:
 
@@ -84,10 +131,11 @@ icp deploy -e ic --subnet <subnet-id>
 
 **Alternative — packaged upload.** If the project is distributed as a built `.icp` package and a direct `icp deploy` is not available, upload the bundle on the console's App Center via **"Upload a custom app"** instead.
 
-## Step 3 — Verify
+## Step 4 — Verify
 
 - The `icp deploy` output reports the deployed canister ids.
 - The canisters appear on the engine's **Applications** page in the console; each canister's detail view offers an "Open in browser" link.
+- If you set the metadata in Step 2, the canisters are grouped under your `__META_PROJECT` name with their `__META_NAME` labels, and the main canister shows an "Open" button — instead of bare principal rows.
 - A frontend (asset) canister is served at `https://<frontend-canister-id>.icp0.io`.
 
 Report the deployed canister ids (and the frontend URL, if any) back to the user.
@@ -100,6 +148,8 @@ Report the deployed canister ids (and the frontend URL, if any) back to the user
 4. **Assuming a fixed identity name.** `<your-identity-name>` is a local label the user chooses (do not hardcode a value like `my-engine-admin`). Use the **same** name in `icp identity link web`, `icp identity default`, and any later command.
 5. **Deploying with the anonymous identity.** The default local identity is anonymous and is not the engine admin. You must link and `icp identity default <your-identity-name>` first.
 6. **Using `dfx`.** This ecosystem uses `icp`, never `dfx`. See the `icp-cli` skill.
+7. **Skipping the app metadata.** Without `__META_PROJECT` (Step 2), the canisters still deploy and work but render as bare, unnamed principal rows in the console. Setting `__META_*` is what produces a named app with labelled canisters and an "Open" button.
+8. **Wrong `__META_MAIN_CANISTER` value.** It is matched as the exact string `"true"`. A boolean, `"True"`, or marking more than one canister means no (or the wrong) "Open" button. Mark exactly one entry-point canister.
 
 ## Related Skills
 


### PR DESCRIPTION
## What

Adds `deploy-to-cloud-engine` (category **Infrastructure**): a skill that deploys an already-built ICP project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). It:

- verifies the `icp` CLI is installed,
- checks existing CLI identities (`icp identity list`) and, when no engine identity exists, links the user's console identity with `icp identity link web <name> --auth <console-origin>` (the user completes the Internet Identity sign-in in the browser),
- defaults the console origin to `https://opencloud.org` (stated to the user and overridable when they sign in to a different console) and obtains the engine's **subnet id**, asking the user rather than guessing,
- deploys with `icp deploy -e ic --subnet <subnet-id>`,
- tags the canisters with `__META_PROJECT` / `__META_NAME` / `__META_MAIN_CANISTER` environment variables (via `settings.environment_variables`) so the engine console shows a single **named** app with labelled backend/frontend canisters and an "Open" button, instead of bare principal rows, and verifies the canisters on the console.

Includes `evaluations/deploy-to-cloud-engine.json` (output + trigger evals) covering the documented pitfalls: wrong or omitted `--auth` origin, the non-interactive "Press Enter" stall, deploying as anonymous, guessing the subnet id, dfx misuse, the console-naming metadata flow (naming an app + the "no Open button" case), and a marketplace-packaging near-miss that must not trigger this skill.

## Why

The `icp-cli` skill covers general builds and mainnet deploys, but nothing covers the cloud-engine-specific path: linking the CLI to the engine's console identity, targeting the engine's own subnet, and tagging the canisters so the engine console shows them as one named app. This is the skill a coding agent links to so it can ship straight to a user's cloud engine — the flow the cloud-engine console currently spells out by hand.

## Updates since opening

- **Verified end-to-end against a real engine** (opencloud.org console) on 2026-06-10: a coding agent following the skill linked the console identity and deployed a two-canister app successfully.
- Fixes harvested from that run: `icp default` → `icp identity default` (the former does not exist in icp 0.3.0), and documentation of the "Press Enter to log in" prompt that stalls `icp identity link web` in non-interactive shells.
- Console origin is now a **stated default** (`https://opencloud.org`) with an invited override, instead of an open-ended ask; the subnet id remains a hard ask.
- Added from CLI verification on icp 0.3.0: identity pre-check via `icp identity list` (the CLI cannot reveal which console an identity was linked against), a warning that omitting `--auth` silently links against its built-in default `https://id.ai`, the frontend URL form `https://<canister-id>.icp0.io`, and a compatibility pin to `icp-cli >= 0.3.0`.
- **App metadata for the console** (2026-06-11): added a step plus two pitfalls documenting the `__META_PROJECT` / `__META_NAME` / `__META_MAIN_CANISTER` environment variables that group CLI-deployed canisters into one named app (same `__META_PROJECT` across canisters), label each one, and mark the entry point (`__META_MAIN_CANISTER: "true"`) for the "Open" button. Verified on the opencloud.org engine: icp-cli **merges** these with the auto-injected `PUBLIC_CANISTER_ID:*` variables, so the asset canister keeps serving. Added matching output evals (naming an app, "no Open button" adversarial) and two `should_trigger` queries.
- **Review fixes** (2026-06-12, addressing the first review): non-interactive link now prescribes `printf '\n' | icp identity link web …` with an explicit do-not-use-`/dev/null` note (Step 1, Pitfall 1, and the stall eval); eval 2's prompt/behavior contradiction fixed ("the link command and what to expect"); the dfx pitfall anchors the full correct sequence; inline `icp.yaml` example added to Step 2 (array form per the v0.3.0 schema — `canisters` is a list of `{name, recipe, settings}`); the identity-name pitfall folded into Step 1; prerequisites defer installation to `icp-cli`.

## ⚠️ Draft — remaining before merge

- [ ] `npm run validate` — `skill-validator` was not available in my environment (no Go/Homebrew install). `node scripts/check-project.js deploy-to-cloud-engine` **passes** (metadata `title`/`category` present, eval file found, 0 warnings).
- [ ] Re-run the evaluation suite (`node scripts/evaluate-skills.js deploy-to-cloud-engine`) after the review fixes and paste results below. (Reviewer's run on the pre-fix state: 40/43 WITH skill vs 8/43 WITHOUT; triggers 17/17.)
- [x] End-to-end verification of `icp identity link web …` and `icp deploy -e ic --subnet …` against a real engine — done 2026-06-10, see "Updates since opening".
- [x] End-to-end verification of the `__META_*` console-naming metadata against a real engine — done 2026-06-11 (canisters merged the vars and rendered as a named app).

<details>
<summary>Evaluation results</summary>

Not yet generated. `evaluations/deploy-to-cloud-engine.json` is included (10 output evals + trigger evals, covering the deploy flow, the documented pitfalls, and the console-naming metadata); results need to be produced with `node scripts/evaluate-skills.js deploy-to-cloud-engine` before merge.

</details>

Per CONTRIBUTING, all PRs require repo-admin approval before merge.
