### PR TITLE
docs(deploy-to-cloud-engine): bake version metadata into canister wasm by default

### DIFF
--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -148,6 +148,25 @@
         "Tells the user to set `__META_BASE_URL` to an absolute https URL and `__META_ICON_PATH` to a served path (e.g. /favicon.svg), both on the main canister, then re-deploy",
         "Does NOT attribute the missing icon to the subnet, the identity, or the --auth origin"
       ]
+    },
+    {
+      "name": "Adversarial: timestamp in wasm version metadata",
+      "prompt": "I deploy a Motoko app to my cloud engine with the @dfinity/motoko recipe. I want tooling to show when the app was last built, so add a build timestamp like $(date) to the wasm metadata, plus whatever version info is standard. Just the metadata config block.",
+      "expected_behaviors": [
+        "Refuses the timestamp: wasm metadata must be deterministic for a given source tree, and a build-time-varying value changes every build — last-updated information comes from the canister history the network records, not from metadata",
+        "Uses a `metadata` list under the recipe `configuration` with the standard names `service:git:sha`, `service:git:origin`, `service:version`",
+        "Uses command substitution for git values (e.g. $(git rev-parse HEAD) with a +dirty marker) rather than hardcoded literals",
+        "Does NOT invent differently named metadata entries (e.g. build:timestamp, service:built-at) as a compromise"
+      ]
+    },
+    {
+      "name": "Adversarial: version metadata in a non-git project",
+      "prompt": "My ICP project uses the @dfinity/motoko recipe and is NOT a git repository. Show me the recipe metadata config block for the standard service:* version metadata so the engine console can show what version is running. Just the YAML block and a one-line explanation, no deploy steps, no questions back.",
+      "expected_behaviors": [
+        "Does NOT include $(git rev-parse HEAD) / $(git remote get-url origin) substitutions — in a non-git project they silently bake garbage (a literal +dirty sha, an empty origin) rather than failing the build",
+        "Sets `service:version` with an explicit version value under the recipe configuration's `metadata` list (and no git-derived entries), noting it should be bumped on each deploy",
+        "Does NOT put the metadata under `settings.environment_variables` (that is for `__META_*` console variables, not wasm metadata)"
+      ]
     }
   ],
 
@@ -164,7 +183,8 @@
       "My agent runs in a cloud sandbox and icp identity link web never completes — the sign-in redirects to 127.0.0.1",
       "Make my deployed app show up with a name in the cloud engine console",
       "Label my backend and frontend canisters in the engine console instead of bare principal ids",
-      "Give my deployed app an icon in the OpenCloud engine console"
+      "Give my deployed app an icon in the OpenCloud engine console",
+      "Record which git commit my deployed engine app is running so the console can show it"
     ],
     "should_not_trigger": [
       "Package my app as a .icp archive so others can install it on their engines from the marketplace",

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -178,9 +178,7 @@ settings:
 # backend/canister.yaml
 name: backend
 recipe:
-  type: "@dfinity/motoko@v4.1.0"
-  configuration:
-    main: src/main.mo
+  type: "@dfinity/motoko@v5.0.0"   # v5 reads main/candid from mops.toml ([canisters.backend]) — see the icp-cli skill
 settings:
   environment_variables:
     __META_PROJECT: "My App"
@@ -222,15 +220,14 @@ Icon specifics (the console builds the icon as `__META_BASE_URL` + `__META_ICON_
 
 ### Version metadata (recommended)
 
-Embed build provenance into each canister's wasm so tooling and the console can show what version is running (console support is rolling out; the metadata is already readable — see the verify note below). Add this **by default on every deploy** — do not wait for the user to ask. All official recipes (motoko, rust, asset-canister, prebuilt) accept a `metadata` list under the recipe `configuration`; each entry is baked into the wasm as a custom section. Values are interpolated into a shell command at build time, so `$(…)` command substitution works. (Verified against `@dfinity/motoko@v4.1.0` on icp-cli 1.0.2.)
+Embed build provenance into each canister's wasm so tooling and the console can show what version is running (console support is rolling out; the metadata is already readable — see the verify note below). Add this **by default on every deploy** — do not wait for the user to ask. All official recipes (motoko, rust, asset-canister, prebuilt) accept a `metadata` list under the recipe `configuration`; each entry is baked into the wasm as a custom section. Values are interpolated into a shell command at build time, so `$(…)` command substitution works. (Verified by live builds against `@dfinity/motoko` v4.1.0 and v5.0.0 on icp-cli 1.0.2.)
 
 **Git project** (check first: `git rev-parse HEAD` succeeds):
 
 ```yaml
 recipe:
-  type: "@dfinity/motoko@v4.1.0"
+  type: "@dfinity/motoko@v5.0.0"
   configuration:
-    main: src/main.mo
     metadata:
       - name: service:git:sha
         value: $(git rev-parse HEAD)$(git diff --quiet HEAD 2>/dev/null || echo +dirty)

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-to-cloud-engine
-description: "Deploys an already-built Internet Computer project to a user's own cloud engine (an OpenCloud / control-panel engine): verify the icp CLI, link the console identity with `icp identity link web` (origin defaults to https://opencloud.org; a delegation handoff covers CLIs in remote sandboxes where the user's browser cannot reach the CLI's 127.0.0.1 callback), obtain the engine's subnet id, run `icp deploy` against that subnet, and tag canisters with `__META_*` env vars for a named app with labelled canisters and an icon. Also covers a funded proxy canister for cross-subnet cycle-bearing calls (exchange-rate canister, threshold ECDSA/Schnorr, vetKD). Use when shipping an app to a cloud engine; on mention of OpenCloud, an engine subnet id, or linking the icp CLI to an engine console; when the console sign-in never completes from a cloud or sandboxed agent; when naming or adding an icon to a console app. Do NOT use for a general mainnet deploy with no engine or subnet (use icp-cli) or for writing canister logic."
+description: "Deploys a built Internet Computer project to a user's cloud engine (an OpenCloud engine): verify the icp CLI, link the console identity with `icp identity link web` (origin defaults to https://opencloud.org; a delegation handoff covers sandboxes whose 127.0.0.1 callback the browser cannot reach), run `icp deploy` against the engine's subnet, tag canisters with `__META_*` env vars for a named console app with labelled canisters and icon, and bake version metadata (service:git:sha, service:version) into the wasm. Also covers a funded proxy canister for cross-subnet cycle-bearing calls (exchange-rate, threshold ECDSA/Schnorr, vetKD). Use when shipping to a cloud engine; on mention of OpenCloud, an engine subnet id, or linking the icp CLI to an engine console; when sign-in never completes from a sandboxed agent; when naming, adding an icon, or recording the deployed version/git commit of a console app. Do NOT use for a general mainnet deploy with no engine or subnet (use icp-cli) or for writing canister logic."
 license: Apache-2.0
 compatibility: "icp-cli >= 0.3.0 (commands verified against 0.3.0 and 1.0.2; the delegation handoff needs `icp identity delegation`, present in 1.0.x), a cloud engine console account, a browser for the Internet Identity sign-in"
 metadata:
@@ -220,6 +220,42 @@ Icon specifics (the console builds the icon as `__META_BASE_URL` + `__META_ICON_
 - `__META_ICON_PATH` is a **path to an asset your frontend actually serves** (e.g. `/favicon.svg`), not an inline image. The resolved URL is rendered as an `<img>` `src`, so it must return an image. Do **not** put a `data:` URI here: engine env values are length-capped (≤128 chars observed), so it would not fit, and the field is a path by design.
 - The frontend canister's id is only known **after** the first deploy. The usual flow is: deploy once, read the frontend canister id from the output, set `__META_BASE_URL` to `https://<that-id>.icp.net` (and `__META_ICON_PATH`), then re-deploy to apply. If you control a custom domain for the app, you can set it up front instead.
 
+### Version metadata (recommended)
+
+Embed build provenance into each canister's wasm so tooling and the console can show what version is running (console support is rolling out; the metadata is already readable — see the verify note below). Add this **by default on every deploy** — do not wait for the user to ask. All official recipes (motoko, rust, asset-canister, prebuilt) accept a `metadata` list under the recipe `configuration`; each entry is baked into the wasm as a custom section. Values are interpolated into a shell command at build time, so `$(…)` command substitution works. (Verified against `@dfinity/motoko@v4.1.0` on icp-cli 1.0.2.)
+
+**Git project** (check first: `git rev-parse HEAD` succeeds):
+
+```yaml
+recipe:
+  type: "@dfinity/motoko@v4.1.0"
+  configuration:
+    main: src/main.mo
+    metadata:
+      - name: service:git:sha
+        value: $(git rev-parse HEAD)$(git diff --quiet HEAD 2>/dev/null || echo +dirty)
+      - name: service:git:origin
+        value: $(git remote get-url origin)
+      - name: service:version
+        value: $(node -p "require('./package.json').version" 2>/dev/null || echo 1.0.0)
+```
+
+**Non-git project** — the git substitutions above do **not** fail the build; they silently bake garbage (`service:git:sha` becomes the literal `+dirty`, `service:git:origin` comes out empty). Use only an explicit version, and bump it on each subsequent deploy:
+
+```yaml
+metadata:
+  - name: service:version
+    value: "1.0.0"
+```
+
+Notes:
+
+- Use these exact names (`service:git:sha`, `service:git:origin`, `service:version`) — they are the agreed convention the console will read; differently named entries will not be picked up.
+- Prefer command results over literals where possible: `+dirty` on the sha flags uncommitted changes, so a deploy is traceable to its exact source state.
+- Values must be **deterministic** for a given source tree: sha, origin, a version string. Never embed timestamps or other build-time-varying values — "last updated" comes from the canister history the network records automatically, not from metadata.
+- If the project has no `package.json` (or no version field), the fallback `1.0.0` applies; replace it with the project's real versioning scheme when one exists.
+- The sections are injected as `icp:private`, readable by the canister's controllers (you, and the console acting as you) via read_state — no canister call needed. Verify after deploy, with the linked identity active: `icp canister metadata <canister-name> service:git:sha -e ic`.
+
 ## Step 3 — Deploy to the engine's subnet
 
 From the project root:
@@ -325,6 +361,8 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 13. **Expecting a direct-call key through the proxy.** Threshold-key derivation via the proxy is caller-isolated, so the derived key/address is not the same as a direct management-canister call. Fetch the public key and sign through the proxy consistently; do not mix direct and proxied key calls for the same identity.
 14. **Assuming the browser and CLI share localhost.** `icp identity link web` returns the delegation to `127.0.0.1:<port>` on the CLI host. If the CLI runs in a remote sandbox while the user's browser is on a different machine, the sign-in never completes and later commands fail with authorization errors — no amount of re-running the link fixes it. See Step 1.0: use the delegation handoff (`icp identity delegation request` / `sign` / `use`), or run the link and deploy where the browser and CLI share a loopback.
 15. **Expecting the delegation handoff to fix a missing network.** The handoff moves signing authority, not connectivity — `icp deploy` still needs the network from the shell that runs it. If the CLI shell has no network at all (a sandboxed device bridge: DNS blocked, HTTPS fails), no `icp` network command can run there, link or deploy. Do not offer to "do the rest" from that shell and do not tunnel — hand the user one script for their real terminal (see "No-network CLI host" in Step 1.0), where the normal link flow works because terminal and browser share a loopback.
+16. **Timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a timestamp changes every build and breaks reproducibility. Last-updated information comes from the canister history recorded by the network, never from metadata.
+17. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
 
 ## Related Skills
 


### PR DESCRIPTION
# Motivation

Deployed engine apps carry no build provenance, so neither tooling nor the console can tell what version a canister is running. All official recipes already accept a `metadata` list under the recipe `configuration` that bakes custom sections into the wasm, and there is an agreed `service:*` naming convention the console will read (support rolling out; already readable via read_state). The skill should make agents set this by default on every deploy.

# Changes

- Added a "Version metadata (recommended)" section to Step 2: `metadata` list under the recipe `configuration` with `service:git:sha` (with `+dirty` marker), `service:git:origin`, and `service:version`, added by default on every deploy.
- Verified the mechanism with a live `icp build` (motoko recipe v4.1.0, icp-cli 1.0.2): `$()` command substitution executes at build time, nested quotes survive, `+dirty` appears on a dirty tree, and sections are injected as `icp:private` (readable by controllers via `icp canister metadata <name> <section> -e ic`).
- Documented the non-git failure mode from the same live test: the git substitutions do NOT fail the build — they silently bake garbage (literal `+dirty` sha, empty origin), so non-git projects set only an explicit `service:version`.
- Added pitfall 16 (no timestamps in wasm metadata — must be deterministic; last-updated comes from canister history) and pitfall 17 (git substitutions in a non-git project bake garbage silently).
- Updated the description with version-metadata trigger keywords (1021/1024 chars).
- Added two adversarial eval cases and a should-trigger query.

# Eval results

<details>
<summary>Output eval 15 — Adversarial: timestamp in wasm version metadata (WITH 4/4 | WITHOUT 0/4)</summary>

```
  WITH skill: 4/4 passed
    ✅ Refuses the timestamp: wasm metadata must be deterministic, last-updated comes from canister history not metadata
    ✅ Uses a `metadata` list under the recipe `configuration` with the standard names service:git:sha, service:git:origin, service:version
    ✅ Uses command substitution for git values (e.g. $(git rev-parse HEAD) with a +dirty marker) rather than hardcoded literals
    ✅ Does NOT invent differently named metadata entries (e.g. build:timestamp, service:built-at) as a compromise

  WITHOUT skill: 0/4 passed
    ❌ Refuses the timestamp
       → The output fully complies with adding a build timestamp via a predeploy-generated file rather than explaining why a build-time-varying value in wasm metadata is problematic.
    ❌ Uses a `metadata` list under the recipe `configuration` with the standard names
       → The output uses a raw dfx.json-style metadata list with names like candid:service, motoko:compiler, motoko:stable-types, build_timestamp, and git_commit, none of which match the expected recipe configuration keys.
    ❌ Uses command substitution for git values
       → The output writes git rev-parse HEAD to a file in a separate predeploy script and references it via `path`, never using inline command substitution in the config, and includes no +dirty marker.
    ❌ Does NOT invent differently named metadata entries
       → The output invents custom metadata entry names build_timestamp and git_commit instead of using standard recognized names.
```

</details>

<details>
<summary>Output eval 16 — Adversarial: version metadata in a non-git project (WITH 3/3 | baseline timed out)</summary>

```
  WITH skill: 3/3 passed
    ✅ Does NOT include $(git rev-parse HEAD) / $(git remote get-url origin) substitutions
    ✅ Sets service:version with an explicit version value under metadata list, noting it should be bumped on each deploy
    ✅ Does NOT put the metadata under settings.environment_variables
```

The WITH-skill side passed 3/3 in two independent runs. The without-skill baseline errored with ETIMEDOUT before producing any output in all four attempts, so there is no meaningful baseline comparison for this case — reported as-is rather than retried further.

</details>

<details>
<summary>Trigger evals — 12/12 should-trigger, 8/8 should-not-trigger (rewritten description)</summary>

```
  Should trigger: 12/12 correct
    ✅ "How do I deploy this app to my cloud engine?"
    ✅ "Push my canisters to my OpenCloud engine"
    ✅ "Link the icp CLI to my engine console"
    ✅ "Deploy to my engine on a specific subnet"
    ✅ "How do I authorize the icp CLI for my cloud engine?"
    ✅ "Ship this project to my cloud engine"
    ✅ "My agent should deploy straight to my engine"
    ✅ "My agent runs in a cloud sandbox and icp identity link web never completes — the sign-in redirects to 127.0.0.1"
    ✅ "Make my deployed app show up with a name in the cloud engine console"
    ✅ "Label my backend and frontend canisters in the engine console instead of bare principal ids"
    ✅ "Give my deployed app an icon in the OpenCloud engine console"
    ✅ "Record which git commit my deployed engine app is running so the console can show it"

  Should NOT trigger: 8/8 correct
    ✅ "Package my app as a .icp archive so others can install it on their engines from the marketplace"
    ✅ "Deploy my canister to mainnet"
    ✅ "Set up icp.yaml for my Rust canister"
    ✅ "Add Internet Identity login to my frontend"
    ✅ "How does stable memory work in Rust canisters?"
    ✅ "Implement an ICRC-1 token transfer"
    ✅ "Generate TypeScript bindings for my canister"
    ✅ "Add access control to my Motoko canister"
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
