### PR TITLE
chore(mops-cli): sync upstream cli-v2.16.1 → cli-v2.19.0

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -52,8 +52,8 @@ Upstream file paths are relative to `.agents/skills/<upstream-skill-name>/` in t
 ## mops-cli
 
 - **Upstream:** https://github.com/caffeinelabs/mops
-- **Tag:** cli-v2.16.1
-- **Commit:** 4bccdc13b512048f41b3296c3590b776c1836fe1
-- **Last synced:** 2026-07-10
+- **Tag:** cli-v2.19.0
+- **Commit:** be449cbeaf8bd9ce6c929b3ceb41591afe8bedca
+- **Last synced:** 2026-07-28
 - **Upstream file:** `.agents/skills/mops-cli/SKILL.md`
 - **icskills-owned sections:** none — body is 1:1 with upstream; only frontmatter differs

--- a/evaluations/mops-cli.json
+++ b/evaluations/mops-cli.json
@@ -140,6 +140,26 @@
         "Redirects to mo:core as the replacement",
         "Does NOT confirm that mo:base/HashMap is a valid choice"
       ]
+    },
+    {
+      "name": "Enabling Wasm optimization",
+      "prompt": "How do I turn on wasm-opt optimization for my mops build? Just the mops.toml config and any toolchain command, no deploy steps.",
+      "expected_behaviors": [
+        "Adds an `[optimize]` section to mops.toml (default level `O3`)",
+        "Pins Binaryen via `mops toolchain use wasm-opt 131` (or `latest`), or notes mops auto-pins latest on first build",
+        "Explains the optimization pass runs during `mops build`, and that `--no-optimize` skips it for a single run",
+        "Does NOT tell the user to invoke the `wasm-opt` binary manually or configure optimization through dfx"
+      ]
+    },
+    {
+      "name": "Running benchmarks",
+      "prompt": "I have benchmark files under bench/ in my mops project. How do I run them, save a baseline, and compare a later run against it? Just the commands.",
+      "expected_behaviors": [
+        "Uses `mops bench` to run benchmarks in `bench/*.bench.mo`",
+        "Uses `mops bench --save` to save results as a baseline",
+        "Uses `mops bench --compare` to compare against saved results",
+        "Does NOT invent a non-existent command or suggest a manual benchmarking harness"
+      ]
     }
   ],
   "trigger_evals": {
@@ -158,7 +178,9 @@
       "How do I add a dev dependency with mops?",
       "How do I configure the moc toolchain version in mops?",
       "How do I regenerate the candid .did file for my Motoko canister with mops?",
-      "How do I keep my check-stable .most baseline in sync after deploying?"
+      "How do I keep my check-stable .most baseline in sync after deploying?",
+      "How do I enable wasm-opt optimization for my mops build?",
+      "How do I run benchmarks with mops?"
     ],
     "should_not_trigger": [
       "Write a Motoko persistent actor with a counter",

--- a/skills/mops-cli/SKILL.md
+++ b/skills/mops-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: mops-cli
 description: "Manage Motoko projects with the mops CLI — toolchain pinning, dependency management, type-checking, building, and linting. Use when working with mops.toml, mops.lock, running mops commands, adding/removing packages, pinning moc or lintoko versions, checking or building canisters, configuring moc flags, or setting up a new Motoko project."
 license: Apache-2.0
-compatibility: "mops >= 2.16.1"
+compatibility: "mops >= 2.19.0"
 metadata:
   title: Mops CLI
   category: Infrastructure
@@ -48,6 +48,12 @@ path = "deployed/backend.most"
 [build]
 outputDir = "src/backend/dist"
 args = ["--release"]
+
+# Opt-in Wasm optimization (Binaryen wasm-opt) for build + bench
+[optimize]
+# level = "O3"       # default
+# keep-names = true  # default
+# wasm-opt pin: [toolchain] wasm-opt = "131" (auto-pinned to latest if missing)
 ```
 
 `check-stable` runs ICP's upgrade-time stable-variable compatibility check locally, so incompatible changes fail in `mops check` instead of being rejected when upgrading a live canister. It compares the current code against a `.most` from the deployed version.
@@ -64,11 +70,11 @@ Optional canister fields: `candid` (path to .did for compatibility checking), `i
 
 Flags are applied in this order (later overrides earlier):
 
-1. `[moc].args` — global, all commands (check, build, test, etc.)
+1. `[moc].args` — global, all commands (check, build, test, bench, etc.)
 2. `[build].args` — build only (e.g. `--release`)
 3. `[canisters.<name>.migrations]` — auto-injected `--enhanced-migration` (managed by mops)
 4. `[canisters.<name>].args` — per-canister
-5. CLI `-- <flags>` — one-off overrides
+5. CLI `-- <flags>` — one-off overrides; supported by `mops check`, `mops build`, `mops check-stable`, `mops generate`, `mops migrate`, `mops test`, and `mops bench`
 
 ## Core Commands
 
@@ -76,9 +82,13 @@ Flags are applied in this order (later overrides earlier):
 
 ```bash
 mops install
+mops install --lock update   # regenerate a stale/corrupt mops.lock
+mops install --lock check    # fail if lockfile is missing or stale (CI)
 ```
 
-Run after cloning or after manual `mops.toml` edits. Updates `mops.lock`. In CI, uses `--lock check` by default (fails if lockfile is stale).
+Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default.
+
+When the `CI` env var is set and `--lock` is omitted, defaults to `--lock check` (deprecated — pass `--lock check` explicitly; auto-detection will be removed in v3). A stale lock fails with a hint to run `mops install --lock update`.
 
 ### `mops add <package>`
 
@@ -88,7 +98,7 @@ mops add core@2.5.0       # specific version
 mops add --dev test       # dev dependency
 ```
 
-Updates `mops.toml` and `mops.lock`.
+Updates `mops.toml` and `mops.lock` (even when `CI` is set).
 
 ### `mops check`
 
@@ -116,6 +126,8 @@ mops build -- --ai-errors # pass extra moc flags
 ```
 
 Produces `.wasm`, `.did`, and `.most` files in `[build].outputDir` (default `.mops/.build`).
+
+With `[optimize]` in `mops.toml`, runs `wasm-opt` after candid metadata (default `-O3 -g`). Pin Binaryen with `mops toolchain use wasm-opt 131` (or let auto-pin write latest on first build). Soft-fails to unoptimized Wasm on error. Pass `--no-optimize` (on `build` or `bench`) to skip the pass for a single run without editing `mops.toml`.
 
 ### `mops deployed`
 
@@ -146,12 +158,16 @@ mops toolchain use moc 1.7.0         # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
 mops toolchain use lintoko 0.10.0    # pin specific version
 mops toolchain use pocket-ic 12.0.0  # pin for replica tests / benchmarks (pin a specific version; `latest` may resolve to one the bundled pic-js client doesn't support)
+mops toolchain use wasm-opt 131      # Binaryen for [optimize] (or `latest`)
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)
 mops toolchain update                # update all tools to latest
+mops toolchain info <tool>           # show release info (latest, pinned, history)
+mops toolchain info <tool> --versions # list recent stable releases, newest first
+mops toolchain info <tool> --versions --all # full stable history (cache warming)
 mops toolchain bin moc               # print path to binary
 ```
 
-**Agent note**: `toolchain use <tool>` without a version opens an interactive picker — do not use in scripts or agents. Always pass a version or `latest`. `toolchain update` only works when the tool already has a `[toolchain]` entry.
+**Agent note**: `toolchain use <tool>` without a version opens an interactive picker — do not use in scripts or agents. Always pass a version or `latest`. `toolchain update` only works when the tool already has a `[toolchain]` entry. `toolchain info <tool> --versions` works without `mops.toml` (first GitHub page by default; pass `--all` for full history).
 
 ### Enhanced migrations
 
@@ -196,9 +212,23 @@ mops test my-test                 # filter by name
 mops test --mode wasi             # use wasmtime (for to_candid/from_candid)
 mops test --reporter verbose      # show Debug.print output
 mops test --watch                 # re-run on file changes
+mops test -- -Werror              # pass extra moc flags
 ```
 
 Replica tests (actor files or `// @testmode replica`) use `pocket-ic` from `[toolchain]`. With no pin they fall back to the deprecated `dfx` replica (warning printed) — pin `pocket-ic` in `[toolchain]` to silence it. Same applies to `mops bench` and `mops watch`.
+
+### `mops bench`
+
+Benchmarks live in `bench/*.bench.mo`:
+
+```bash
+mops bench                        # run all benchmarks
+mops bench my-bench               # filter by name
+mops bench --gc incremental       # select GC
+mops bench --save                 # save results to .bench/<name>.json
+mops bench --compare              # compare with saved results
+mops bench -- -Werror             # pass extra moc flags
+```
 
 ### `mops lint`
 
@@ -243,5 +273,3 @@ mops add core
 Then configure `[moc].args`, `[canisters]`, and `[build]` in `mops.toml`.
 
 To update tools later: `mops toolchain update moc` or `mops toolchain update` (all tools).
-</content>
-</invoke>


### PR DESCRIPTION
Syncs the `mops-cli` skill from the caffeinelabs/mops release **cli-v2.16.1 → cli-v2.19.0** (commit [`be449cbeaf8b`](https://github.com/caffeinelabs/mops/commit/be449cbeaf8bd9ce6c929b3ceb41591afe8bedca)).

`mops-cli` has no icskills-owned body sections (`.claude/upstream.md`: only frontmatter differs), so all upstream additions were applied directly. After the sync the body is byte-for-byte identical to upstream.

## Upstream changes applied

- **`[optimize]` section** (Binaryen wasm-opt) added to the minimal `mops.toml`.
- **`mops build`**: new paragraph on the `wasm-opt` pass (default `-O3 -g`), `--no-optimize`, and pinning Binaryen with `mops toolchain use wasm-opt 131` (auto-pins latest if missing).
- **`mops install`**: `--lock update` / `--lock check` shown; prose updated — updates `mops.lock` by default, and the CI `--lock check` auto-detection is now deprecated (pass `--lock check` explicitly; removed in v3).
- **`mops add`**: clarifies it updates `mops.toml` + `mops.lock` even when `CI` is set.
- **`mops toolchain`**: added `use wasm-opt`, `info <tool>`, `info <tool> --versions [--all]`; agent note extended (`info --versions` works without `mops.toml`).
- **New `### mops bench` section** (`bench/*.bench.mo`, `--gc`, `--save`, `--compare`, `-- -Werror`).
- **Moc args layering**: global args now note `bench`; CLI `-- <flags>` lists every supporting command.
- **`mops test`**: `-- -Werror` example added.

## Other changes

- Bumped `compatibility` to `mops >= 2.19.0`.
- Removed stray `</content></invoke>` tags accidentally left at EOF by a prior sync (not present upstream).
- Updated `.claude/upstream.md`: Tag `cli-v2.19.0`, Commit `be449cbeaf8bd9ce6c929b3ceb41591afe8bedca`, Last synced `2026-07-28`.

`npm run validate` — all 26 skills pass (warnings only).

## Evals

Seeded two new output eval cases for the new commands (wasm optimization, `mops bench`) plus two trigger queries. Both new cases run with baseline below.

<details>
<summary>Eval results (new cases, with baseline)</summary>

```
Enabling Wasm optimization: WITH 4/4 | WITHOUT 4/4
  ✅ Adds an [optimize] section to mops.toml (default level O3)
  ✅ Pins Binaryen via `mops toolchain use wasm-opt 131` (or auto-pin)
  ✅ Explains the pass runs during `mops build`, and `--no-optimize` skips it
  ✅ Does NOT invoke wasm-opt manually or configure via dfx
  (baseline also 4/4 — the base model already knows [optimize]; kept as a regression net)

Running benchmarks: WITH 4/4 | WITHOUT 1/4
  ✅ Uses `mops bench` (bench/*.bench.mo)
  ✅ Uses `mops bench --save` for a baseline
  ✅ Uses `mops bench --compare`
  ✅ Does NOT invent syntax / a manual harness
  ✗ baseline fabricated a named-baseline `--save <name>` / `--compare <name>` syntax
    that mops does not support (or produced no command at all)
```

</details>

Closes #254
