### PR TITLE
chore: sync mops-cli skill from upstream cli-v2.14.0

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -52,8 +52,8 @@ Upstream file paths are relative to `.agents/skills/<upstream-skill-name>/` in t
 ## mops-cli
 
 - **Upstream:** https://github.com/caffeinelabs/mops
-- **Tag:** cli-v2.13.2
-- **Commit:** 59d4c5f264ec4276bbe03d3df2d81fe3cd0e6352
-- **Last synced:** 2026-05-28
+- **Tag:** cli-v2.14.0
+- **Commit:** d448cdf90991c3164cafd8b6d1b39f433ad820b1
+- **Last synced:** 2026-06-16
 - **Upstream file:** `.agents/skills/mops-cli/SKILL.md`
 - **icskills-owned sections:** none — body is 1:1 with upstream; only frontmatter differs

--- a/evaluations/mops-cli.json
+++ b/evaluations/mops-cli.json
@@ -74,6 +74,16 @@
       ]
     },
     {
+      "name": "Replica tests pocket-ic pin",
+      "prompt": "I'm adding replica-mode tests (actor files / `// @testmode replica`) to my mops project and `mops test --mode replica` prints a warning about the dfx replica. How do I configure mops so it doesn't fall back to the deprecated dfx replica? Just the config change.",
+      "expected_behaviors": [
+        "Explains the warning is because `pocket-ic` is not pinned in `[toolchain]`, so mops falls back to the deprecated dfx replica",
+        "Pins `pocket-ic` in the `[toolchain]` section of mops.toml (e.g. `pocket-ic = \"12.0.0\"`) OR uses `mops toolchain use pocket-ic 12.0.0`",
+        "Pins a specific pocket-ic version rather than `latest` (latest may resolve to a version the bundled pic-js client doesn't support)",
+        "Notes the same pin also applies to `mops bench` and `mops watch`"
+      ]
+    },
+    {
       "name": "Adversarial: file path to mops check",
       "prompt": "I want to type-check my canister. My main file is at src/backend/main.mo. I'll run: mops check src/backend/main.mo. Is that right?",
       "expected_behaviors": [

--- a/skills/mops-cli/SKILL.md
+++ b/skills/mops-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: mops-cli
 description: "Manage Motoko projects with the mops CLI — toolchain pinning, dependency management, type-checking, building, and linting. Use when working with mops.toml, mops.lock, running mops commands, adding/removing packages, pinning moc or lintoko versions, checking or building canisters, configuring moc flags, or setting up a new Motoko project."
 license: Apache-2.0
-compatibility: "mops >= 2.13.0"
+compatibility: "mops >= 2.14.0"
 metadata:
   title: Mops CLI
   category: Infrastructure
@@ -14,7 +14,7 @@ Opinionated guide for Motoko projects. Covers project config, dependency managem
 
 ## Key Principles
 
-1. **No dfx** — always pin `moc` in `[toolchain]`. Use the newest `moc` version.
+1. **No dfx** — always pin `moc` in `[toolchain]`. Use the newest `moc` version. Pin `pocket-ic` too if you have replica tests or benchmarks (otherwise `mops test --mode replica`, `mops bench`, and `mops watch` fall back to the deprecated dfx replica and print a warning).
 2. **No `mo:base`** — it is deprecated. Always use `mo:core` (`import Array "mo:core/Array"`).
 3. **All config in `mops.toml`** — canisters, moc flags, toolchain versions, build settings.
 4. **Canister-centric workflow** — define all canisters in `[canisters]`; never pass file paths to `mops check`. Exception: library packages (no `[canisters]`) use file paths directly: `mops check src/**/*.mo`.
@@ -27,6 +27,7 @@ Opinionated guide for Motoko projects. Covers project config, dependency managem
 [toolchain]
 moc = "1.7.0"
 lintoko = "0.10.0"
+pocket-ic = "12.0.0"  # only if you have replica tests / benchmarks
 
 [dependencies]
 core = "2.5.0"
@@ -108,7 +109,7 @@ mops check -- -Werror     # treat warnings as errors
 
 **Always use canister names, not file paths.** Per-canister args from `mops.toml` are applied automatically.
 
-`--fix` applies machine-applicable fixes from both moc and lintoko in one pass.
+`--fix` applies machine-applicable fixes from both moc and lintoko in one pass. Concurrent `--fix` runs (across processes) serialize automatically via an advisory lock at `.mops/fix.lock` — safe to invoke from multiple agents on the same project.
 
 ### `mops build`
 
@@ -127,6 +128,7 @@ Produces `.wasm`, `.did`, and `.most` files in `[build].outputDir` (default `.mo
 mops toolchain use moc 1.7.0         # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
 mops toolchain use lintoko 0.10.0    # pin specific version
+mops toolchain use pocket-ic 12.0.0  # pin for replica tests / benchmarks (pin a specific version; `latest` may resolve to one the bundled pic-js client doesn't support)
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)
 mops toolchain update                # update all tools to latest
 mops toolchain bin moc               # print path to binary
@@ -154,6 +156,7 @@ mops remove base
 mops outdated             # list outdated dependencies (caret-bound)
 mops update               # update all within caret bound (no major-version crossing)
 mops update core          # update specific package within caret bound
+mops update --patch       # restrict to patch bumps only (mutually exclusive with --major)
 mops update --major       # allow updates that cross major versions
 mops sync                 # add missing / remove unused packages
 ```
@@ -171,6 +174,8 @@ mops test --mode wasi             # use wasmtime (for to_candid/from_candid)
 mops test --reporter verbose      # show Debug.print output
 mops test --watch                 # re-run on file changes
 ```
+
+Replica tests (actor files or `// @testmode replica`) use `pocket-ic` from `[toolchain]`. With no pin they fall back to the deprecated `dfx` replica (warning printed) — pin `pocket-ic` in `[toolchain]` to silence it. Same applies to `mops bench` and `mops watch`.
 
 ### `mops lint`
 


### PR DESCRIPTION
Syncs the `mops-cli` skill from upstream `caffeinelabs/mops` `cli-v2.13.2` → `cli-v2.14.0` (commit [`d448cdf9`](https://github.com/caffeinelabs/mops/commit/d448cdf90991c3164cafd8b6d1b39f433ad820b1)).

The `mops-cli` body is 1:1 with upstream (no icskills-owned sections), so all upstream additions are applied directly.

## Upstream changes applied

- **`pocket-ic` toolchain pinning** — pin `pocket-ic` in `[toolchain]` if you have replica tests or benchmarks; otherwise `mops test --mode replica`, `mops bench`, and `mops watch` fall back to the deprecated dfx replica and print a warning. Applied to Key Principles, the minimal `mops.toml`, `mops toolchain use`, and the `mops test` section.
- **`.mops/fix.lock`** — concurrent `--fix` runs serialize automatically via an advisory lock; safe to invoke from multiple agents on the same project.
- **`mops update --patch`** — restrict to patch bumps only (mutually exclusive with `--major`).

## Other changes

- Bumped `compatibility` to `mops >= 2.14.0` (new features require it).
- Updated `.claude/upstream.md` — tag, full commit SHA, last-synced date.
- Added a `Replica tests pocket-ic pin` eval case for the new (and easily-missed) fallback pitfall.

## Eval results

<details>
<summary>New eval case — <code>Replica tests pocket-ic pin</code> (with skill)</summary>

```
WITH skill: 4/4 passed
  ✅ Explains the warning is because `pocket-ic` is not pinned in `[toolchain]`, so mops falls back to the deprecated dfx replica
  ✅ Pins `pocket-ic` in the `[toolchain]` section of mops.toml (e.g. `pocket-ic = "12.0.0"`) OR uses `mops toolchain use pocket-ic 12.0.0`
  ✅ Pins a specific pocket-ic version rather than `latest` (latest may resolve to a version the bundled pic-js client doesn't support)
  ✅ Notes the same pin also applies to `mops bench` and `mops watch`
```

</details>

Closes #220