### PR TITLE
fix(multi-canister): read sibling ID from `PUBLIC_CANISTER_ID`, drop nonexistent `--argument`

### DIFF
--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -12,6 +12,16 @@
         "Shows reading the ID with Runtime.envVar<system>(\"PUBLIC_CANISTER_ID:user_service\") in Motoko",
         "Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml"
       ]
+    },
+    {
+      "name": "Adversarial: passing a sibling canister ID to a Rust canister at deploy time",
+      "prompt": "My icp-cli project has a Rust content_service canister that needs the user_service canister's principal. Show the deploy command and the Rust accessor that reads the ID. Just those two, no icp.yaml and no full canister code.",
+      "expected_behaviors": [
+        "Deploy command is a plain `icp deploy content_service` with no init-argument flag",
+        "Does NOT use `--argument` or `--argument-file`, which are not icp deploy flags (the real flags are `--args` / `--args-file`)",
+        "Rust accessor reads ic_cdk::api::env_var_value(\"PUBLIC_CANISTER_ID:user_service\") and parses it with Principal::from_text",
+        "Does NOT take the sibling ID as an #[init] or #[post_upgrade] parameter"
+      ]
     }
   ],
 

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -531,9 +531,6 @@ thread_local! {
             0u64,
         )
     );
-
-    // Store the user_service canister ID (set during init, re-set on upgrade)
-    static USER_SERVICE_ID: RefCell<Option<Principal>> = RefCell::new(None);
 }
 
 fn post_id_to_key(id: u64) -> Vec<u8> {
@@ -549,21 +546,15 @@ fn deserialize_post(bytes: &[u8]) -> Post {
 }
 
 #[init]
-fn init(user_service_id: Principal) {
-    USER_SERVICE_ID.with(|id| *id.borrow_mut() = Some(user_service_id));
-}
+fn init() {}
 
 #[post_upgrade]
-fn post_upgrade(user_service_id: Principal) {
-    // Re-set the user_service ID (not stored in stable memory for simplicity,
-    // since it is always passed as an init/upgrade argument)
-    init(user_service_id);
-}
+fn post_upgrade() {}
 
+// icp deploy injects the sibling's ID on every deploy -- no init argument needed
 fn get_user_service_id() -> Principal {
-    USER_SERVICE_ID.with(|id| {
-        id.borrow().expect("user_service canister ID not set")
-    })
+    let id = ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service");
+    Principal::from_text(id).expect("invalid PUBLIC_CANISTER_ID:user_service")
 }
 
 // Defensive: capture caller before any await
@@ -870,12 +861,8 @@ The factory examples above are intentionally kept simple to demonstrate the cani
 ### Upgrade Commands
 
 ```bash
-# Upgrade canisters in dependency order
 icp deploy user_service
-
-# Rust content_service requires the user_service principal on every upgrade (post_upgrade arg)
-USER_SERVICE_ID=$(icp canister status user_service --id-only)
-icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
+icp deploy content_service
 
 npm run build
 icp deploy frontend
@@ -889,12 +876,9 @@ icp deploy frontend
 # Start the local replica
 icp network start -d
 
-# Deploy in dependency order
+# Deploy order does not matter -- each canister discovers its siblings at runtime
 icp deploy user_service
-
-# content_service (Rust) requires the user_service canister ID as an init argument
-USER_SERVICE_ID=$(icp canister status user_service --id-only)
-icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"
+icp deploy content_service
 
 # Build and deploy frontend
 npm run build
@@ -932,7 +916,6 @@ icp canister call user_service register "(\"alice\")"
 icp canister call user_service is_valid_user "(principal \"$PRINCIPAL\")"
 # Expected: (true)
 
-# content_service must have been deployed with --argument "(principal \"<user_service_id>\")"
 icp canister call content_service create_post "(\"Hello World\", \"My first post\")"
 # Expected: (variant { ok = record { id = 0 : nat64; author = principal "..."; ... } })
 


### PR DESCRIPTION
Closes #269.

## Problem

The deploy and upgrade blocks wired the `user_service` principal into the Rust `content_service` with `icp deploy content_service --argument "(principal \"$USER_SERVICE_ID\")"`. That flag does not exist, so every command in the section fails at argument parsing.

## Verification (not assumed)

Against the installed `icp 1.2.0`:

```
$ icp deploy foo --argument '(principal "aaaaa-aa")'
error: unexpected argument '--argument' found
  tip: a similar argument exists: '--args'

$ icp deploy foo --argument-file ./x.did
error: unexpected argument '--argument-file' found
  tip: a similar argument exists: '--args-file'
```

The real flags are `--args`, `--args-file`, `--args-format`. Note the repo had **zero** occurrences of the correct spellings — see "Follow-up" below.

The replacement API was compiled, not assumed. `ic_cdk::api::env_var_value` exists at the version this skill pins (`ic-cdk = "0.19"`), with signature `pub fn env_var_value<T: AsRef<str>>(name: T) -> String` (`ic-cdk-0.19.0/src/api.rs:616`). I extracted the skill's edited `content_service/src/lib.rs` block verbatim and built it against the skill's own pinned deps (ic-cdk 0.19, candid 0.10, ic-stable-structures 0.7): **173 lines, compiles clean, no warnings.**

## Change

Rather than rename the flag to `--args`, this drops the init-arg wiring altogether — which is what `icp-cli` pitfall 22 and this skill's own pitfall 1 (added in #304) already prescribe:

- `get_user_service_id()` now reads `ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service")` and parses it with `Principal::from_text`.
- Dropped the `USER_SERVICE_ID` thread-local and the `#[init]`/`#[post_upgrade]` principal parameters (now empty, matching `user_service` in the same skill).
- Deploy, upgrade, and test blocks lost the `--argument` lines and the `icp canister status --id-only` plumbing that fed them; deploy order no longer matters.

Net: **-25 / +18 lines** — the fix removes more than it adds.

The Motoko example needed no change; it uses `import UserService "canister:user_service"` and never took an init argument.

## Eval results

<details>
<summary>New case — node scripts/evaluate-skills.js multi-canister --eval 2</summary>

```
━━━ Adversarial: passing a sibling canister ID to a Rust canister at deploy time ━━━

  WITH skill: 4/4 passed
    ✅ Deploy command is a plain `icp deploy content_service` with no init-argument flag
    ✅ Does NOT use `--argument` or `--argument-file`, which are not icp deploy flags
    ✅ Rust accessor reads ic_cdk::api::env_var_value("PUBLIC_CANISTER_ID:user_service") and parses it with Principal::from_text
    ✅ Does NOT take the sibling ID as an #[init] or #[post_upgrade] parameter

  WITHOUT skill: 2/4 passed
    ❌ Deploy command is a plain `icp deploy content_service` ...
       → uses `icp-cli deploy content_service --network local`
    ✅ Does NOT use `--argument` or `--argument-file` ...
    ❌ Rust accessor reads ic_cdk::api::env_var_value(...) ...
       → uses the env!("CANISTER_ID_USER_SERVICE") compile-time macro instead
    ✅ Does NOT take the sibling ID as an #[init] or #[post_upgrade] parameter

  Summary: WITH 4/4 | WITHOUT 2/4
```

Baseline reaches for dfx's `CANISTER_ID_*` compile-time convention, which icp-cli does not provide.

</details>

<details>
<summary>Regression — existing case 1, unchanged (--no-baseline)</summary>

```
━━━ Adversarial: dependencies field for deploy ordering ━━━
  ✅ States that icp.yaml deploys canisters in parallel and deploy ordering is not needed for ID discovery
  ✅ Says icp deploy injects every canister's ID as a PUBLIC_CANISTER_ID:<canister-name> environment variable
  ✅ Shows reading the ID with Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service") in Motoko
  ✅ Does NOT invent a dependencies field or other deploy-ordering configuration in icp.yaml

  Summary: WITH 4/4
```

Run because this PR edits the deploy-order commands that case partly covers.

</details>

`npm run validate` — 26 skills validated, all passed (15 warnings, all pre-existing).

## Follow-up (not in this PR)

`skills/icrc-ledger/SKILL.md:52` has the same nonexistent flags in pitfall 8: `--argument-file` and `--argument`, which should be `--args-file` and `--args`. Out of scope here — happy to send it separately or fold it in if you'd rather have one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek