### PR TITLE
feat(icp-cli): update Motoko recipe to v5.0.0 (mops build)

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -160,7 +160,7 @@
       "expected_behaviors": [
         "icp.yaml has Motoko backend with @dfinity/motoko@v5.0.0 (no recipe.configuration block) and asset canister for frontend (version-pinned)",
         "Shows mops.toml with [toolchain] section (concrete moc version) and [canisters.backend] section with main field",
-        "Shows how to generate the .did file using 'mops build backend && cp .mops/.build/backend.did ...' and specifies candid in mops.toml [canisters.backend], NOT in icp.yaml recipe.configuration",
+        "Shows how to generate the .did file using 'mops build backend && cp .mops/.build/backend.did <path>' and explains that after interface changes the copy must be re-run manually",
         "Uses @icp-sdk/bindgen (>= 0.3.0) Vite plugin with correct didFile path pointing to the committed .did file",
         "Uses @icp-sdk/core (>= 5.0.0) — does NOT use a 0.x or 1.x version",
         "Uses ./src/bindings as outDir (not per-canister subdirectories) so imports are clean (e.g., ./bindings/backend)",

--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -122,6 +122,16 @@
       ]
     },
     {
+      "name": "Adversarial: missing [canisters] section in mops.toml for Motoko v5",
+      "prompt": "I set up a new Motoko canister with the @dfinity/motoko@v5.0.0 recipe. My icp.yaml has the canister named 'backend'. I have a mops.toml with [toolchain] but no [canisters] section. When I run icp build I get: 'No Motoko canisters found in mops.toml configuration'. What's wrong? Just the fix, no deploy steps.",
+      "expected_behaviors": [
+        "Identifies that mops.toml is missing the [canisters.backend] section required by the v5 recipe",
+        "Shows adding [canisters.backend] with a main field pointing to the .mo entry point",
+        "Explains that the key (backend) must exactly match the canister name in icp.yaml",
+        "Does NOT suggest adding main or candid inside recipe.configuration in icp.yaml"
+      ]
+    },
+    {
       "name": "Staging and production environments",
       "prompt": "I want to deploy my project to both a staging and production environment on mainnet, with different settings for each. How?",
       "expected_behaviors": [
@@ -137,19 +147,20 @@
       "expected_behaviors": [
         "Uses icp (not dfx) commands throughout",
         "Configuration file is icp.yaml, NOT dfx.json",
-        "Motoko canister uses @dfinity/motoko recipe with a version pin",
+        "Motoko canister uses @dfinity/motoko@v5.0.0 recipe with NO recipe.configuration block in icp.yaml",
         "Mentions installing ic-mops (npm i -g ic-mops)",
-        "Shows a mops.toml file with a [toolchain] section specifying a concrete moc version (e.g., moc = \"1.3.0\")",
-        "Does NOT leave the moc version as a placeholder like <version>"
+        "Shows a mops.toml with a [toolchain] section specifying a concrete moc version (not a placeholder like <version>)",
+        "Shows a [canisters.backend] section in mops.toml with the main field pointing to the .mo entry point",
+        "Does NOT put main or candid inside recipe.configuration in icp.yaml"
       ]
     },
     {
       "name": "Full-stack Motoko hello-world with React frontend",
       "prompt": "Build me a hello-world ICP dapp with a Motoko backend and a React frontend. The frontend should call a greet function on the backend. Show me the full project setup including icp.yaml, TypeScript bindings, and dev server config.",
       "expected_behaviors": [
-        "icp.yaml has Motoko backend with @dfinity/motoko recipe (version-pinned) and asset canister for frontend (version-pinned)",
-        "Shows mops.toml with [toolchain] section and a concrete moc version",
-        "Shows how to generate the .did file and specifies candid in the recipe config so bindgen can find it",
+        "icp.yaml has Motoko backend with @dfinity/motoko@v5.0.0 (no recipe.configuration block) and asset canister for frontend (version-pinned)",
+        "Shows mops.toml with [toolchain] section (concrete moc version) and [canisters.backend] section with main field",
+        "Shows how to generate the .did file using 'mops build backend && cp .mops/.build/backend.did ...' and specifies candid in mops.toml [canisters.backend], NOT in icp.yaml recipe.configuration",
         "Uses @icp-sdk/bindgen (>= 0.3.0) Vite plugin with correct didFile path pointing to the committed .did file",
         "Uses @icp-sdk/core (>= 5.0.0) — does NOT use a 0.x or 1.x version",
         "Uses ./src/bindings as outDir (not per-canister subdirectories) so imports are clean (e.g., ./bindings/backend)",

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -143,7 +143,7 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
     When `mops.toml` is not found, `mops build` fails because it cannot locate the project configuration. When `mops.toml` exists but is missing the matching `[canisters.<name>]` entry, see Pitfall 17.
 
-16. **Misunderstanding Candid file generation with recipes.** For `@icp-sdk/bindgen`, a `.did` file must exist on disk. Where to configure it depends on the recipe:
+16. **Misunderstanding Candid file generation with recipes.** Binding generation tools (e.g. `@icp-sdk/bindgen`) require a `.did` file at a known path on disk. Where to configure it depends on the recipe:
 
     **Rust** — `candid` goes inside `recipe.configuration` in `icp.yaml`:
     - If **specified**: the file must already exist. The recipe uses it as-is and does not generate one.
@@ -158,13 +158,13 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
     **Motoko (v5 recipe)** — `mops build` auto-generates the `.did` to `.mops/.build/<name>.did`.
 
-    - **No bindgen** — nothing to do. The generated `.did` in `.mops/.build/` is sufficient; do not commit it.
-    - **With bindgen** — commit a `.did` at a stable path and keep it in sync:
+    - **No binding generation needed** — nothing to do. The generated `.did` in `.mops/.build/` is sufficient; do not commit it.
+    - **Binding generation needed** — commit a `.did` at a stable path and keep it in sync:
       ```bash
       mops build backend
       cp .mops/.build/backend.did backend/backend.did
       ```
-      Point bindgen's `didFile` at `backend/backend.did`. **After any interface change, re-run both commands** — `mops build` always writes to `.mops/.build/` and does not update the committed file automatically.
+      Point the binding tool's config (e.g. `@icp-sdk/bindgen`'s `didFile`) at `backend/backend.did`. **After any interface change, re-run both commands** — `mops build` always writes to `.mops/.build/` and does not update the committed file automatically.
 
 17. **Missing or mismatched `[canisters]` key in `mops.toml`.** The `@dfinity/motoko@v5+` recipe calls `mops build <canister-name>`, where the name comes from the `name` field in `icp.yaml`. `mops build` requires a matching `[canisters.<name>]` entry in `mops.toml`. If the entry is absent or the key does not exactly match (including casing), the build fails with:
     ```

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -156,12 +156,15 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
     candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > backend/backend.did
     ```
 
-    **Motoko (v5 recipe)** — `candid` goes in `mops.toml` under `[canisters.<name>]`, **not** in `recipe.configuration`. `mops build` auto-generates the `.did` to `.mops/.build/<name>.did`. To commit a `.did` file for bindgen:
-    ```bash
-    mops build backend
-    cp .mops/.build/backend.did backend/backend.did
-    ```
-    Then add `candid = "backend/backend.did"` under `[canisters.backend]` in `mops.toml`.
+    **Motoko (v5 recipe)** — `mops build` auto-generates the `.did` to `.mops/.build/<name>.did`.
+
+    - **No bindgen** — nothing to do. The generated `.did` in `.mops/.build/` is sufficient; do not commit it.
+    - **With bindgen** — commit a `.did` at a stable path and keep it in sync:
+      ```bash
+      mops build backend
+      cp .mops/.build/backend.did backend/backend.did
+      ```
+      Point bindgen's `didFile` at `backend/backend.did`. **After any interface change, re-run both commands** — `mops build` always writes to `.mops/.build/` and does not update the committed file automatically.
 
 17. **Missing or mismatched `[canisters]` key in `mops.toml`.** The `@dfinity/motoko@v5+` recipe calls `mops build <canister-name>`, where the name comes from the `name` field in `icp.yaml`. `mops build` requires a matching `[canisters.<name>]` entry in `mops.toml`. If the entry is absent or the key does not exactly match (including casing), the build fails with:
     ```

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -28,12 +28,15 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 ## Prerequisites
 
 - For Rust canisters: `rustup target add wasm32-unknown-unknown`
-- For Motoko canisters: `npm i -g ic-mops` and a `mops.toml` at the project root with the Motoko compiler version:
+- For Motoko canisters: `npm i -g ic-mops` and a `mops.toml` at the project root with the Motoko compiler version and a `[canisters]` entry:
   ```toml
   [toolchain]
-  moc = "1.3.0"
+  moc = "1.9.0"
+
+  [canisters.backend]
+  main = "src/backend/main.mo"
   ```
-  The `@dfinity/motoko` recipe uses this to resolve the compiler. Without `mops.toml`, the recipe fails because `moc` is not found. Templates include `mops.toml` automatically; for manual projects, create it before running `icp build`.
+  The `@dfinity/motoko@v5+` recipe compiles via `mops build <canister-name>`. The canister name in `icp.yaml` must exactly match a key in `[canisters]` — a missing or mismatched key causes `mops build` to fail with `No Motoko canisters found in mops.toml configuration` (see Pitfall 17). Without `mops.toml`, the recipe fails because `mops` is not found. Templates include `mops.toml` automatically; for manual projects, create it before running `icp build`. Load `mops-cli` for `[canisters]` configuration options, dependency management, and `mops build` details.
 
 ## Common Pitfalls
 
@@ -138,27 +141,39 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
     - **Inline canisters** (defined directly in `icp.yaml`): build cwd is the project root. Place `mops.toml` at the project root next to `icp.yaml`. A `mops.toml` in `src/backend/` will not be found.
     - **Path-based canisters** (referenced via `canisters/*` or `./my-canister`, each with its own `canister.yaml`): build cwd is the canister directory. Place `mops.toml` in each canister's directory for per-canister dependencies and compiler versions, or omit it to fall back to a shared `mops.toml` in a parent directory.
 
-    When `mops.toml` is not found, `mops toolchain bin moc` outputs an error instead of a path, causing a cryptic `sh: Error:: command not found` build failure.
+    When `mops.toml` is not found, `mops build` fails because it cannot locate the project configuration. When `mops.toml` exists but is missing the matching `[canisters.<name>]` entry, see Pitfall 17.
 
-16. **Misunderstanding Candid file generation with recipes.** When using the Rust or Motoko recipe:
-    - If `candid` is **specified**: the file must already exist (checked in or manually created). The recipe uses it as-is and does **not** generate one.
-    - If `candid` is **omitted**: the recipe auto-generates the `.did` file from the compiled WASM (via `candid-extractor` for Rust, `moc` for Motoko). The generated file is placed in the build cache, not at a predictable project path.
+16. **Misunderstanding Candid file generation with recipes.** For `@icp-sdk/bindgen`, a `.did` file must exist on disk. Where to configure it depends on the recipe:
 
-    For projects that need a `.did` file on disk (e.g., for `@icp-sdk/bindgen`), the recommended pattern is: generate the `.did` file once, commit it, and specify `candid` in the recipe config. To generate it manually:
+    **Rust** — `candid` goes inside `recipe.configuration` in `icp.yaml`:
+    - If **specified**: the file must already exist. The recipe uses it as-is and does not generate one.
+    - If **omitted**: the recipe auto-generates the `.did` via `candid-extractor` into the build cache (no predictable project path).
 
-    **Rust** — build the WASM first, then extract the Candid interface:
+    To generate and commit it, then add `candid: backend/backend.did` inside `recipe.configuration`:
     ```bash
     cargo install candid-extractor  # one-time setup
     icp build backend
     candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > backend/backend.did
     ```
 
-    **Motoko** — use `moc` directly with the `--idl` flag:
+    **Motoko (v5 recipe)** — `candid` goes in `mops.toml` under `[canisters.<name>]`, **not** in `recipe.configuration`. `mops build` auto-generates the `.did` to `.mops/.build/<name>.did`. To commit a `.did` file for bindgen:
     ```bash
-    $(mops toolchain bin moc) --idl $(mops sources) -o backend/backend.did backend/app.mo
+    mops build backend
+    cp .mops/.build/backend.did backend/backend.did
+    ```
+    Then add `candid = "backend/backend.did"` under `[canisters.backend]` in `mops.toml`.
+
+17. **Missing or mismatched `[canisters]` key in `mops.toml`.** The `@dfinity/motoko@v5+` recipe calls `mops build <canister-name>`, where the name comes from the `name` field in `icp.yaml`. `mops build` requires a matching `[canisters.<name>]` entry in `mops.toml`. If the entry is absent or the key does not exactly match (including casing), the build fails with:
+    ```
+    No Motoko canisters found in mops.toml configuration
+    ```
+    Add the matching entry — the key must equal the `name:` value in `icp.yaml`:
+    ```toml
+    [canisters.backend]
+    main = "src/backend/main.mo"
     ```
 
-17. **Port 8000 already in use when starting the local network.** Two scenarios:
+18. **Port 8000 already in use when starting the local network.** Two scenarios:
 
     **Scenario A — another icp-cli project holds the port.** Stop that project's network using `--project-root-override` (a global flag available on all commands):
     ```bash
@@ -178,12 +193,12 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
     icp network status --json  # returns gateway URL, replica URL, etc.
     ```
 
-18. **`icp new` hangs in CI without `--silent`.** Without `--define` flags, `icp new` launches an interactive prompt that blocks indefinitely in non-interactive environments. Always pass `--subfolder`, `--define`, and `--silent` for scripted use:
+19. **`icp new` hangs in CI without `--silent`.** Without `--define` flags, `icp new` launches an interactive prompt that blocks indefinitely in non-interactive environments. Always pass `--subfolder`, `--define`, and `--silent` for scripted use:
     ```bash
     icp new my-project --subfolder rust --define project_name=my-project --silent
     ```
 
-19. **Using the anonymous identity on mainnet.** The local network seeds all managed identities — including the anonymous identity, which is the default — with ICP and cycles on start, so local development works out of the box with no identity or cycles setup required. On mainnet this does not apply, and the anonymous identity should never be used: it is shared by anyone, meaning ICP sent to it is publicly accessible and canisters deployed under it are uncontrolled.
+20. **Using the anonymous identity on mainnet.** The local network seeds all managed identities — including the anonymous identity, which is the default — with ICP and cycles on start, so local development works out of the box with no identity or cycles setup required. On mainnet this does not apply, and the anonymous identity should never be used: it is shared by anyone, meaning ICP sent to it is publicly accessible and canisters deployed under it are uncontrolled.
 
     Before deploying to mainnet, switch to a named identity:
     ```bash
@@ -307,15 +322,26 @@ canisters:
 
 ### Motoko canister
 
+The v5 recipe delegates compilation to `mops build`. Canister configuration (`main`, `candid`, `args`) moves from `icp.yaml` to `mops.toml`:
+
 ```yaml
+# icp.yaml
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: src/backend/main.mo
-        candid: backend.did  # optional — if specified, file must exist (auto-generated when omitted)
+      type: "@dfinity/motoko@v5.0.0"
 ```
+```toml
+# mops.toml
+[toolchain]
+moc = "1.9.0"
+
+[canisters.backend]
+main = "src/backend/main.mo"
+candid = "backend.did"  # optional — auto-generated to .mops/.build/ when omitted
+```
+
+The canister name (`backend`) must exactly match between `icp.yaml` and `mops.toml`. No `recipe.configuration` block is needed in `icp.yaml`.
 
 ### Asset canister (frontend)
 
@@ -358,7 +384,7 @@ canisters:
 | Recipe | Type string | Required config | Optional config |
 |--------|------------|-----------------|-----------------|
 | Rust | `@dfinity/rust@v3.2.0` | `package` | `candid`, `locked`, `shrink`, `compress` |
-| Motoko | `@dfinity/motoko@v4.1.0` | `main` | `candid`, `args`, `shrink`, `compress` |
+| Motoko | `@dfinity/motoko@v5.0.0` | — | `shrink`, `compress`, `metadata` |
 | Asset | `@dfinity/asset-canister@v2.2.1` | `dir` | `build`, `version` |
 | Prebuilt | `@dfinity/prebuilt@v1.0.0` | `wasm` | `sha256`, `candid`, `shrink`, `compress` |
 


### PR DESCRIPTION
## Summary

- Updates `@dfinity/motoko` recipe reference from `v4.1.0` → `v5.0.0` throughout the skill
- Moves Motoko canister config (`main`, `candid`, `args`) from `recipe.configuration` in `icp.yaml` to `[canisters.<name>]` in `mops.toml` — no `configuration:` block needed in `icp.yaml` anymore
- Updates Prerequisites, Motoko canister config section, recipes table, Pitfall 15 (failure mode), and Pitfall 16 (Candid generation for Motoko)
- Adds **Pitfall 17**: missing/mismatched `[canisters]` key in `mops.toml` causes `No Motoko canisters found in mops.toml configuration`; renumbers old 17–19 → 18–20
- Adds cross-reference to `mops-cli` skill for `[canisters]` config details (avoids duplication)
- Updates and adds evals for the affected cases

Closes #191

## Eval results

<details>
<summary>Eval results (3 cases, with-skill only)</summary>

```
Motoko project setup: WITH 7/7
  ✅ Uses icp (not dfx) commands throughout
  ✅ Configuration file is icp.yaml, NOT dfx.json
  ✅ Motoko canister uses @dfinity/motoko@v5.0.0 recipe with NO recipe.configuration block in icp.yaml
  ✅ Mentions installing ic-mops (npm i -g ic-mops)
  ✅ Shows a mops.toml with a [toolchain] section specifying a concrete moc version (not a placeholder like <version>)
  ✅ Shows a [canisters.backend] section in mops.toml with the main field pointing to the .mo entry point
  ✅ Does NOT put main or candid inside recipe.configuration in icp.yaml

Full-stack Motoko hello-world with React frontend: WITH 9/9
  ✅ icp.yaml has Motoko backend with @dfinity/motoko@v5.0.0 (no recipe.configuration block) and asset canister for frontend (version-pinned)
  ✅ Shows mops.toml with [toolchain] section (concrete moc version) and [canisters.backend] section with main field
  ✅ Shows how to generate the .did file using 'mops build backend && cp .mops/.build/backend.did ...' and specifies candid in mops.toml [canisters.backend], NOT in icp.yaml recipe.configuration
  ✅ Uses @icp-sdk/bindgen (>= 0.3.0) Vite plugin with correct didFile path pointing to the committed .did file
  ✅ Uses @icp-sdk/core (>= 5.0.0) — does NOT use a 0.x or 1.x version
  ✅ Uses ./src/bindings as outDir (not per-canister subdirectories) so imports are clean (e.g., ./bindings/backend)
  ✅ Dev server config only runs getDevServerConfig() during vite dev (command === 'serve'), not during vite build
  ✅ Mentions starting the local network and deploying backend before running vite dev
  ✅ Does NOT use dfx commands, dfx.json, .env files, or process.env for canister IDs

Adversarial: missing [canisters] section in mops.toml for Motoko v5: WITH 4/4
  ✅ Identifies that mops.toml is missing the [canisters.backend] section required by the v5 recipe
  ✅ Shows adding [canisters.backend] with a main field pointing to the .mo entry point
  ✅ Explains that the key (backend) must exactly match the canister name in icp.yaml
  ✅ Does NOT suggest adding main or candid inside recipe.configuration in icp.yaml
```
</details>