### PR TITLE
Fix invalid icp-cli command usage across skills

### DIFF
--- a/skills/cycles-management/SKILL.md
+++ b/skills/cycles-management/SKILL.md
@@ -40,7 +40,7 @@ The Management Canister (`aaaaa-aa`) is a virtual canister -- it does not exist 
 
 4. **Sending cycles to the wrong canister** -- Cycles sent to a canister cannot be retrieved. There is no refund mechanism for cycles transferred to the wrong principal. Double-check the canister ID before topping up.
 
-5. **Forgetting to set the canister controller** -- If you lose the controller identity, you permanently lose the ability to upgrade, top up, or manage the canister. Always add a backup controller. Use `icp canister update-settings --add-controller PRINCIPAL` to add one.
+5. **Forgetting to set the canister controller** -- If you lose the controller identity, you permanently lose the ability to upgrade, top up, or manage the canister. Always add a backup controller. Use `icp canister settings update --add-controller PRINCIPAL` to add one.
 
 6. **Using ExperimentalCycles in mo:core** -- In mo:core 2.0, the module is renamed to `Cycles`. `import ExperimentalCycles "mo:base/ExperimentalCycles"` will fail. Use `import Cycles "mo:core/Cycles"`.
 
@@ -285,17 +285,17 @@ icp canister create my_canister
 icp canister create my_canister -e ic --cycles 2000000000000
 
 # Add a backup controller
-icp canister update-settings my_canister --add-controller BACKUP_PRINCIPAL_HERE
+icp canister settings update my_canister --add-controller BACKUP_PRINCIPAL_HERE
 ```
 
 ### Set Freezing Threshold
 
 ```bash
 # Set freezing threshold to 90 days (in seconds: 90 * 24 * 60 * 60 = 7776000)
-icp canister update-settings backend --freezing-threshold 7776000
+icp canister settings update backend --freezing-threshold 7776000
 
 # Mainnet
-icp canister update-settings backend --freezing-threshold 7776000 -e ic
+icp canister settings update backend --freezing-threshold 7776000 -e ic
 ```
 
 ## Verify It Works

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -874,7 +874,7 @@ The factory examples above are intentionally kept simple to demonstrate the cani
 icp deploy user_service
 
 # Rust content_service requires the user_service principal on every upgrade (post_upgrade arg)
-USER_SERVICE_ID=$(icp canister id user_service)
+USER_SERVICE_ID=$(icp canister status user_service --id-only)
 icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
 
 npm run build
@@ -893,7 +893,7 @@ icp network start -d
 icp deploy user_service
 
 # content_service (Rust) requires the user_service canister ID as an init argument
-USER_SERVICE_ID=$(icp canister id user_service)
+USER_SERVICE_ID=$(icp canister status user_service --id-only)
 icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
 
 # Build and deploy frontend
@@ -959,12 +959,12 @@ icp canister call content_service createPost '("Test Title", "Test Body")'
 
 # Create a new identity that is NOT registered
 icp identity new unregistered --storage plaintext
-icp identity use unregistered
+icp identity default unregistered
 icp canister call content_service createPost '("Should Fail", "No user")'
 # Expected: (variant { err = "User not registered" })
 
 # Switch back
-icp identity use default
+icp identity default default
 ```
 
 ### Verify Cross-Canister Query

--- a/skills/sns-launch/SKILL.md
+++ b/skills/sns-launch/SKILL.md
@@ -369,10 +369,10 @@ dfx sns propose --network ic --neuron $NEURON_ID sns_init.yaml
 
 ```bash
 # List deployed SNS canisters
-icp canister id sns_governance
-icp canister id sns_ledger
-icp canister id sns_root
-icp canister id sns_swap
+icp canister status sns_governance --id-only
+icp canister status sns_ledger --id-only
+icp canister status sns_root --id-only
+icp canister status sns_swap --id-only
 
 # Verify SNS governance is operational
 icp canister call sns_governance get_nervous_system_parameters '()'


### PR DESCRIPTION
## What

Audited **every** `icp …` invocation in all skills against the real `icp-cli` (1.2.0) and fixed the ones that name subcommands which don't exist. Scope is strictly **icp-cli command usage** — no other changes.

| Wrong (doesn't exist) | Correct | Where |
|---|---|---|
| `icp canister id <name>` | `icp canister status <name> --id-only` | `sns-launch` (×4), `multi-canister` (×2) |
| `icp canister update-settings …` | `icp canister settings update …` | `cycles-management` (×4: `--add-controller`, `--freezing-threshold`) |
| `icp identity use <name>` | `icp identity default <name>` | `multi-canister` (×2) |

These were verified against the CLI: `icp canister` has no `id`/`update-settings` subcommand (it's `status --id-only` and `settings update`), and `icp identity` has no `use` (it's `default`). The repo's own `icp-cli` skill already documents the correct forms (Pitfall 6; the dfx→icp mapping), so these were stragglers inconsistent with it.

## What was deliberately left alone

- **`asset-canister` skill** — it has the same `icp canister id` / `update-settings` bugs, but those are already fixed as part of the `asset-canister` → `static-site` rename in **#256**. Editing that file here would conflict with #256, so it's excluded (it'll be correct once #256 merges).
- **Intentional "wrong-command" examples** in the `icp-cli` pitfalls (e.g. the text explaining `icp identity use` and `icp deploy --network ic` are *wrong*) — left as-is.
- **Valid usages** confirmed against the CLI and kept: `icp deploy --subnet` (real flag), `icp deploy <canister-name>` (e.g. `icp deploy assets`), `icp canister top-up`, `icp identity link/delegation/reauth`, `icp project bundle/show`, `icp sync <name>`, etc.

## Verification

- Enumerated the full `icp` command tree (`canister`, `identity`, `network`, `token`, `cycles`, `deploy` flags, …) from `icp --help` and cross-checked every usage.
- Final grep shows no remaining invalid command (outside the excluded `asset-canister` and the explanatory pitfalls).
- `npm run validate`: 26 skills, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
