### PR TITLE
fix(icp-cli): make agentOptions host conditional so builds work on custom domains

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -293,10 +293,10 @@
       "name": "Adversarial: agentOptions host on a custom domain",
       "prompt": "My icp-cli frontend uses @icp-sdk/bindgen bindings and safeGetCanisterEnv(). Show the agentOptions object I should pass to createActor so the same build works on the local network AND in production, including when the site is served from a custom domain. Just the agentOptions object plus a one-sentence explanation.",
       "expected_behaviors": [
+        "Omits host from agentOptions (or explicitly says to leave it unset), relying on the agent's default host resolution",
         "Sets rootKey from the ic_env cookie (canisterEnv?.IC_ROOT_KEY via safeGetCanisterEnv)",
-        "Makes host conditional: window.location.origin only when the ic_env cookie provides a root key (local network); undefined/omitted otherwise",
-        "Explains that an omitted host defaults to https://icp-api.io on mainnet, which works on custom domains where the gateway does not serve /api/v2",
-        "Does NOT set host unconditionally to window.location.origin"
+        "Explains that the default host resolution uses the page origin on known gateway hosts (ic0.app/icp0.io/localhost) and falls back to https://icp-api.io elsewhere, so custom domains work even though they do not serve /api/v2",
+        "Does NOT set host to window.location.origin (conditionally or unconditionally)"
       ]
     }
   ],

--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -288,6 +288,16 @@
         "Does NOT use a `wasm` key inside recipe.configuration — that key does not exist and fails with a cryptic strict-mode template error naming `path`",
         "Uses a version-pinned `@dfinity/prebuilt` recipe type string (e.g. @dfinity/prebuilt@v2.1.0), not the non-functional v1.0.0"
       ]
