### PR TITLE
fix: repair .zip download and serve raw SKILL.md without attribution comment

### DIFF
--- a/src/pages/.well-known/skills/[name]/SKILL.zip.ts
+++ b/src/pages/.well-known/skills/[name]/SKILL.zip.ts
@@ -1,5 +1,7 @@
 // Serves /.well-known/skills/<name>/SKILL.zip at build time
-// Only generated for multi-file skills (SKILL.md + references)
+// Generated for every skill so the download link always resolves. Single-file
+// skills produce a zip containing just SKILL.md; multi-file skills bundle
+// SKILL.md plus their references/ tree.
 import type { APIRoute } from 'astro';
 import archiver from 'archiver';
 import { readdirSync, readFileSync, statSync } from 'fs';
@@ -58,7 +60,7 @@ async function buildZip(skillDir: string): Promise<Buffer> {
 
 let _cache: SkillZipData[] | null = null;
 
-async function loadMultiFileSkillZips(): Promise<SkillZipData[]> {
+async function loadSkillZips(): Promise<SkillZipData[]> {
   if (_cache) return _cache;
 
   const dirs = readdirSync(SKILLS_DIR)
@@ -76,9 +78,6 @@ async function loadMultiFileSkillZips(): Promise<SkillZipData[]> {
 
   for (const dir of dirs) {
     const skillDir = join(SKILLS_DIR, dir);
-    const files = collectFilePaths(skillDir, skillDir);
-    if (files.length <= 1) continue; // skip single-file skills
-
     const content = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
     const name = parseName(content);
     if (!name) continue;
@@ -92,7 +91,7 @@ async function loadMultiFileSkillZips(): Promise<SkillZipData[]> {
 }
 
 export async function getStaticPaths() {
-  const skills = await loadMultiFileSkillZips();
+  const skills = await loadSkillZips();
   return skills.map((s) => ({
     params: { name: s.name },
     props: { zipBuffer: s.zipBuffer },

--- a/src/pages/skills/[slug]/SKILL.md.ts
+++ b/src/pages/skills/[slug]/SKILL.md.ts
@@ -1,11 +1,11 @@
 // Raw markdown endpoint: /skills/{slug}/SKILL.md returns the unmodified SKILL.md
-// bytes (frontmatter + body). Served with text/markdown so LLM crawlers can
-// parse it natively. An attribution header line is prepended as a markdown
-// comment so the origin stays visible even if the file is copy-pasted.
+// bytes (frontmatter + body), byte-identical to the repo file. Served with
+// text/markdown so LLM crawlers can parse it natively. Provenance is carried in
+// the X-Content-Source and X-License response headers, not in the body.
 
 import type { APIRoute } from 'astro';
 import { getAllSkills, getSkillGitInfo, getSkillRawMarkdown, githubCommitUrl } from '../../../lib/skills';
-import { SITE, absUrl } from '../../../lib/site';
+import { SITE } from '../../../lib/site';
 
 export async function getStaticPaths() {
   const skills = await getAllSkills();
@@ -19,13 +19,10 @@ export const GET: APIRoute = async ({ props }) => {
   if (!skill) return new Response('Not found', { status: 404 });
 
   const body = await getSkillRawMarkdown(skill);
-  const { sha, updatedAt } = await getSkillGitInfo(skill);
+  const { sha } = await getSkillGitInfo(skill);
   const sourceUrl = githubCommitUrl(slug, sha);
-  const attribution =
-    `<!-- source: ${absUrl(`/skills/${slug}/`)} | origin: ${sourceUrl} | ` +
-    `publisher: ${SITE.author.name} | license: ${SITE.license.spdx} | updated: ${updatedAt} -->\n`;
 
-  return new Response(attribution + body, {
+  return new Response(body, {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
       'X-Content-Source': sourceUrl,


### PR DESCRIPTION
Fixes two regressions on the skill delivery endpoints.

## 1. `.zip` download returned 404 for most skills

The skill detail page shows an unconditional **Download .zip** link for every skill (introduced in #169), but the zip endpoint only generated a file for *multi-file* skills. Single-file skills (the majority — e.g. `agent-web-identity`) therefore linked to a zip that was never built, returning 404.

**Fix:** drop the multi-file guard in `SKILL.zip.ts` so a zip is generated for every skill. Single-file skills get a zip containing just `SKILL.md`; multi-file skills continue to bundle `SKILL.md` plus their `references/` tree.

## 2. Raw `SKILL.md` was prefixed with an HTML attribution comment

The `/skills/<name>/SKILL.md` endpoint prepended an HTML comment with source/origin/publisher/license/updated metadata (added in #171), so the served markdown was not byte-identical to the repo file.

**Fix:** serve the raw `SKILL.md` bytes unchanged. Provenance is still carried in the `X-Content-Source` and `X-License` response headers, so nothing is lost for machine consumers.

## Verification

Ran `npm run build` and inspected `dist/`:

<details>
<summary>Build output checks</summary>

- **26 zips generated** — one per skill (was: only 5 multi-file skills).
- `agent-web-identity` (single-file) zip contains just `SKILL.md`.
- `motoko` (multi-file) zip still contains `SKILL.md` + `references/examples.md`.
- Served `dist/skills/agent-web-identity/SKILL.md` starts at `---` (no comment) and is **byte-identical** to `skills/agent-web-identity/SKILL.md`.

</details>

This is a `src/`-only change (site delivery endpoints); no skill content changed, so no skill evals apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)