### PR TITLE
chore: sync mops-cli skill from upstream cli-v2.16.1

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -52,8 +52,8 @@ Upstream file paths are relative to `.agents/skills/<upstream-skill-name>/` in t
 ## mops-cli
 
 - **Upstream:** https://github.com/caffeinelabs/mops
-- **Tag:** cli-v2.15.2
-- **Commit:** 564a380c945022ef6e47aa85c40197c037e49b83
-- **Last synced:** 2026-07-01
+- **Tag:** cli-v2.16.1
+- **Commit:** 4bccdc13b512048f41b3296c3590b776c1836fe1
+- **Last synced:** 2026-07-10
 - **Upstream file:** `.agents/skills/mops-cli/SKILL.md`
 - **icskills-owned sections:** none — body is 1:1 with upstream; only frontmatter differs

--- a/evaluations/mops-cli.json
+++ b/evaluations/mops-cli.json
@@ -56,8 +56,8 @@
       "name": "Migration workflow",
       "prompt": "My mops check is failing with a migration compatibility hint. How do I add a new migration called `AddEmailField` for my `backend` canister that uses enhanced migration?",
       "expected_behaviors": [
-        "Runs `mops check --fix` (or `mops check backend`) to verify the migration resolves the error",
-        "Runs `mops build` after check passes — NOT before",
+        "Recommends `mops check --fix` (or `mops check backend`) to verify the migration resolves the error",
+        "Places `mops build` after the check step — never before",
         "Does NOT suggest `mops migrate new` (command no longer exists)",
         "Does NOT suggest `mops migrate freeze` (command no longer exists)",
         "Does NOT suggest adding `--enhanced-migration` to mops.toml manually (mops auto-injects it)"

--- a/skills/mops-cli/SKILL.md
+++ b/skills/mops-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: mops-cli
 description: "Manage Motoko projects with the mops CLI — toolchain pinning, dependency management, type-checking, building, and linting. Use when working with mops.toml, mops.lock, running mops commands, adding/removing packages, pinning moc or lintoko versions, checking or building canisters, configuring moc flags, or setting up a new Motoko project."
 license: Apache-2.0
-compatibility: "mops >= 2.15.2"
+compatibility: "mops >= 2.16.1"
 metadata:
   title: Mops CLI
   category: Infrastructure
@@ -158,6 +158,8 @@ mops toolchain bin moc               # print path to binary
 When `[canisters.<name>.migrations]` is configured, `mops check`, `mops build`, and `mops check-stable` automatically inject `--enhanced-migration`. Do not add `--enhanced-migration` to `[canisters.<name>].args` — mops will error.
 
 Create migration files directly in the `chain` directory.
+
+After `mops check --fix` (or `mops check <canister>`) confirms the chain compiles, run `mops build` to produce the wasm artifact.
 
 `check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` is unaffected by `check-limit`. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
 


### PR DESCRIPTION
Syncs `mops-cli` from `caffeinelabs/mops` `cli-v2.15.2` → `cli-v2.16.1`.

## Upstream delta
One added sentence in **Enhanced migrations**:
> After `mops check --fix` (or `mops check <canister>`) confirms the chain
> compiles, run `mops build` to produce the wasm artifact.

Body is 1:1 with upstream (no icskills-owned sections).

## Changes
- Add build-after-check sentence to Enhanced migrations
- Bump `compatibility` → `mops >= 2.16.1`
- Update `.claude/upstream.md` (tag, full commit SHA `4bccdc13b512048f41b3296c3590b776c1836fe1`, last synced 2026-07-10)
- Reword Migration-workflow eval to assert on written guidance rather than command execution (the "how do I" prompt elicits instructions, not runs)

## Eval

<details><summary>Migration workflow (#6) — with baseline</summary>

```
Migration workflow: WITH 5/5 | WITHOUT 5/5

  WITH skill: 5/5 passed
    ✅ Recommends `mops check --fix` (or `mops check backend`) to verify the migration resolves the error
    ✅ Places `mops build` after the check step — never before
    ✅ Does NOT suggest `mops migrate new` (command no longer exists)
    ✅ Does NOT suggest `mops migrate freeze` (command no longer exists)
    ✅ Does NOT suggest adding `--enhanced-migration` to mops.toml manually (mops auto-injects it)

  WITHOUT skill: 5/5 passed
    (same 5 behaviors)
```

Reworded behaviors now pass with the skill. No with/without delta on this case — its regression value is guarding the removed-command (`mops migrate new/freeze`) and manual `--enhanced-migration` pitfalls.

</details>

Closes #239
