### PR TITLE
fix(multi-canister): remove nonexistent `dependencies` field; wire IDs via PUBLIC_CANISTER_ID env vars

### DIFF
--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -1,0 +1,29 @@
+{
+  "skill": "multi-canister",
+  "description": "Evaluation cases for the multi-canister skill. Tests whether agents avoid documented pitfalls: inventing a dependencies field in icp.yaml instead of using the injected PUBLIC_CANISTER_ID environment variables for inter-canister wiring.",
+
+  "output_evals": [
+    {
+      "name": "Adversarial: dependencies field for deploy ordering",
+      "prompt": "My icp-cli project has two canisters in icp.yaml: user_service and content_service. content_service needs user_service's canister ID at runtime. How do I make sure they deploy in the right order and content_service gets the ID? Just the icp.yaml/config approach and the one-line Motoko read, no full code.",
+      "expected_behaviors": [
+        "States that icp.yaml has no dependencies field and deploy ordering is not needed for ID discovery",
+        "Says icp deploy injects every canister's ID as a PUBLIC_CANISTER_ID:<canister-name> environment variable into every canister",
+        "Shows reading the ID with Runtime.envVar<system>(\"PUBLIC_CANISTER_ID:user_service\") in Motoko",
+        "Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I split my IC app across multiple canisters that call each other?",
+      "My canister's inter-canister call sometimes returns SYS_UNKNOWN — what does that mean?",
+      "Design a canister factory that spins up a new canister per user"
+    ],
+    "should_not_trigger": [
+      "How do I deploy a single Motoko canister to mainnet with icp-cli?"
+    ]
+  }
+}

--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -7,7 +7,7 @@
       "name": "Adversarial: dependencies field for deploy ordering",
       "prompt": "My icp-cli project has two canisters in icp.yaml: user_service and content_service. content_service needs user_service's canister ID at runtime. How do I make sure they deploy in the right order and content_service gets the ID? Just the icp.yaml/config approach and the one-line Motoko read, no full code.",
       "expected_behaviors": [
-        "States that icp.yaml has no dependencies field and deploy ordering is not needed for ID discovery",
+        "States that icp.yaml deploys canisters in parallel and deploy ordering is not needed for ID discovery",
         "Says icp deploy injects every canister's ID as a PUBLIC_CANISTER_ID:<canister-name> environment variable into every canister",
         "Shows reading the ID with Runtime.envVar<system>(\"PUBLIC_CANISTER_ID:user_service\") in Motoko",
         "Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml"

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -83,7 +83,7 @@ Take the perspective of an experienced senior security engineer and carefully re
 
 ## Mistakes That Break Your Build
 
-1. **Deploying canisters in the wrong order.** Canisters with dependencies must be deployed according to their dependencies. Declare `dependencies` in icp.yaml so `icp deploy` orders them correctly.
+1. **Trying to order deployment with a `dependencies` field.** icp.yaml has no `dependencies` field — icp-cli builds canisters in parallel, and `icp deploy` injects every canister's ID into every canister as a `PUBLIC_CANISTER_ID:<canister-name>` environment variable, so a canister can discover a sibling's ID at runtime regardless of deploy order. Read it with `Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service")` in Motoko (motoko-core >= 2.1.0) or `ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service")` in Rust. See the `icp-cli` skill's Canister Environment Variables section.
 
 2. **Forgetting to generate type declarations for each backend canister.** Use language-specific tooling (e.g., `didc` for Candid bindings) to generate declarations for each backend canister individually.
 

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -83,7 +83,7 @@ Take the perspective of an experienced senior security engineer and carefully re
 
 ## Mistakes That Break Your Build
 
-1. **Trying to order deployment with a `dependencies` field.** icp.yaml has no `dependencies` field — icp-cli builds canisters in parallel, and `icp deploy` injects every canister's ID into every canister as a `PUBLIC_CANISTER_ID:<canister-name>` environment variable, so a canister can discover a sibling's ID at runtime regardless of deploy order. Read it with `Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service")` in Motoko (motoko-core >= 2.1.0) or `ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service")` in Rust. See the `icp-cli` skill's Canister Environment Variables section.
+1. **Trying to order deployment with a `dependencies` field.** icp.yaml has a `dependencies` field but it is not used to order the deployment — icp-cli builds canisters in parallel, and `icp deploy` injects every canister's ID into every canister as a `PUBLIC_CANISTER_ID:<canister-name>` environment variable, so a canister can discover a sibling's ID at runtime regardless of deploy order. Read it with `Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service")` in Motoko (motoko-core >= 2.1.0) or `ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service")` in Rust. See the `icp-cli` skill's Canister Environment Variables section.
 
 2. **Forgetting to generate type declarations for each backend canister.** Use language-specific tooling (e.g., `didc` for Candid bindings) to generate declarations for each backend canister individually.
 


### PR DESCRIPTION
Closes #268.

## Problem

`multi-canister` pitfall 1 ("Mistakes That Break Your Build") told agents to declare a `dependencies` field in icp.yaml so `icp deploy` orders canisters correctly. `icp-cli/SKILL.md` and its `dfx-migration.md` reference both state there is no `dependencies` field — canisters build in parallel, and inter-canister wiring uses the injected `PUBLIC_CANISTER_ID:<canister-name>` environment variables.

## Change

- Rewrote the pitfall: icp.yaml has no `dependencies` field; `icp deploy` injects every canister's ID into every canister as `PUBLIC_CANISTER_ID:<name>`, read via `Runtime.envVar<system>` (Motoko, motoko-core >= 2.1.0) or `ic_cdk::api::env_var_value` (Rust), with a cross-reference to the icp-cli skill.
- Seeded `evaluations/multi-canister.json` (the skill had no eval file): one adversarial output case targeting this exact hallucination, plus 3 should-trigger / 1 should-not-trigger cases.

Note: the related init-arg wiring in this skill's deployment section (`icp deploy --argument …`) is tracked separately in #269 and intentionally not touched here.

## Eval results (new file, full suite with baseline)

<details>
<summary>node scripts/evaluate-skills.js multi-canister</summary>

```
━━━ Adversarial: dependencies field for deploy ordering ━━━

  WITH skill: 4/4 passed
    ✅ States that icp.yaml has no dependencies field and deploy ordering is not needed for ID discovery
    ✅ Says icp deploy injects every canister's ID as a PUBLIC_CANISTER_ID:<canister-name> environment variable into every canister
    ✅ Shows reading the ID with Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service") in Motoko
    ✅ Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml

  WITHOUT skill: 0/4 passed
    ❌ States that icp.yaml has no dependencies field and deploy ordering is not needed for ID discovery
       → The output invents and recommends a dependencies field in icp.yaml, the opposite of the expected behavior.
    ❌ Says icp deploy injects every canister's ID as a PUBLIC_CANISTER_ID:<canister-name> environment variable into every canister
       → The output never mentions this environment variable mechanism at all.
    ❌ Shows reading the ID with Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service") in Motoko
       → The output instead shows an actor class constructor parameter pattern, not Runtime.envVar.
    ❌ Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml
       → The output explicitly invents a `dependencies:` key under content_service in icp.yaml.

━━━ Trigger Evals ━━━

  Should trigger: 3/3 correct
    ✅ "How do I split my IC app across multiple canisters that call each other?"
    ✅ "My canister's inter-canister call sometimes returns SYS_UNKNOWN — what does that mean?"
    ✅ "Design a canister factory that spins up a new canister per user"

  Should NOT trigger: 1/1 correct
    ✅ "How do I deploy a single Motoko canister to mainnet with icp-cli?"
```

The baseline run invents the exact `dependencies:` key this fix removes from the skill.

</details>

`npm run validate` passes (warnings only, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek