### PR TITLE
fix(icp-cli): `icp identity list`, not `icp identities list`

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -242,6 +242,7 @@
       "prompt": "My project works great locally. Can I just run 'icp deploy -e ic' to deploy to mainnet?",
       "expected_behaviors": [
         "Warns that the anonymous identity (default locally) should not be used on mainnet — it is shared and uncontrolled",
+        "Uses `icp identity list` (singular) to list identities — NOT `icp identities list`, which is not a valid subcommand",
         "Recommends checking and switching to a named identity using icp commands (e.g. icp identity default, icp identity new, icp identity default <name>) — NOT dfx identity use",
         "Recommends checking mainnet balance before deploying using icp commands: icp token balance -n ic or icp cycles balance -n ic (NOT dfx ledger balance)",
         "Mentions that a new identity will need to be funded with ICP or cycles before it can deploy",

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -68,14 +68,6 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 6. **Using `icp identity use` instead of `icp identity default`.** The dfx command `dfx identity use <name>` became `icp identity default <name>` (setter). `icp identity default` with no argument is the getter — it prints the current default identity, equivalent to `dfx identity whoami`. The command `icp identity use` does not exist. Similarly, `dfx identity get-principal` became `icp identity principal`, and `dfx identity remove` became `icp identity delete`.
 
-    The subcommand group is **singular** — `icp identity`, never `icp identities`. The plural fails outright:
-    ```
-    $ icp identities list
-    error: unrecognized subcommand 'identities'
-      tip: a similar subcommand exists: 'identity'
-    ```
-    Verified subcommands: `account-id`, `default`, `delegation`, `delete`, `export`, `import`, `link`, `list`, `new`, `principal`, `reauth`, `rename`.
-
 7. **Confusing networks and environments.** A network is a connection endpoint (URL). An environment combines a network + canisters + settings. You deploy to environments (`-e`), not networks. Multiple environments can target the same network with different settings (e.g., staging and production both on `ic`).
 
 8. **Writing `networks` or `environments` as a YAML map instead of an array.** Both `networks` and `environments` are arrays of objects in `icp.yaml`, not maps:

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -68,6 +68,14 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 6. **Using `icp identity use` instead of `icp identity default`.** The dfx command `dfx identity use <name>` became `icp identity default <name>` (setter). `icp identity default` with no argument is the getter — it prints the current default identity, equivalent to `dfx identity whoami`. The command `icp identity use` does not exist. Similarly, `dfx identity get-principal` became `icp identity principal`, and `dfx identity remove` became `icp identity delete`.
 
+    The subcommand group is **singular** — `icp identity`, never `icp identities`. The plural fails outright:
+    ```
+    $ icp identities list
+    error: unrecognized subcommand 'identities'
+      tip: a similar subcommand exists: 'identity'
+    ```
+    Verified subcommands: `account-id`, `default`, `delegation`, `delete`, `export`, `import`, `link`, `list`, `new`, `principal`, `reauth`, `rename`.
+
 7. **Confusing networks and environments.** A network is a connection endpoint (URL). An environment combines a network + canisters + settings. You deploy to environments (`-e`), not networks. Multiple environments can target the same network with different settings (e.g., staging and production both on `ic`).
 
 8. **Writing `networks` or `environments` as a YAML map instead of an array.** Both `networks` and `environments` are arrays of objects in `icp.yaml`, not maps:
@@ -201,7 +209,7 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
     Before deploying to mainnet, switch to a named identity:
     ```bash
-    icp identities list                                        # check available identities
+    icp identity list                                          # check available identities (`identity`, never `identities`)
     icp identity default my-identity                           # switch to an existing one
     # or: icp identity new my-identity && icp identity default my-identity
     ```


### PR DESCRIPTION
Closes #279.

## Problem

`icp-cli/SKILL.md` pitfall 20 (deploying to mainnet with the anonymous identity) told agents to run `icp identities list`. That subcommand does not exist, so the first command an agent runs before a mainnet deploy fails.

## Verification (not assumed)

Checked against the actual CLI rather than inferred — `icp 1.2.0`:

```
$ icp identities list
error: unrecognized subcommand 'identities'
  tip: a similar subcommand exists: 'identity'

$ icp identity --help
Manage your identities
Usage: icp identity [OPTIONS] <COMMAND>
Commands:
  account-id  default  delegation  delete  export  import
  link  list  new  principal  reauth  rename
```

Cross-checked against the upstream reference at <https://cli.internetcomputer.org/llms.txt>, which also documents the group as `icp identity`.

So the issue resolves in favour of `deploy-to-cloud-engine`: the singular spelling is correct and `icp-cli` was the wrong one. `git blame` shows the plural was introduced as a one-line typo in #159 — every other identity command in the repo (26 occurrences across `icp-cli`, `deploy-to-cloud-engine`, `icrc-ledger`, `dfx-migration.md`) already uses the singular, so this was the only line needing a change.

## Change

- `skills/icp-cli/SKILL.md:204` — `icp identities list` → `icp identity list`.
- Pitfall 6 now states the group is singular, quotes the real error text for the plural, and lists the twelve verified subcommands, so an agent that reaches for a plural or invented subcommand has the correct set in front of it.
- `evaluations/icp-cli.json` — extended the existing "Adversarial: deploying to mainnet with the anonymous identity" case (which covers exactly this code block) with a behavior asserting the singular spelling.

Not touched: `icp token balance -n ic` / `icp cycles balance -n ic` on the following lines. Both `-n/--network` and `-e/--environment` exist in the CLI and that inconsistency is tracked separately in #290.

## Eval results

<details>
<summary>node scripts/evaluate-skills.js icp-cli --eval 23</summary>

```
━━━ Adversarial: deploying to mainnet with the anonymous identity ━━━

  WITH skill: 6/6 passed
    ✅ Warns that the anonymous identity (default locally) should not be used on mainnet — it is shared and uncontrolled
    ✅ Uses `icp identity list` (singular) to list identities — NOT `icp identities list`
    ✅ Recommends checking and switching to a named identity using icp commands — NOT dfx identity use
    ✅ Recommends checking mainnet balance before deploying using icp token balance -n ic or icp cycles balance -n ic
    ✅ Mentions that a new identity will need to be funded with ICP or cycles before it can deploy
    ✅ Presents identity switch and balance check as required prerequisites before running icp deploy -e ic, not optional suggestions

  WITHOUT skill: 0/6 passed
    ❌ Warns that the anonymous identity ... → The output never mentions the anonymous identity or its risks at all.
    ❌ Uses `icp identity list` (singular) ... → No identity-listing command is mentioned anywhere in the output.
    ❌ Recommends checking and switching to a named identity ... → only vaguely references 'canister controllers'.
    ❌ Recommends checking mainnet balance ... → gives no concrete icp balance command, references dfx canister status.
    ❌ Mentions that a new identity will need to be funded ... → no mention.
    ❌ Presents identity switch and balance check as required prerequisites ... → framed as generic considerations.

  Summary: WITH 6/6 | WITHOUT 0/6
```

</details>

`npm run validate` — 26 skills validated, all passed (15 warnings, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek