### PR TITLE
fix(stable-memory): dot-notation Map calls in the persistent actor example

### DIFF
--- a/evaluations/stable-memory.json
+++ b/evaluations/stable-memory.json
@@ -1,0 +1,28 @@
+{
+  "skill": "stable-memory",
+  "description": "Evaluation cases for the stable-memory skill. Tests whether agents write persistent actors in the dot-notation call style mo:core requires (moc >= 1.7.0) instead of passing Map's implicit compare argument explicitly.",
+
+  "output_evals": [
+    {
+      "name": "Adversarial: mo:core Map call style in a persistent actor",
+      "prompt": "Write a Motoko persistent actor that keeps users in a Map keyed by Nat, with an addUser and a getUser method, using mo:core. Just the actor and its imports, no mops.toml and no explanation.",
+      "expected_behaviors": [
+        "Calls Map operations in dot notation on the map value, e.g. users.add(id, user) and users.get(id)",
+        "Does NOT pass Nat.compare (or any compare function) explicitly as an argument",
+        "Imports mo:core/Nat, which is what lets the compiler derive Map's implicit compare argument",
+        "Declares the map with Map.empty<Nat, User>() and no `stable` keyword"
+      ]
+    }
+  ],
+
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "My canister loses all its data every time I upgrade it",
+      "How do I keep a Map across canister upgrades in Motoko?"
+    ],
+    "should_not_trigger": [
+      "How do I call another canister and handle a rejected call?"
+    ]
+  }
+}

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -2,7 +2,7 @@
 name: stable-memory
 description: "Persist canister state across upgrades. Covers StableBTreeMap and MemoryManager in Rust, persistent actor in Motoko, and upgrade hook patterns. Use when dealing with canister upgrades, data persistence, data lost after upgrade, stable storage, StableBTreeMap, pre_upgrade traps, or heap vs stable memory. Do NOT use for inter-canister calls or access control — use multi-canister or canister-security instead."
 license: Apache-2.0
-compatibility: "icp-cli >= 0.2.2"
+compatibility: "icp-cli >= 0.2.2, moc >= 1.7.0 for the Motoko examples (dot notation)"
 metadata:
   title: "Stable Memory & Upgrades"
   category: Core
@@ -15,7 +15,7 @@ Stable memory is persistent storage on Internet Computer that survives canister 
 
 ## Prerequisites
 
-- For Motoko: mops with `core = "2.0.0"` in mops.toml
+- For Motoko: mops with `core = "2.0.0"` in mops.toml, and `moc >= 1.7.0` (dot notation on `Map`/`List` needs it)
 - For Rust: `ic-stable-structures = "0.7"` in Cargo.toml
 
 ## Canister IDs
@@ -46,7 +46,7 @@ With mo:core 2.0, `persistent actor` makes stable storage trivial. All `let` and
 ```motoko
 import Map "mo:core/Map";
 import List "mo:core/List";
-import Nat "mo:core/Nat";
+import Nat "mo:core/Nat";  // required: the compiler derives Map's implicit `compare` from this module
 import Text "mo:core/Text";
 import Time "mo:core/Time";
 
@@ -69,7 +69,7 @@ persistent actor {
 
   public func addUser(name : Text) : async Nat {
     let id = userCounter;
-    Map.add(users, Nat.compare, id, {
+    users.add(id, {
       id;
       name;
       created = Time.now();
@@ -80,11 +80,11 @@ persistent actor {
   };
 
   public query func getUser(id : Nat) : async ?User {
-    Map.get(users, Nat.compare, id)
+    users.get(id)
   };
 
   public query func getUserCount() : async Nat {
-    Map.size(users)
+    users.size()
   };
 
   // requestCount resets to 0 after every upgrade


### PR DESCRIPTION
Closes #277.

## Problem

The canonical `persistent actor` example called `mo:core` `Map` in the module-function style that `motoko` explicitly forbids (`SKILL.md:22`, and `:120-123` marks `Map.add(m, Nat.compare, 1, "hello")` as wrong):

```motoko
Map.add(users, Nat.compare, id, {...});   // ✗
Map.get(users, Nat.compare, id)           // ✗
Map.size(users)                           // ✗
```

## Verification (compiled, not assumed)

Real `mops check` runs, with `core = "2.0.0"` as this skill pins:

| moc | dot notation | module style |
|---|---|---|
| 1.9.0 | ✓ | ✓ |
| 0.14.14 | ✗ `M0072 field get does not exist` | ✓ |

Two things this establishes that the issue didn't:

1. **The module style is not a compile error** — both styles typecheck on a current compiler. So this is the style rule `motoko` mandates, not broken code.
2. **Dot notation is a *compiler* feature, not a library one.** It works at `core = "2.0.0"`; what it needs is `moc >= 1.7.0`. `stable-memory` declared no moc version at all, so the rewritten example needs that floor added — otherwise it silently fails for anyone on an older compiler.

I also tried dropping the now-seemingly-unused `mo:core/Nat` import. That **breaks the build**:

```
M0230: Cannot determine implicit argument `compare` of type (Nat, Nat) -> Order
note: Did you mean to import mo:core/Nat?
```

The import is precisely *how* `users.add(id, …)` derives `compare` — the mechanism `motoko:110` describes as "Nat.compare inferred". Kept it, with a comment so it doesn't get pruned as dead.

The final example compiles clean (`✓ src/main.mo`); the one remaining warning, unused `tags`, is pre-existing and untouched.

## Change

- Three call sites → `users.add(id, {...})`, `users.get(id)`, `users.size()`. `Map.empty<Nat, User>()` stays module-style — it takes no self parameter, matching `motoko:107`.
- `compatibility:` and Prerequisites now state `moc >= 1.7.0` for the Motoko examples.
- Comment on the `Nat` import explaining why it must stay.

## Eval results

The skill had no eval file; this seeds `evaluations/stable-memory.json`.

<details>
<summary>node scripts/evaluate-skills.js stable-memory</summary>

```
━━━ Adversarial: mo:core Map call style in a persistent actor ━━━

  WITH skill: 4/4 passed
    ✅ Calls Map operations in dot notation on the map value
    ✅ Does NOT pass Nat.compare explicitly
    ✅ Imports mo:core/Nat, which lets the compiler derive Map's implicit compare
    ✅ Declares the map with Map.empty<Nat, User>() and no `stable` keyword

  WITHOUT skill: 2/4 passed
    ❌ Calls Map operations in dot notation
       → calls Map.add(users, Nat.compare, id, {...}) and Map.get(users, Nat.compare, id)
    ❌ Does NOT pass Nat.compare explicitly
       → Nat.compare passed explicitly to both
    ✅ Imports mo:core/Nat
    ✅ Declares the map with Map.empty<Nat, User>()

━━━ Trigger Evals ━━━
  Should trigger: 2/2 | Should NOT trigger: 1/1

  Summary: WITH 4/4 | WITHOUT 2/4
```

The baseline writes the exact style this PR removes.

</details>

`npm run validate` — 26 skills validated, all passed (15 warnings, all pre-existing).

## Related, not included

`#295` covers this skill's `mops.toml` example having no `[toolchain]` section. That is the natural place to pin `moc` in the config example; I've stated the floor in `compatibility`/Prerequisites here and left the config example for that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek