### PR TITLE
fix(vetkd): use the current ic-cdk call API for management-canister vetKD calls

### DIFF
--- a/evaluations/vetkd.json
+++ b/evaluations/vetkd.json
@@ -1,0 +1,28 @@
+{
+  "skill": "vetkd",
+  "description": "Evaluation cases for the vetkd skill. Tests whether agents use the current ic-cdk call API for management-canister vetKD calls rather than the ic_cdk::api::call::* / ic_cdk::caller() functions, which are deprecated in ic-cdk 0.19 and removed in 0.20.",
+
+  "output_evals": [
+    {
+      "name": "Adversarial: management canister vetkd_derive_key call with cycles",
+      "prompt": "Write the Rust update function that calls the management canister's vetkd_derive_key for the calling principal, attaching the cycles key_1 needs. Just the function body and the imports it needs, no struct definitions and no Cargo.toml.",
+      "expected_behaviors": [
+        "Builds the call with Call::unbounded_wait(Principal::management_canister(), \"vetkd_derive_key\")",
+        "Attaches cycles with .with_cycles(...) using ~26 billion for key_1",
+        "Gets the caller with ic_cdk::api::msg_caller() and captures it before the await",
+        "Does NOT use ic_cdk::api::call::call, call_with_payment128, or ic_cdk::caller() — all removed in ic-cdk 0.20"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I derive a per-user encryption key inside my canister with vetKeys?",
+      "How many cycles does a vetkd_derive_key call cost?"
+    ],
+    "should_not_trigger": [
+      "How do I let users sign in to my dapp with Internet Identity?"
+    ]
+  }
+}

--- a/skills/vetkd/SKILL.md
+++ b/skills/vetkd/SKILL.md
@@ -177,7 +177,7 @@ fn init() {
 
 #[update]
 async fn get_encrypted_vetkey(subkey_id: Vec<u8>, transport_public_key: Vec<u8>) -> Vec<u8> {
-    let caller = ic_cdk::caller(); // Capture BEFORE await
+    let caller = ic_cdk::api::msg_caller(); // Capture BEFORE await
     let future = KEY_MANAGER.with(|km| {
         let km = km.borrow();
         let km = km.as_ref().expect("not initialized");
@@ -202,6 +202,7 @@ async fn get_vetkey_verification_key() -> Vec<u8> {
 
 ```rust
 use candid::{CandidType, Deserialize, Principal};
+use ic_cdk::call::Call;
 use ic_cdk::update;
 
 #[derive(CandidType, Deserialize)]
@@ -260,20 +261,22 @@ async fn vetkd_public_key() -> Vec<u8> {
     };
 
     // vetkd_public_key does not require cycles (unlike vetkd_derive_key).
-    let (response,): (VetKdPublicKeyResponse,) = ic_cdk::api::call::call(
+    let response: VetKdPublicKeyResponse = Call::unbounded_wait(
         Principal::management_canister(), // aaaaa-aa
         "vetkd_public_key",
-        (request,),
     )
+    .with_arg(request)
     .await
-    .expect("vetkd_public_key call failed");
+    .expect("vetkd_public_key call failed")
+    .candid()
+    .expect("failed to decode vetkd_public_key response");
 
     response.public_key
 }
 
 #[update]
 async fn vetkd_derive_key(transport_public_key: Vec<u8>) -> Vec<u8> {
-    let caller = ic_cdk::caller(); // MUST capture before await
+    let caller = ic_cdk::api::msg_caller(); // MUST capture before await
 
     let request = VetKdDeriveKeyRequest {
         input: caller.as_slice().to_vec(), // derive key specific to this caller
@@ -283,14 +286,16 @@ async fn vetkd_derive_key(transport_public_key: Vec<u8>) -> Vec<u8> {
     };
 
     // key_1 costs ~26B cycles, test_key_1 costs ~10B cycles.
-    let (response,): (VetKdDeriveKeyResponse,) = ic_cdk::api::call::call_with_payment128(
+    let response: VetKdDeriveKeyResponse = Call::unbounded_wait(
         Principal::management_canister(),
         "vetkd_derive_key",
-        (request,),
-        26_000_000_000, // cycles for key_1 (use 10_000_000_000 for test_key_1)
     )
+    .with_arg(request)
+    .with_cycles(26_000_000_000) // cycles for key_1 (use 10_000_000_000 for test_key_1)
     .await
-    .expect("vetkd_derive_key call failed");
+    .expect("vetkd_derive_key call failed")
+    .candid()
+    .expect("failed to decode vetkd_derive_key response");
 
     response.encrypted_key
 }


### PR DESCRIPTION
Closes #272.

## Problem

The Rust snippets called `ic_cdk::caller()`, `ic_cdk::api::call::call`, and `ic_cdk::api::call::call_with_payment128`.

One correction to the issue: it says the code "likely will not compile against its own declared CDK version." It does compile at the pinned `ic-cdk = "0.19"` — those functions are deprecated there, not gone. The real breakage is one minor version later.

## Verification (compiled, not assumed)

I extracted the skill's "Calling management canister directly" block verbatim and built it against the skill's own pinned deps:

| ic-cdk | Result |
|---|---|
| 0.19.0 (the pin) | compiles — 3 deprecation warnings (`ic_cdk::caller` → `msg_caller`, `call`/`call_with_payment128` → `Call::unbounded_wait()`) |
| 0.20.2 (current release) | **3 hard errors** — `cannot find 'call' in 'api'` ×2, `cannot find function 'caller' in crate 'ic_cdk'` |

Builder API confirmed against `ic-cdk-0.19.0/src/call.rs`: `unbounded_wait` (:197), `with_arg` (:216), `with_cycles` (:279), `candid` (:342).

After the change, the same extracted block compiles **clean with zero warnings on both 0.19.0 and 0.20.2**.

## Change

- `Call::unbounded_wait(Principal::management_canister(), "vetkd_public_key").with_arg(request).await…​.candid()`
- `vetkd_derive_key` likewise, with the cycles moved to `.with_cycles(26_000_000_000)`
- `ic_cdk::caller()` → `ic_cdk::api::msg_caller()` in both the `ic-vetkeys` and lower-level snippets
- added `use ic_cdk::call::Call;`

This is the API `canister-security`, `multi-canister`, and `internet-identity` already use at the same pin, which resolves the cross-skill contradiction in the issue.

The `ic-cdk = "0.19"` pin is deliberately untouched — the modern API exists at 0.19, so no bump is needed here, and pin drift is tracked in #301.

## Eval results

The skill had no eval file; this seeds `evaluations/vetkd.json` with one adversarial output case and three trigger queries.

<details>
<summary>node scripts/evaluate-skills.js vetkd</summary>

```
━━━ Adversarial: management canister vetkd_derive_key call with cycles ━━━

  WITH skill: 4/4 passed
    ✅ Builds the call with Call::unbounded_wait(Principal::management_canister(), "vetkd_derive_key")
    ✅ Attaches cycles with .with_cycles(...) using ~26 billion for key_1
    ✅ Gets the caller with ic_cdk::api::msg_caller() and captures it before the await
    ✅ Does NOT use ic_cdk::api::call::call, call_with_payment128, or ic_cdk::caller() — all removed in ic-cdk 0.20

  WITHOUT skill: 0/4 passed
    ❌ Builds the call with Call::unbounded_wait(...) → uses ic_cdk::api::call::call_with_payment128 instead
    ❌ Attaches cycles with .with_cycles(...) → passes cycles as a positional arg to call_with_payment128
    ❌ Gets the caller with ic_cdk::api::msg_caller() → calls the deprecated ic_cdk::caller()
    ❌ Does NOT use the removed APIs → uses both call_with_payment128 and ic_cdk::caller()

━━━ Trigger Evals ━━━
  Should trigger: 2/2 correct
  Should NOT trigger: 1/1 correct

  Summary: WITH 4/4 | WITHOUT 0/4 | triggers 2/2 and 1/1
```

The baseline writes exactly the code that fails to compile on current ic-cdk.

</details>

`npm run validate` — 26 skills validated, all passed (15 warnings, all pre-existing).

## Note

PR #162 also touches `skills/vetkd/SKILL.md` (replacing it with a `vetkeys` skill). It has been open since April; this change is confined to two snippets, so it should be easy to carry across if #162 lands later — but flagging it in case you'd rather fix this there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek