### PR TITLE
docs(deploy-to-cloud-engine): proxy-canister usage for cross-subnet calls

### DIFF
--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-cloud-engine
-description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), running `icp deploy` against that subnet, tagging the canisters with `__META_*` environment variables so the engine console shows a named app with labelled backend/frontend canisters and an app icon, and (for engine apps that must make cross-subnet cycle-bearing calls such as the exchange-rate canister, threshold ECDSA/Schnorr, or vetKD) deploying a funded proxy canister from the console and calling targets through it. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, linking the icp CLI to an engine console, giving a deployed app a name or icon in the console, or needs an engine canister to reach the exchange-rate canister / threshold ECDSA/Schnorr / vetKD or make another cross-subnet cycle-bearing call (proxy canister). Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing general canister application logic."
+description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine): verify the icp CLI, link the console identity with `icp identity link web` (console origin defaults to https://opencloud.org), obtain the engine's subnet id, run `icp deploy` against that subnet, and tag canisters with `__META_*` environment variables for a named app with labelled canisters and an icon. Also covers deploying and calling a funded proxy canister when an engine app must make cross-subnet cycle-bearing calls (the exchange-rate canister, threshold ECDSA/Schnorr, vetKD). Use when shipping an app to a cloud engine; on mention of OpenCloud, an engine subnet id, or linking the icp CLI to an engine console; when naming or adding an icon to a console app; or when an engine canister needs a cross-subnet cycle-bearing call (proxy canister). Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing general canister logic."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.3.0 (commands verified against 0.3.0), a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
@@ -187,12 +187,12 @@ A cloud engine runs on a **`CloudEngine` subnet**, which the IC protocol restric
 - **vetKD** (`vetkd_derive_key`, `vetkd_public_key`),
 - any other canister you must call **with cycles** across a subnet boundary.
 
-The workaround is a **proxy canister**: a small canister deployed on a normal Application subnet and funded with cycles. Your engine canister makes a cheap, cycle-less, bounded-wait call to the proxy; the proxy re-issues the call locally **with the cycles attached** and relays the raw reply back. Same-subnet calls and ordinary cycle-less calls do **not** need it — reach for the proxy only for the cross-subnet, cycle-bearing case above.
+The workaround is a **proxy canister**: deployed on a normal Application subnet and funded with cycles. Your engine canister makes a cheap, cycle-less, bounded-wait call to the proxy, which re-issues it locally **with the cycles attached** and relays the raw reply back. Same-subnet or cycle-less calls do **not** need it.
 
 ### Deploy and fund the proxy (from the console, not the CLI)
 
 1. Open the engine console → **Applications** (App Center) → **Proxy canisters**.
-2. **Deploy a proxy**, choose an initial balance (minimum $5), and optionally enable **automatic top-up** so it recharges from the saved card when the balance runs low. You can change the top-up setting, top up manually, or delete the proxy later from the same table.
+2. **Deploy a proxy**, choose an initial balance (minimum $5), and optionally enable **automatic top-up** to recharge from the saved card when it runs low. You can top up manually or delete the proxy later from the same table.
 3. Copy the **proxy canister id** shown in the table — the app calls this id.
 
 The proxy authorizes callers whose principal falls in **the engine's canister-id range**, so every canister deployed to the engine may use it with no extra configuration.
@@ -223,17 +223,7 @@ service : {
 Motoko sketch (Rust is analogous with `candid::encode_one` / `decode_one`):
 
 ```motoko
-let proxy = actor ("<proxy-canister-id>") : actor {
-  proxy : ({ canister_id : Principal; method : Text; args : Blob; cycles : Nat }) -> async {
-    #Ok : { result : Blob };
-    #Err : {
-      #InsufficientCycles : { available : Nat; required : Nat };
-      #CallFailed : { reason : Text };
-      #UnauthorizedUser;
-    };
-  };
-};
-
+// `proxy` is an actor typed to the candid interface above.
 let arg = to_candid (request);                    // encode the TARGET method's argument
 let res = await proxy.proxy({
   canister_id = xrcPrincipal;
@@ -242,7 +232,7 @@ let res = await proxy.proxy({
   cycles = 1_000_000_000;                         // the XRC fee the proxy forwards
 });
 switch (res) {
-  case (#Ok { result }) { let ?reply = from_candid (result) else { /* decode error */ }; /* … */ };
+  case (#Ok { result }) { let ?reply = from_candid (result) else return; /* … */ };
   case (#Err e) { /* InsufficientCycles | CallFailed | UnauthorizedUser */ };
 };
 ```

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-cloud-engine
-description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), running `icp deploy` against that subnet, and tagging the canisters with `__META_*` environment variables so the engine console shows a named app with labelled backend/frontend canisters and an app icon. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, linking the icp CLI to an engine console, or giving a deployed app a name or icon in the console. Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing canister code."
+description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine, administered from a web console). Covers verifying the icp CLI, linking the user's console identity to the CLI with `icp identity link web`, defaulting the console origin to https://opencloud.org (overridable when the user signs in to a different console), obtaining the engine's subnet id (asking the user when it is unknown), running `icp deploy` against that subnet, tagging the canisters with `__META_*` environment variables so the engine console shows a named app with labelled backend/frontend canisters and an app icon, and (for engine apps that must make cross-subnet cycle-bearing calls such as the exchange-rate canister, threshold ECDSA/Schnorr, or vetKD) deploying a funded proxy canister from the console and calling targets through it. Use when a developer wants to ship an app to their cloud engine, mentions a cloud engine, OpenCloud, an engine subnet id, linking the icp CLI to an engine console, giving a deployed app a name or icon in the console, or needs an engine canister to reach the exchange-rate canister / threshold ECDSA/Schnorr / vetKD or make another cross-subnet cycle-bearing call (proxy canister). Do NOT use for a general mainnet deploy with no specific engine or subnet (use the icp-cli skill) or for writing general canister application logic."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.3.0 (commands verified against 0.3.0), a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
@@ -178,6 +178,82 @@ icp deploy -e ic --subnet <subnet-id>
 
 Report the deployed canister ids (and the frontend URL, if any) back to the user.
 
+## Cross-subnet calls via a proxy canister (only if the app needs them)
+
+A cloud engine runs on a **`CloudEngine` subnet**, which the IC protocol restricts: a canister on it **cannot** send a cross-subnet (XNet) message that carries **attached cycles** or that is a **guaranteed-response (unbounded-wait)** call. So an engine canister **cannot call these directly**, because they live on other subnets and require cycles:
+
+- the **exchange-rate canister** (XRC),
+- **threshold ECDSA / Schnorr** signing (`sign_with_ecdsa`, `sign_with_schnorr`) and their public-key methods,
+- **vetKD** (`vetkd_derive_key`, `vetkd_public_key`),
+- any other canister you must call **with cycles** across a subnet boundary.
+
+The workaround is a **proxy canister**: a small canister deployed on a normal Application subnet and funded with cycles. Your engine canister makes a cheap, cycle-less, bounded-wait call to the proxy; the proxy re-issues the call locally **with the cycles attached** and relays the raw reply back. Same-subnet calls and ordinary cycle-less calls do **not** need it — reach for the proxy only for the cross-subnet, cycle-bearing case above.
+
+### Deploy and fund the proxy (from the console, not the CLI)
+
+1. Open the engine console → **Applications** (App Center) → **Proxy canisters**.
+2. **Deploy a proxy**, choose an initial balance (minimum $5), and optionally enable **automatic top-up** so it recharges from the saved card when the balance runs low. You can change the top-up setting, top up manually, or delete the proxy later from the same table.
+3. Copy the **proxy canister id** shown in the table — the app calls this id.
+
+The proxy authorizes callers whose principal falls in **the engine's canister-id range**, so every canister deployed to the engine may use it with no extra configuration.
+
+### Call through the proxy from your canister
+
+Instead of calling the target canister directly, call the proxy's `proxy` method with the target id, method name, candid-encoded argument bytes, and the cycles to attach. Its candid interface:
+
+```candid
+type ProxyArgs = record { canister_id : principal; method : text; args : blob; cycles : nat };
+type ProxySucceed = record { result : blob };
+type ProxyError = variant {
+  InsufficientCycles : record { available : nat; required : nat };
+  CallFailed : record { reason : text };
+  UnauthorizedUser;
+};
+type ProxyResult = variant { Ok : ProxySucceed; Err : ProxyError };
+service : {
+  proxy : (ProxyArgs) -> (ProxyResult);
+  get_allowed_ranges : () -> (vec record { start : principal; end : principal }) query;
+};
+```
+
+- `args` is the **candid-encoded argument of the _target_ method** (you encode it); `result` is the target's **raw reply bytes** (you decode it).
+- `cycles` is what the proxy attaches to the relayed call — size it to what the target charges (e.g. the XRC or signing fee). Do **not** attach cycles to the outer `proxy` call itself; the engine subnet forbids that and it is unnecessary.
+- Handle `ProxyError`: `InsufficientCycles` means the proxy's balance is too low (top it up in the console), `UnauthorizedUser` means the caller is outside the engine's range, `CallFailed` carries the downstream reject reason.
+
+Motoko sketch (Rust is analogous with `candid::encode_one` / `decode_one`):
+
+```motoko
+let proxy = actor ("<proxy-canister-id>") : actor {
+  proxy : ({ canister_id : Principal; method : Text; args : Blob; cycles : Nat }) -> async {
+    #Ok : { result : Blob };
+    #Err : {
+      #InsufficientCycles : { available : Nat; required : Nat };
+      #CallFailed : { reason : Text };
+      #UnauthorizedUser;
+    };
+  };
+};
+
+let arg = to_candid (request);                    // encode the TARGET method's argument
+let res = await proxy.proxy({
+  canister_id = xrcPrincipal;
+  method = "get_exchange_rate";
+  args = arg;
+  cycles = 1_000_000_000;                         // the XRC fee the proxy forwards
+});
+switch (res) {
+  case (#Ok { result }) { let ?reply = from_candid (result) else { /* decode error */ }; /* … */ };
+  case (#Err e) { /* InsufficientCycles | CallFailed | UnauthorizedUser */ };
+};
+```
+
+### Threshold keys through the proxy (read this before deriving keys)
+
+For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, `sign_with_schnorr`, `schnorr_public_key`, `vetkd_derive_key`, `vetkd_public_key`), the proxy **isolates the derivation per calling canister**: it prefixes the caller's (unforgeable) principal into the `derivation_path` (ECDSA/Schnorr) or `context` (vetKD), and forces `canister_id = None` on the `*_public_key` calls. Two consequences:
+
+- Each engine canister behind the proxy gets its **own** key namespace — one canister cannot read or sign with another's key.
+- The key/address obtained **through the proxy differs** from what a direct management-canister call would give (the injected prefix changes the derivation). Always fetch the public key and sign **through the same proxy**, consistently, so the address you derive matches the key you can sign for. Do not mix direct and proxied key calls for one identity.
+
 ## Common Pitfalls
 
 1. **Sign-in not completed.** Running `icp identity link web …` but not finishing the Internet Identity sign-in in the browser leaves the CLI unlinked; later commands fail with authorization errors. Re-run and wait for the user to confirm the browser flow finished. If no browser ever opened, the command is stalled at the "Press Enter to log in" prompt — relaunch with a piped newline, `printf '\n' | icp identity link web …`, never `< /dev/null` (see Step 1).