+    },
+    {
+      "name": "Adversarial: agentOptions host on a custom domain",
+      "prompt": "My icp-cli frontend uses @icp-sdk/bindgen bindings and safeGetCanisterEnv(). Show the agentOptions object I should pass to createActor so the same build works on the local network AND in production, including when the site is served from a custom domain. Just the agentOptions object plus a one-sentence explanation.",
+      "expected_behaviors": [
+        "Sets rootKey from the ic_env cookie (canisterEnv?.IC_ROOT_KEY via safeGetCanisterEnv)",
+        "Makes host conditional: window.location.origin only when the ic_env cookie provides a root key (local network); undefined/omitted otherwise",
+        "Explains that an omitted host defaults to https://icp-api.io on mainnet, which works on custom domains where the gateway does not serve /api/v2",
+        "Does NOT set host unconditionally to window.location.origin"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/icp-cli/references/binding-generation.md
+++ b/skills/icp-cli/references/binding-generation.md
@@ -37,14 +37,15 @@ import { createActor } from "./bindings/backend";
 // For additional canisters: import { createActor as createOther } from "./bindings/other";
 
 const canisterEnv = safeGetCanisterEnv();
-// Local networks set the ic_env cookie with a root key, and the same origin
-// serves /api (local gateway or Vite dev-server proxy) — use window.location.origin.
-// On mainnet the cookie carries no root key: leave host undefined so the agent
-// defaults to https://icp-api.io. Never hardcode window.location.origin for
-// mainnet — a custom domain serves only the HTTP gateway, not /api/v2, so calls
-// from it would fail (see the custom-domains skill).
+// Do NOT set host. The agent's default host resolution already picks the right
+// API endpoint everywhere: on known gateway origins (ic0.app, icp0.io,
+// localhost, 127.0.0.1) it uses the page origin — so the local gateway and the
+// Vite dev-server /api proxy keep working — and anywhere else, including custom
+// domains and icp.net, it falls back to https://icp-api.io. Hardcoding
+// host: window.location.origin breaks frontends served from a custom domain:
+// the custom domain is only the HTTP gateway and does not serve /api/v2 (see
+// the custom-domains skill).
 const agentOptions = {
-  host: canisterEnv?.IC_ROOT_KEY ? window.location.origin : undefined,
   rootKey: canisterEnv?.IC_ROOT_KEY,
 };
 

--- a/skills/icp-cli/references/binding-generation.md
+++ b/skills/icp-cli/references/binding-generation.md
@@ -37,8 +37,14 @@ import { createActor } from "./bindings/backend";
 // For additional canisters: import { createActor as createOther } from "./bindings/other";
 
 const canisterEnv = safeGetCanisterEnv();
+// Local networks set the ic_env cookie with a root key, and the same origin
+// serves /api (local gateway or Vite dev-server proxy) — use window.location.origin.
+// On mainnet the cookie carries no root key: leave host undefined so the agent
+// defaults to https://icp-api.io. Never hardcode window.location.origin for
+// mainnet — a custom domain serves only the HTTP gateway, not /api/v2, so calls
+// from it would fail (see the custom-domains skill).
 const agentOptions = {
-  host: window.location.origin,
+  host: canisterEnv?.IC_ROOT_KEY ? window.location.origin : undefined,
   rootKey: canisterEnv?.IC_ROOT_KEY,
 };
 

--- a/skills/icp-cli/references/dfx-migration.md
+++ b/skills/icp-cli/references/dfx-migration.md
@@ -23,7 +23,7 @@ import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env";
 const backendId = safeGetCanisterEnv()?.["PUBLIC_CANISTER_ID:backend"];
 ```
 
-Note: `safeGetCanisterEnv()` also returns `IC_ROOT_KEY` (as a `Uint8Array`) on local networks, replacing the need for `agent.fetchRootKey()`.
+Note: `safeGetCanisterEnv()` also returns `IC_ROOT_KEY` (as a `Uint8Array`) — the `ic_env` cookie always carries the network's root key, on local networks and mainnet alike. Passing it as the `rootKey` agent option replaces the need for `agent.fetchRootKey()`.
 
 ## Frontend package migration
 
@@ -50,13 +50,11 @@ createActor(canisterId, { agent });
 import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env";
 const canisterEnv = safeGetCanisterEnv();
 createActor(canisterEnv?.["PUBLIC_CANISTER_ID:backend"], {
-  // window.location.origin only on local networks (root key present in the
-  // ic_env cookie); undefined on mainnet → defaults to https://icp-api.io,
-  // which also works when the site is served from a custom domain.
-  agentOptions: {
-    host: canisterEnv?.IC_ROOT_KEY ? window.location.origin : undefined,
-    rootKey: canisterEnv?.IC_ROOT_KEY,
-  }
+  // No host: the agent's default resolves to the page origin on known gateway
+  // hosts (ic0.app, icp0.io, localhost, 127.0.0.1) and to https://icp-api.io
+  // everywhere else — including custom domains, which serve only the HTTP
+  // gateway, not /api/v2. Do not set host: window.location.origin.
+  agentOptions: { rootKey: canisterEnv?.IC_ROOT_KEY }
 });
 ```
 

--- a/skills/icp-cli/references/dfx-migration.md
+++ b/skills/icp-cli/references/dfx-migration.md
@@ -50,7 +50,13 @@ createActor(canisterId, { agent });
 import { safeGetCanisterEnv } from "@icp-sdk/core/agent/canister-env";
 const canisterEnv = safeGetCanisterEnv();
 createActor(canisterEnv?.["PUBLIC_CANISTER_ID:backend"], {
-  agentOptions: { host: window.location.origin, rootKey: canisterEnv?.IC_ROOT_KEY }
+  // window.location.origin only on local networks (root key present in the
+  // ic_env cookie); undefined on mainnet → defaults to https://icp-api.io,
+  // which also works when the site is served from a custom domain.
+  agentOptions: {
+    host: canisterEnv?.IC_ROOT_KEY ? window.location.origin : undefined,
+    rootKey: canisterEnv?.IC_ROOT_KEY,
+  }
 });
 ```
 


### PR DESCRIPTION
Closes #267.

## Problem

`skills/icp-cli/references/binding-generation.md` and `references/dfx-migration.md` presented `host: window.location.origin` as the unconditional `HttpAgent` pattern. The `custom-domains` skill (pitfall 8) correctly states that a custom domain serves only the HTTP gateway — not `/api/v2` — so a frontend built from the icp-cli pattern fails exactly when served from a custom domain. Two skills, opposite instructions.

## Change

Both references now **omit `host` entirely** and pass only `rootKey`:

```js
const agentOptions = {
  rootKey: canisterEnv?.IC_ROOT_KEY,
};
```

`@icp-sdk/core`'s default host resolution (`determineHost()`) already picks the right API endpoint everywhere:
- Known gateway origins (`ic0.app`, `icp0.io`, `localhost`, `127.0.0.1`) → page origin, so the local gateway and the Vite dev-server `/api` proxy keep working.
- Everywhere else — custom domains, `icp.net` — → `https://icp-api.io`, which is exactly what `custom-domains` prescribes.

Also corrected the `dfx-migration.md` note that scoped `IC_ROOT_KEY` to local networks: `certified-assets` renders `ic_root_key=<hex>` into the `ic_env` cookie unconditionally (sourced from `ic_cdk::api::root_key()`), so the cookie carries the network's root key on mainnet too. Passing it as `rootKey` is a no-op on mainnet (it equals the agent's hardcoded key) and replaces `fetchRootKey()` locally.

> Note: the first commit on this branch gated `host` on `IC_ROOT_KEY` presence, assuming the cookie omits the root key on mainnet. Review surfaced that the assumption was false, which would have re-broken custom domains — see the second commit and the PR comment for the source-level evidence.

Added an adversarial eval case ("agentOptions host on a custom domain") to `evaluations/icp-cli.json`.

## Eval results (new case, with baseline)

<details>
<summary>node scripts/evaluate-skills.js icp-cli --eval 28</summary>

```
━━━ Adversarial: agentOptions host on a custom domain ━━━

  WITH skill: 4/4 passed
    ✅ Omits host from agentOptions (or explicitly says to leave it unset), relying on the agent's default host resolution
    ✅ Sets rootKey from the ic_env cookie (canisterEnv?.IC_ROOT_KEY via safeGetCanisterEnv)
    ✅ Explains that the default host resolution uses the page origin on known gateway hosts (ic0.app/icp0.io/localhost) and falls back to https://icp-api.io elsewhere, so custom domains work even though they do not serve /api/v2
    ✅ Does NOT set host to window.location.origin (conditionally or unconditionally)

  WITHOUT skill: 1/4 passed
    ❌ Omits host from agentOptions (or explicitly says to leave it unset), relying on the agent's default host resolution
       → The output explicitly sets host to a hardcoded local or icp-api.io URL via a ternary rather than omitting it.
    ❌ Sets rootKey from the ic_env cookie (canisterEnv?.IC_ROOT_KEY via safeGetCanisterEnv)
       → The output uses a boolean shouldFetchRootKey flag based on env.network, not a rootKey value sourced from canisterEnv.IC_ROOT_KEY.
    ❌ Explains that the default host resolution uses the page origin on known gateway hosts (ic0.app/icp0.io/localhost) and falls back to https://icp-api.io elsewhere, so custom domains work even though they do not serve /api/v2
       → The explanation only discusses using env.network instead of window.location, with no mention of default host resolution behavior on gateway hosts or the /api/v2 fallback rationale.
    ✅ Does NOT set host to window.location.origin (conditionally or unconditionally)
```

</details>

`npm run validate` passes (warnings only, pre-existing). No existing eval case encoded the old pattern; `custom-domains` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
