### PR TITLE
fix(icp-cli): correct broken prebuilt recipe row

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -279,6 +279,15 @@
         "Deploys by extracting the archive (tar -xzf) and running `icp deploy` from the extracted directory",
         "Does NOT invent commands like `icp bundle`, `icp package`, or `dfx` equivalents"
       ]
+    },
+    {
+      "name": "Adversarial: prebuilt recipe config key",
+      "prompt": "I have a pre-compiled canister.wasm.gz and want to deploy it with icp-cli using the prebuilt recipe. Show me just the icp.yaml canister entry, no deploy steps.",
+      "expected_behaviors": [
+        "Points the pre-built WASM at the `path` configuration key (e.g. path: canister.wasm.gz)",
+        "Does NOT use a `wasm` key inside recipe.configuration — that key does not exist and fails with a cryptic strict-mode template error naming `path`",
+        "Uses a version-pinned `@dfinity/prebuilt` recipe type string (e.g. @dfinity/prebuilt@v2.1.0), not the non-functional v1.0.0"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -441,7 +441,7 @@ canisters:
 | Motoko | `@dfinity/motoko@v5.0.0` | — | `shrink`, `compress`, `metadata` |
 | Static site (frontend) | `@dfinity/static-site@v0.3.3` | `dir` | `build`, `presync`, `metadata` |
 | Asset (legacy frontend) | `@dfinity/asset-canister@v2.2.1` | `dir` | `build`, `version` |
-| Prebuilt | `@dfinity/prebuilt@v1.0.0` | `wasm` | `sha256`, `candid`, `shrink`, `compress` |
+| Prebuilt | `@dfinity/prebuilt@v2.1.0` | `path` | `sha256`, `shrink`, `compress`, `metadata` |
 
 `@dfinity/static-site` is the recommended way to host a frontend; `@dfinity/asset-canister` is the legacy asset canister (see the `static-site` skill).
 

--- a/skills/icp-cli/references/canister-env-vars.md
+++ b/skills/icp-cli/references/canister-env-vars.md
@@ -4,19 +4,25 @@
 
 ## Motoko
 
-Requires motoko-core v2.1.0+. `Runtime.envVar` needs the `<system>` capability and returns `?Text`:
+Requires motoko-core v2.1.0+. `Runtime.envVar` needs the `<system>` capability and returns `?Text`. The capability does not cross an ordinary `func` boundary, so a helper that calls it must itself be declared `<system>` and be called with `<system>` from a context that holds the capability (actor init or an update method body):
 
 ```motoko
 import Runtime "mo:core/Runtime";
 import Principal "mo:core/Principal";
 
-func bridgePrincipal() : ?Principal {
+// note the `<system>` on the function — a plain `func` cannot call Runtime.envVar
+func bridgePrincipal<system>() : ?Principal {
   switch (Runtime.envVar<system>("PUBLIC_CANISTER_ID:bridge")) {
     case (?id) { ?Principal.fromText(id) };
     case null { null };
   };
 };
+
+// call site inside an update method, propagating the capability:
+// let bridge = bridgePrincipal<system>();
 ```
+
+A `query` cannot obtain the `<system>` capability, so it cannot read the variable directly. To expose a resolved ID through a query method, mirror it into a `transient var` during a call that can read it (actor init or an update method) and have the query return the cached value.
 
 ## Rust
 


### PR DESCRIPTION
Closes #258.

## Problem

The recipe table's **Prebuilt** row advertised a required config key `wasm` — but that key **never existed at any recipe version**. The prebuilt recipe has used `path` since [`prebuilt-v1.0.0`](https://github.com/dfinity/icp-cli-recipes/blob/prebuilt-v1.0.0/recipes/prebuilt/recipe.hbs). Following the table failed with a cryptic strict-mode template error naming `path` without saying it was the key you should have used.

Root-cause trace: `wasm` was introduced in [`f6be531`](https://github.com/dfinity/icskills/commit/f6be531) (PR #121, *"prevent recipe and frontend config hallucinations"*) — inferred from the prose *"path to the pre-built WASM file"* and committed without checking the recipe source. It survived ~4 months because **no eval exercised the prebuilt recipe config**.

Two adjacent errors in the same row: `candid` (optional column) is also fabricated — the prebuilt recipe has no `candid` param — and the real `metadata` key was missing. The pinned `v1.0.0` is additionally non-functional on current `icp` (its `recipe.hbs` references a `wasm-inject-metadata` partial removed in the v2.x rewrite).

## Changes

- **Prebuilt row:** `wasm` → `path`; drop fabricated `candid`; add real `metadata`; bump `v1.0.0` → `v2.1.0`. Prebuilt is referenced only in this table, so the version pin stays self-consistent.
- **`references/canister-env-vars.md`:** the Motoko example did not compile — a plain `func` cannot call `Runtime.envVar<system>`. Declare the helper `<system>`, show the call site, and document that a `query` cannot hold the capability (mirror the ID into a `transient var`).
- **New eval #27** ("Adversarial: prebuilt recipe config key") — closes the coverage gap that let the wrong key survive.

## Deliberately *not* changed: the other recipe versions

The issue also noted Rust (`v3.3.0`→`v3.4.0`), Motoko (`v5.0.0`→`v5.1.0`), and Asset (`v2.2.1`→`v2.3.0`) are stale. I am **not** bumping them here:

- Those bumps are non-blocking (the table already links the releases page for agents to verify latest).
- The same versions are pinned in ~10 example sites throughout the skill body (and older still in `dfx-migration.md`). Bumping only the table would desync it from the examples — a worse inconsistency than uniform staleness.

A blanket "bump every recipe version everywhere to latest" is a separate, self-contained change and belongs in its own PR. This PR is scoped to the correctness bug.

## Evals

Ran the new case with baseline (per PR policy).

<details>
<summary>Eval #27 — WITH 3/3 | baseline</summary>

```
━━━ Adversarial: prebuilt recipe config key ━━━
  WITH skill: 3/3 passed
    ✅ Points the pre-built WASM at the `path` configuration key
    ✅ Does NOT use a `wasm` key inside recipe.configuration
    ✅ Uses a version-pinned @dfinity/prebuilt type string (e.g. v2.1.0), not v1.0.0
```

The without-skill judge JSON failed to parse (judge flake), but the raw baseline output is unambiguous — a model with **no skill** produced the correct `path` key on its own:

```yaml
canisters:
  - name: <your-canister-name>
    recipe:
      type: "@dfinity/prebuilt@v2.0.0"
      configuration:
        path: ./canister.wasm.gz
        sha256: "<sha256-of-canister.wasm.gz>"  # from `sha256sum canister.wasm.gz`
```

This makes the fix's value concrete: the old table was **worse than no skill at all**, steering agents to a `wasm` key they would not otherwise have invented.
</details>
