### PR TITLE
fix(site): serve skill reference files at /skills/<slug>/references/<path>

### DIFF
--- a/src/pages/skills/[slug]/references/[...path].ts
+++ b/src/pages/skills/[slug]/references/[...path].ts
@@ -11,10 +11,17 @@ function getContentType(path: string): string {
 
 export async function getStaticPaths() {
   const entries = await getSkillFileEntries();
-  return entries.map((e) => ({
-    params: { slug: e.name, path: e.path },
-    props: { content: e.content, filePath: e.path },
-  }));
+  // This route already lives under `references/`, so the catch-all `[...path]`
+  // must be the path *relative to* `references/`. Passing the full `references/<...>`
+  // path doubles the segment, emitting `/skills/<slug>/references/references/<...>`
+  // and 404ing the documented `/skills/<slug>/references/<...>` URL.
+  const prefix = 'references/';
+  return entries
+    .filter((e) => e.path.startsWith(prefix))
+    .map((e) => ({
+      params: { slug: e.name, path: e.path.slice(prefix.length) },
+      props: { content: e.content, filePath: e.path },
+    }));
 }
 
 export const GET: APIRoute = ({ props }) => {


### PR DESCRIPTION
## Problem

Every skill's `SKILL.md` links its reference files with a **relative** path — e.g. `[references/examples.md](references/examples.md)` — which resolves to `/skills/<slug>/references/<file>`. That URL **404s for every skill**:

- `…/skills/motoko/references/examples.md` → 404
- `…/skills/icp-cli/references/dfx-migration.md` → 404
- `…/skills/caffeine-app/references/frontend-template.md` → 404

The files *are* built, but only at the **doubled** path `…/skills/<slug>/references/references/<file>` (which returns 200), plus the `/.well-known/skills/<name>/references/<file>` route.

This means an agent (or reader) that fetches a raw `SKILL.md` and follows its relative reference link hits a 404.

Confirmed live across **all** skills that ship references — every one 404s at the single path and 200s under `.well-known`:

| reference file | `/skills/<slug>/references/<file>` | `/.well-known/…` |
|---|---|---|
| `caffeine-app/references/frontend-template.md` | 404 | 200 |
| `icp-cli/references/binding-generation.md` | 404 | 200 |
| `icp-cli/references/dev-server.md` | 404 | 200 |
| `icp-cli/references/dfx-migration.md` | 404 | 200 |
| `motoko/references/examples.md` | 404 | 200 |

## Cause

`src/pages/skills/[slug]/references/[...path].ts` already lives under a literal `references/` path segment, but its `getStaticPaths` passes the **full** `references/<path>` (straight from `getSkillFileEntries`) as the catch-all `[...path]` param — so it emits `/skills/<slug>/references/references/<path>`.

The `/.well-known/skills/[name]/[...path].ts` route works because it has no literal `references/` segment (the full path supplies it). Pre-existing since #171.

## Fix

Filter to `references/` entries and pass the path **relative to** `references/`, so the route emits the documented `/skills/<slug>/references/<file>`. One file changed.

## Verification

Ran `astro build` and inspected `dist/`:

- `dist/skills/caffeine-app/references/frontend-template.md` ✅ (correct content) — and likewise `dist/skills/icp-cli/references/*.md` and `dist/skills/motoko/references/examples.md`.
- **No** `references/references/*` anywhere in `dist` (0 doubled dirs).
- `/.well-known/skills/<name>/references/...` output unchanged.

## Scope / completeness

Audited every non-`SKILL.md` file shipped by every skill, to confirm this covers all broken links and introduces no regressions:

- **All three skills that ship a `references/` dir** (`caffeine-app`, `icp-cli`, `motoko`) were affected and are fixed — each `references/*` file now resolves at `/skills/<slug>/references/<file>` in the build.
- The only **other** shipped files are `scripts/` in two skills, and neither uses the `/skills/<slug>/...` path: `autosync-ic-skills` fetches its script via the `/.well-known/skills/<name>/scripts/...` URL (verified 200), and `canhelp` runs `./scripts/...` locally (never fetched). Both are unaffected.
- The route stays intentionally scoped to `references/`; non-reference files (e.g. `scripts/`) remain served by the `/.well-known/skills/<name>/...` catch-all, so their behaviour is unchanged.
- The only local markdown links in any `SKILL.md` point at `references/...`; cross-skill links use `/skills/<slug>/SKILL.md` (unaffected).
