### PR TITLE
Remove security team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,6 @@
 /skills/multi-canister/          @derlerd-dfinity
 /skills/stable-memory/           @derlerd-dfinity
 /skills/vetkd/                   @andreacerulli
-/skills/canister-security/       @dfinity/security
 /skills/wallet-integration/      @dfinity/oisy
 /skills/ic-dashboard/            @jp-dfinity
 


### PR DESCRIPTION
Removes the `@dfinity/security` team from `.github/CODEOWNERS`.
- Co-owners on each rule are kept; rules left with no owner are removed.
- Section comments left unchanged.