@@ -189,6 +265,10 @@ Report the deployed canister ids (and the frontend URL, if any) back to the user
 7. **Wrong `__META_MAIN_CANISTER` value.** It is matched as the exact string `"true"`. A boolean, `"True"`, or marking more than one canister means no (or the wrong) "Open" button. Mark exactly one entry-point canister.
 8. **Inventing an icon variable.** The icon variable is `__META_ICON_PATH` (a path resolved against `__META_BASE_URL`). Do not guess `__META_ICON`, `__META_LOGO`, or `__META_ICON_LINK` — they are ignored, so the icon silently never appears.
 9. **Icon set on the wrong canister, or without a base URL.** The icon is read only from the **main** canister and needs **both** `__META_BASE_URL` (a valid absolute `https://` URL) and `__META_ICON_PATH`. Setting the icon path on a side canister, omitting the base URL, or giving a non-https / `data:` base means no icon renders. (The "Open" button still works — it falls back to the main canister's gateway URL — so a bad base URL costs the icon and the custom Open URL, not the button.)
+10. **Calling the XRC / threshold signing / vetKD directly from an engine canister.** These are cross-subnet, cycle-bearing calls, which a `CloudEngine`-subnet canister cannot make — the call is rejected. Route them through a funded proxy canister (see "Cross-subnet calls via a proxy canister"). Plain same-subnet or cycle-less calls do not need the proxy.
+11. **Attaching cycles to the outer `proxy` call.** The engine subnet forbids cycle-bearing cross-subnet messages — that is the whole reason for the proxy. Put the cycles inside `ProxyArgs.cycles` (the proxy attaches them locally); never `with_cycles` on the call to `proxy` itself.
+12. **Proxy out of cycles, or funded from the CLI.** A `ProxyError::InsufficientCycles` means the proxy's balance is spent — top it up (or enable auto top-up) on the console's Proxy canisters page. Deploying and funding the proxy is a console action, not an `icp` command.
+13. **Expecting a direct-call key through the proxy.** Threshold-key derivation via the proxy is caller-isolated, so the derived key/address is not the same as a direct management-canister call. Fetch the public key and sign through the proxy consistently; do not mix direct and proxied key calls for the same identity.
 
 ## Related Skills
 


### PR DESCRIPTION
## What

Adds a **Cross-subnet calls via a proxy canister** section to the `deploy-to-cloud-engine` skill, plus four pitfalls and a widened `description` so the skill triggers on proxy / XRC / threshold-key questions.

## Why

A cloud engine runs on a `CloudEngine` subnet, which the protocol forbids from sending cross-subnet messages that carry cycles or are guaranteed-response. So an engine canister **cannot directly call** the exchange-rate canister, threshold ECDSA/Schnorr, or vetKD — all of which are cross-subnet and cycle-bearing. Agents writing engine apps hit this and need the proxy-canister workaround, which was previously undocumented in the skill.

## Contents

- When a proxy is (and isn't) needed.
- Deploying + funding a proxy from the engine console (Applications → Proxy canisters; initial balance, optional auto top-up).
- Calling targets through the proxy's `proxy` method — full candid interface + Motoko sketch, with `ProxyArgs.cycles` semantics and `ProxyError` handling.
- Threshold-key caveat: the proxy caller-isolates key derivation, so a key/address obtained through the proxy differs from a direct management-canister call — fetch the public key and sign through the same proxy consistently.
- Pitfalls 10–13: direct cross-subnet calls, attaching cycles to the outer `proxy` call, running the proxy dry / funding via CLI, and expecting a direct-call key through the proxy.

## Validation

- `node scripts/check-project.js` passes (pre-existing warnings only, unrelated skills).
- SKILL.md is 276 lines (< 500).
- `skill-validator` not run (not installed in my environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)