### PR TITLE
feat(icp-cli): route web identity flows to specialized skills

### DIFF
--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -447,17 +447,12 @@ const backendId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
   ```
 Note: variables are only updated for canisters at deploy time. When adding a new canister, run `icp deploy` (without specifying a canister name) to update all canisters with the complete ID set.
 
-### Using the cli with a web identity
+### Web identity flows
 
-Users can link a web identity and use it with icp-cli. This is This is useful to make calls to a canister from the cli using the same identity you would get by logging in through the web UI.
+Two specialized skills cover `icp identity link web`. Load the right one for the task — both document the stdin "Press Enter" block, the browser sign-in step, and their flag-specific pitfalls:
 
-```
-# Sign in as your NNS identity
-icp identity link web nns-identity --app nns.ic0.app
-
-# Sign in as your OISY identity
-icp identity link web oisy-identity --app oisy.com
-```
+- `deploy-to-cloud-engine` — link the CLI to a cloud engine console with `--auth <console-origin>`, then deploy to the engine's subnet
+- `agent-web-identity` — obtain a delegation for an app-specific principal with `--app <domain>`, then make canister calls as the user
 
 ## Additional References
 


### PR DESCRIPTION
## Summary

Resolves #218. Replaces the thin web-identity stub in `skills/icp-cli/SKILL.md` with a routing pointer to the two specialized skills that now own `icp identity link web` (both prerequisites — #212 `deploy-to-cloud-engine` and #217 `agent-web-identity` — have merged).

The old stub had two bare command examples with no `--auth` vs `--app` distinction, no stdin "Press Enter" warning, and no pitfalls — worse than nothing, since an agent could pick them up and run the command blind.

## Change

```diff
-### Using the cli with a web identity
-...two bare `icp identity link web ... --app` examples...
+### Web identity flows
+- `deploy-to-cloud-engine` — link the CLI to a cloud engine console with `--auth <console-origin>`, then deploy to the engine's subnet
+- `agent-web-identity` — obtain a delegation for an app-specific principal with `--app <domain>`, then make canister calls as the user
```

## Verification

- Confirmed each target skill's actual flag against its source:
  - `deploy-to-cloud-engine` uses `--auth <console-origin>` ✓
  - `agent-web-identity` uses `--app <domain>` ✓
- `npm run validate` → all 26 skills pass (only pre-existing unrelated warnings).

## Evals

No case in `evaluations/icp-cli.json` referenced the removed content, so nothing breaks. No new cases added: this is a pure scope reduction with no new agent-facing behavior to regression-test, and a `should_not_trigger` guard for cloud-engine deploys would fight icp-cli's intentionally broad description ("deploying any IC project", "identity management").

Closes #218