### PR TITLE
fix(icp-cli): `-i` is `--id-only`, not an identity selector

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -202,6 +202,7 @@
         "States prerequisites: local network must be running (icp network start -d) and backend must be deployed (icp deploy backend) before vite dev works",
         "Wraps getDevServerConfig() in a mode guard so it only runs during vite dev (command === 'serve'), not during vite build",
         "Uses icp network status and icp canister status commands (not dfx or hardcoded ports)",
+        "Reads canister IDs with `icp canister status <name> --id-only` (or its short form `-i`), not by parsing full status output",
         "Mentions the ic_env cookie for passing canister IDs and root key to the frontend",
         "Does NOT suggest using .env files or process.env for canister IDs"
       ]

--- a/skills/icp-cli/references/dev-server.md
+++ b/skills/icp-cli/references/dev-server.md
@@ -22,8 +22,8 @@ const environment = process.env.ICP_ENVIRONMENT || "local";
 const CANISTER_NAMES = ["backend", "other"];
 
 function getCanisterId(name) {
-  // `-i` makes the command return only the identity of the canister
-  return execSync(`icp canister status ${name} -e ${environment} -i`, {
+  // `--id-only` makes the command print just the canister ID
+  return execSync(`icp canister status ${name} -e ${environment} --id-only`, {
     encoding: "utf-8", stdio: "pipe",
   }).trim();
 }
@@ -72,6 +72,6 @@ Without this guard, `vite build` will execute `icp network status` and `icp cani
 ## Key differences from dfx
 
 - The proxy target and root key come from `icp network status --json` (no hardcoded ports)
-- Canister IDs come from `icp canister status <name> -e <env> -i` (no `.env` file)
+- Canister IDs come from `icp canister status <name> -e <env> --id-only` (no `.env` file)
 - The `ic_env` cookie replaces dfx's `CANISTER_ID_*` environment variables
 - `ICP_ENVIRONMENT` lets the dev server target any environment (local, staging, ic)


### PR DESCRIPTION
Closes #280.

## Problem

`references/dev-server.md:25` told agents that `-i` "makes the command return only the identity of the canister". An agent reading that could reasonably write `icp canister status backend -i my-identity`, which is wrong in a way the CLI will not catch as a typo.

## Verification

From `icp canister status --help` on icp 1.2.0:

```
  -i, --id-only
          Only print the canister ids

Identity Selection Parameters:
      --identity <IDENTITY>
          The user identity to run this command as
```

So `-i` is the short form of `--id-only`, and `--identity` has **no** short form — the "identity" reading is impossible. The issue's first reading was correct.

## Change

Switched the three occurrences in `dev-server.md` to the explicit `--id-only` and corrected the comment to "prints just the canister ID". That matches the 12 other uses across `static-site`, `multi-canister`, and `dfx-migration.md`, so the repo now spells this one way. No other file used the short form.

## Eval results

Extended the existing "Dev server configuration" case — which already covers this file — with one behavior asserting how canister IDs get read.

<details>
<summary>node scripts/evaluate-skills.js icp-cli --eval 19</summary>

```
━━━ Dev server configuration ━━━

  WITH skill: 7/7 passed
    ✅ Shows or references the getDevServerConfig() pattern from references/dev-server.md
    ✅ States prerequisites: local network running and backend deployed
    ✅ Wraps getDevServerConfig() in a mode guard (command === 'serve')
    ✅ Uses icp network status and icp canister status commands (not dfx or hardcoded ports)
    ✅ Reads canister IDs with `icp canister status <name> --id-only` (or its short form `-i`)
    ✅ Mentions the ic_env cookie for passing canister IDs and root key to the frontend
    ✅ Does NOT suggest using .env files or process.env for canister IDs

  WITHOUT skill: 0/7 passed
    ❌ ... → uses dfx throughout, hardcodes port 4943
    ❌ Reads canister IDs with --id-only
       → sources them from .dfx/local/canister_ids.json and .env via dotenv
    ❌ ... → no ic_env cookie; relies on process.env.CANISTER_ID_BACKEND

  Summary: WITH 7/7 | WITHOUT 0/7
```

</details>

`npm run validate` — 26 skills validated, all passed (15 warnings, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek