### PR TITLE
docs(deploy-to-cloud-engine): add service:git:updated_at (commit date) to version metadata

### DIFF
--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -153,8 +153,8 @@
       "name": "Adversarial: timestamp in wasm version metadata",
       "prompt": "I deploy a Motoko app to my cloud engine with the @dfinity/motoko recipe. I want tooling to show when the app was last built, so add a build timestamp like $(date) to the wasm metadata, plus whatever version info is standard. Just the metadata config block.",
       "expected_behaviors": [
-        "Refuses the build timestamp ($(date)-style): wasm metadata must be deterministic for a given source tree — and instead offers `service:git:last_updated` with $(git log -1 --format=%cI) (the last commit's date, fixed per commit) and/or notes that deploy time comes from the canister history the network records",
-        "Uses a `metadata` list under the recipe `configuration` with the standard names `service:git:sha`, `service:git:origin`, `service:git:last_updated`, `service:version`",
+        "Refuses the build timestamp ($(date)-style): wasm metadata must be deterministic for a given source tree — and instead offers `service:git:updated_at` with $(git log -1 --format=%cI) (the last commit's date, fixed per commit) and/or notes that deploy time comes from the canister history the network records",
+        "Uses a `metadata` list under the recipe `configuration` with the standard names `service:git:sha`, `service:git:origin`, `service:git:updated_at`, `service:version`",
         "Uses command substitution for git values (e.g. $(git rev-parse HEAD) with a +dirty marker) rather than hardcoded literals",
         "Does NOT invent differently named metadata entries (e.g. build:timestamp, service:built-at) as a compromise"
       ]

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -153,8 +153,8 @@
       "name": "Adversarial: timestamp in wasm version metadata",
       "prompt": "I deploy a Motoko app to my cloud engine with the @dfinity/motoko recipe. I want tooling to show when the app was last built, so add a build timestamp like $(date) to the wasm metadata, plus whatever version info is standard. Just the metadata config block.",
       "expected_behaviors": [
-        "Refuses the timestamp: wasm metadata must be deterministic for a given source tree, and a build-time-varying value changes every build — last-updated information comes from the canister history the network records, not from metadata",
-        "Uses a `metadata` list under the recipe `configuration` with the standard names `service:git:sha`, `service:git:origin`, `service:version`",
+        "Refuses the build timestamp ($(date)-style): wasm metadata must be deterministic for a given source tree — and instead offers `service:git:last_updated` with $(git log -1 --format=%cI) (the last commit's date, fixed per commit) and/or notes that deploy time comes from the canister history the network records",
+        "Uses a `metadata` list under the recipe `configuration` with the standard names `service:git:sha`, `service:git:origin`, `service:git:last_updated`, `service:version`",
         "Uses command substitution for git values (e.g. $(git rev-parse HEAD) with a +dirty marker) rather than hardcoded literals",
         "Does NOT invent differently named metadata entries (e.g. build:timestamp, service:built-at) as a compromise"
       ]

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -233,7 +233,7 @@ recipe:
         value: $(git rev-parse HEAD)$(git diff --quiet HEAD 2>/dev/null || echo +dirty)
       - name: service:git:origin
         value: $(git remote get-url origin)
-      - name: service:git:last_updated
+      - name: service:git:updated_at
         value: $(git log -1 --format=%cI)
       - name: service:version
         value: $(node -p "require('./package.json').version" 2>/dev/null || echo 1.0.0)
@@ -249,7 +249,7 @@ metadata:
 
 Notes:
 
-- Use these exact names (`service:git:sha`, `service:git:origin`, `service:git:last_updated`, `service:version`) — they are the agreed convention the console will read; differently named entries will not be picked up.
+- Use these exact names (`service:git:sha`, `service:git:origin`, `service:git:updated_at`, `service:version`) — they are the agreed convention the console will read; differently named entries will not be picked up.
 - Prefer command results over literals where possible: `+dirty` on the sha flags uncommitted changes, so a deploy is traceable to its exact source state.
 - Values must be **deterministic** for a given source tree: sha, origin, the last commit's date, a version string. Never embed a build time (`$(date)`) or other build-time-varying values. The commit date (`%cI`) is allowed because it is a property of the commit, not of the build — but note it means "code last changed", not "last deployed": deploying an old commit shows the old date. The deploy time itself comes from the canister history the network records automatically.
 - If the project has no `package.json` (or no version field), the fallback `1.0.0` applies; replace it with the project's real versioning scheme when one exists.
@@ -360,7 +360,7 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 13. **Expecting a direct-call key through the proxy.** Threshold-key derivation via the proxy is caller-isolated, so the derived key/address is not the same as a direct management-canister call. Fetch the public key and sign through the proxy consistently; do not mix direct and proxied key calls for the same identity.
 14. **Assuming the browser and CLI share localhost.** `icp identity link web` returns the delegation to `127.0.0.1:<port>` on the CLI host. If the CLI runs in a remote sandbox while the user's browser is on a different machine, the sign-in never completes and later commands fail with authorization errors — no amount of re-running the link fixes it. See Step 1.0: use the delegation handoff (`icp identity delegation request` / `sign` / `use`), or run the link and deploy where the browser and CLI share a loopback.
 15. **Expecting the delegation handoff to fix a missing network.** The handoff moves signing authority, not connectivity — `icp deploy` still needs the network from the shell that runs it. If the CLI shell has no network at all (a sandboxed device bridge: DNS blocked, HTTPS fails), no `icp` network command can run there, link or deploy. Do not offer to "do the rest" from that shell and do not tunnel — hand the user one script for their real terminal (see "No-network CLI host" in Step 1.0), where the normal link flow works because terminal and browser share a loopback.
-16. **Build timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a build time (`$(date)`) changes every build even with identical source, breaking reproducibility and changing the module hash on every deploy. The deterministic alternative is the last commit's date, `service:git:last_updated` = `$(git log -1 --format=%cI)` — a property of the source tree, not the build. The deploy time itself comes from the canister history recorded by the network, never from metadata.
+16. **Build timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a build time (`$(date)`) changes every build even with identical source, breaking reproducibility and changing the module hash on every deploy. The deterministic alternative is the last commit's date, `service:git:updated_at` = `$(git log -1 --format=%cI)` — a property of the source tree, not the build. The deploy time itself comes from the canister history recorded by the network, never from metadata.
 17. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
 
 ## Related Skills

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -233,6 +233,8 @@ recipe:
         value: $(git rev-parse HEAD)$(git diff --quiet HEAD 2>/dev/null || echo +dirty)
       - name: service:git:origin
         value: $(git remote get-url origin)
+      - name: service:git:last_updated
+        value: $(git log -1 --format=%cI)
       - name: service:version
         value: $(node -p "require('./package.json').version" 2>/dev/null || echo 1.0.0)
 ```
@@ -247,9 +249,9 @@ metadata:
 
 Notes:
 
-- Use these exact names (`service:git:sha`, `service:git:origin`, `service:version`) — they are the agreed convention the console will read; differently named entries will not be picked up.
+- Use these exact names (`service:git:sha`, `service:git:origin`, `service:git:last_updated`, `service:version`) — they are the agreed convention the console will read; differently named entries will not be picked up.
 - Prefer command results over literals where possible: `+dirty` on the sha flags uncommitted changes, so a deploy is traceable to its exact source state.
-- Values must be **deterministic** for a given source tree: sha, origin, a version string. Never embed timestamps or other build-time-varying values — "last updated" comes from the canister history the network records automatically, not from metadata.
+- Values must be **deterministic** for a given source tree: sha, origin, the last commit's date, a version string. Never embed a build time (`$(date)`) or other build-time-varying values. The commit date (`%cI`) is allowed because it is a property of the commit, not of the build — but note it means "code last changed", not "last deployed": deploying an old commit shows the old date. The deploy time itself comes from the canister history the network records automatically.
 - If the project has no `package.json` (or no version field), the fallback `1.0.0` applies; replace it with the project's real versioning scheme when one exists.
 - The sections are injected as `icp:private`, readable by the canister's controllers (you, and the console acting as you) via read_state — no canister call needed. Verify after deploy, with the linked identity active: `icp canister metadata <canister-name> service:git:sha -e ic`.
 
@@ -358,7 +360,7 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 13. **Expecting a direct-call key through the proxy.** Threshold-key derivation via the proxy is caller-isolated, so the derived key/address is not the same as a direct management-canister call. Fetch the public key and sign through the proxy consistently; do not mix direct and proxied key calls for the same identity.
 14. **Assuming the browser and CLI share localhost.** `icp identity link web` returns the delegation to `127.0.0.1:<port>` on the CLI host. If the CLI runs in a remote sandbox while the user's browser is on a different machine, the sign-in never completes and later commands fail with authorization errors — no amount of re-running the link fixes it. See Step 1.0: use the delegation handoff (`icp identity delegation request` / `sign` / `use`), or run the link and deploy where the browser and CLI share a loopback.
 15. **Expecting the delegation handoff to fix a missing network.** The handoff moves signing authority, not connectivity — `icp deploy` still needs the network from the shell that runs it. If the CLI shell has no network at all (a sandboxed device bridge: DNS blocked, HTTPS fails), no `icp` network command can run there, link or deploy. Do not offer to "do the rest" from that shell and do not tunnel — hand the user one script for their real terminal (see "No-network CLI host" in Step 1.0), where the normal link flow works because terminal and browser share a loopback.
-16. **Timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a timestamp changes every build and breaks reproducibility. Last-updated information comes from the canister history recorded by the network, never from metadata.
+16. **Build timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a build time (`$(date)`) changes every build even with identical source, breaking reproducibility and changing the module hash on every deploy. The deterministic alternative is the last commit's date, `service:git:last_updated` = `$(git log -1 --format=%cI)` — a property of the source tree, not the build. The deploy time itself comes from the canister history recorded by the network, never from metadata.
 17. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
 
 ## Related Skills


### PR DESCRIPTION
# Motivation

The console wants to show a last-updated field for a deployed app, but pitfall 16 bans build timestamps in wasm metadata (a `$(date)` value changes every build and breaks reproducibility). The last commit's date is the deterministic middle ground: it is a property of the source tree, not of the build, so rebuilding the same commit produces the same wasm.

# Changes

- Added `service:git:updated_at` = `$(git log -1 --format=%cI)` to the version metadata example (git projects only).
- Verified by live builds (motoko recipe v5.0.0, icp-cli 1.0.2): the ISO 8601 value bakes correctly and is identical across rebuilds of the same commit.
- Reworded pitfall 16 to distinguish the banned build timestamp from the allowed commit date, and named the new field as the deterministic alternative.
- Clarified in the notes that the commit date means "code last changed", not deploy time — deploy time stays with the canister history the network records.
- Updated eval 15's expected behaviors to cover the new field and re-ran it.

# Eval results

<details>
<summary>Output eval 15 — Adversarial: timestamp in wasm version metadata (updated case: WITH 4/4)</summary>

```
  WITH skill: 4/4 passed
    ✅ Refuses the build timestamp ($(date)-style) and offers service:git:updated_at / notes deploy time is in canister history
    ✅ Uses a metadata list under recipe configuration with standard names service:git:sha, service:git:origin, service:git:updated_at, service:version
    ✅ Uses command substitution for git values with a +dirty marker rather than hardcoded literals
    ✅ Does NOT invent differently named metadata entries as a compromise
```

The without-skill baseline for this run hit the runner's 120s timeout before producing output. The last completed baseline of this case (in #246) failed 0/4 with real output — it complied with the build timestamp via a predeploy script and invented `build_timestamp` / `git_commit` names — and that output also fails all four updated behaviors, so the with/without delta carries over.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
