### PR TITLE
cycles-management: add pitfall for icp cycles transfer vs icp canister top-up

### DIFF
--- a/evaluations/cycles-management.json
+++ b/evaluations/cycles-management.json
@@ -1,0 +1,39 @@
+{
+  "skill": "cycles-management",
+  "description": "Evaluation cases for the cycles-management skill. Tests whether agents use icp canister top-up (not icp cycles transfer) to fund canisters, and correctly explain why cycles transfer does not work for this purpose.",
+  "output_evals": [
+    {
+      "name": "Top up a mainnet canister",
+      "prompt": "My canister on mainnet is almost out of cycles. What's the command to add more cycles to it? Just the command and a one-line explanation, no need to cover freezing thresholds.",
+      "expected_behaviors": [
+        "Uses 'icp canister top-up <canister> --amount <N> -e ic' (or -n ic with a principal)",
+        "Does NOT suggest 'icp cycles transfer' to fund the canister",
+        "Mentions that --amount supports k/m/b/t suffixes, or shows a concrete amount like 600b or 1000000000000"
+      ]
+    },
+    {
+      "name": "Cycles transfer does not fund a canister",
+      "prompt": "I ran `icp cycles transfer 600000000000 <canister-principal> -n ic` to fund my canister but `icp canister status` still shows a low balance and the canister is about to freeze. What went wrong?",
+      "expected_behaviors": [
+        "Explains that 'icp cycles transfer' moves cycles to the recipient's cycles-ledger balance, not the canister's execution/compute cycle balance",
+        "States that the canister cannot use cycles sent this way",
+        "Recommends 'icp canister top-up <canister> --amount <N> -e ic' as the correct fix",
+        "Does NOT suggest that running 'icp cycles transfer' again (to the canister or elsewhere) will move the parked cycles into the canister's execution balance -- only 'icp canister top-up' increases it"
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I top up my canister with more cycles?",
+      "My canister ran out of cycles and froze, what do I do?",
+      "I sent cycles to my canister's principal with icp cycles transfer but it's still low on cycles",
+      "How do I fund a canister on mainnet before deploying?"
+    ],
+    "should_not_trigger": [
+      "Add a wallet connect button for ICRC token transfers in my dapp",
+      "How do I integrate Internet Identity login into my frontend?",
+      "Implement ICRC-1 transfer logic inside my canister"
+    ]
+  }
+}

--- a/skills/cycles-management/SKILL.md
+++ b/skills/cycles-management/SKILL.md
@@ -44,6 +44,8 @@ The Management Canister (`aaaaa-aa`) is a virtual canister -- it does not exist 
 
 6. **Using ExperimentalCycles in mo:core** -- In mo:core 2.0, the module is renamed to `Cycles`. `import ExperimentalCycles "mo:base/ExperimentalCycles"` will fail. Use `import Cycles "mo:core/Cycles"`.
 
+7. **Using `icp cycles transfer` to fund a canister** -- `icp cycles transfer <amount> <principal>` moves cycles between cycles-ledger balances, the same as a token transfer between accounts. Passing a canister's principal as the recipient credits that principal's cycles-ledger balance, not the canister's actual execution/compute cycle balance -- `icp canister status` will not show the cycles as received, and the canister keeps burning down its real balance toward freezing with no indication anything went wrong. Use `icp canister top-up <canister> --amount <N> -e ic` instead, which deposits cycles directly onto the canister via the management canister. See "Top Up a Canister" below for both commands side by side.
+
 ## Implementation
 
 ### Motoko
@@ -262,6 +264,16 @@ icp canister top-up backend --amount 1000000000000 -e ic
 icp cycles mint --icp 1.0 -e ic
 icp canister top-up backend --amount 1000000000000 -e ic
 ```
+
+```bash
+# CORRECT -- funds the canister's execution balance:
+icp canister top-up backend --amount 600b -e ic
+
+# WRONG -- sends to the recipient's cycles-ledger balance, canister cannot use it:
+icp cycles transfer 600000000000 <canister-principal> -n ic
+```
+
+`--amount` on `icp canister top-up` accepts `k`/`m`/`b`/`t` suffixes (thousand/million/billion/trillion).
 
 ### Create a Canister via icp
 


### PR DESCRIPTION
## Summary
- Adds pitfall #7 to `cycles-management`: `icp cycles transfer` credits the recipient's cycles-ledger balance, not a canister's execution/compute cycle balance — pointing it at a canister principal silently fails to fund the canister, with no error and no visible change in `icp canister status`.
- Adds a correct/wrong command comparison to the "Top Up a Canister" section.
- Adds `evaluations/cycles-management.json` (did not previously exist) with 2 output evals and trigger evals covering this distinction.

Found via a real incident: made this exact mistake twice in a row against a live mainnet canister before realizing `icp canister top-up` was the correct command.

## Test plan
- [x] `npm run validate` — 26 skills validated, all passed, no new warnings
- [x] Eval 1 "Top up a mainnet canister" — WITH skill 3/3, WITHOUT skill 1/3
- [x] Eval 2 "Cycles transfer does not fund a canister" — WITH skill 4/4, WITHOUT skill 3/4
- [x] Trigger evals — should-trigger 4/4, should-not-trigger 3/3

<details>
<summary>Eval 1: Top up a mainnet canister</summary>

```
WITH skill: 3/3 passed
  ✅ Uses 'icp canister top-up <canister> --amount <N> -e ic' (or -n ic with a principal)
  ✅ Does NOT suggest 'icp cycles transfer' to fund the canister
  ✅ Mentions that --amount supports k/m/b/t suffixes, or shows a concrete amount like 600b or 1000000000000

WITHOUT skill: 1/3 passed
  ❌ Uses 'icp canister top-up <canister> --amount <N> -e ic' (or -n ic with a principal)
     → Uses the old dfx tool ('dfx ledger top-up' / 'dfx cycles top-up') rather than 'icp canister top-up -e ic'.
  ✅ Does NOT suggest 'icp cycles transfer' to fund the canister
  ❌ Mentions that --amount supports k/m/b/t suffixes, or shows a concrete amount like 600b or 1000000000000
     → Uses a generic placeholder '<ICP>' and never mentions suffixes or a concrete cycle amount.
```
</details>

<details>
<summary>Eval 2: Cycles transfer does not fund a canister</summary>

```
WITH skill: 4/4 passed
  ✅ Explains that 'icp cycles transfer' moves cycles to the recipient's cycles-ledger balance, not the canister's execution/compute cycle balance
  ✅ States that the canister cannot use cycles sent this way
  ✅ Recommends 'icp canister top-up <canister> --amount <N> -e ic' as the correct fix
  ✅ Does NOT suggest that running 'icp cycles transfer' again will move the parked cycles into the canister's execution balance

WITHOUT skill: 3/4 passed
  ✅ Explains that 'icp cycles transfer' moves cycles to the recipient's cycles-ledger balance, not the canister's execution/compute cycle balance
  ✅ States that the canister cannot use cycles sent this way
  ❌ Recommends 'icp canister top-up <canister> --amount <N> -e ic' as the correct fix
     → Suggests 'icp cycles top-up <canister-id> 600000000000 -n ic' — wrong subcommand/flags.
  ✅ Does NOT suggest that running 'icp cycles transfer' again will move the parked cycles into the canister's execution balance
```
</details>

<details>
<summary>Trigger evals</summary>

```
Should trigger: 4/4 correct
  ✅ "How do I top up my canister with more cycles?"
  ✅ "My canister ran out of cycles and froze, what do I do?"
  ✅ "I sent cycles to my canister's principal with icp cycles transfer but it's still low on cycles"
  ✅ "How do I fund a canister on mainnet before deploying?"

Should NOT trigger: 3/3 correct
  ✅ "Add a wallet connect button for ICRC token transfers in my dapp"
  ✅ "How do I integrate Internet Identity login into my frontend?"
  ✅ "Implement ICRC-1 transfer logic inside my canister"
```
</details>