### PR TITLE
fix(cycles-management): canister is uninstalled at zero cycles, not deleted

### DIFF
--- a/evaluations/cycles-management.json
+++ b/evaluations/cycles-management.json
@@ -20,6 +20,15 @@
         "Recommends 'icp canister top-up <canister> --amount <N> -e ic' as the correct fix",
         "Does NOT suggest that running 'icp cycles transfer' again (to the canister or elsewhere) will move the parked cycles into the canister's execution balance -- only 'icp canister top-up' increases it"
       ]
+    },
+    {
+      "name": "Zero cycles uninstalls the canister, it is not deleted",
+      "prompt": "My mainnet canister ran out of cycles months ago and I never topped it up. Its ID is hardcoded in my frontend and in two other canisters. Do I have to create a brand new canister and update every hardcoded ID? Short answer, no top-up commands.",
+      "expected_behaviors": [
+        "States that at zero cycles the canister is uninstalled -- its code and data are deleted",
+        "States that the canister ID, controllers, and settings are retained",
+        "Does NOT claim the canister itself is permanently deleted or that the canister ID is lost"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/cycles-management/SKILL.md
+++ b/skills/cycles-management/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 # Cycles & Canister Management
 
 ## What This Is
-Cycles are the computation fuel for canisters on Internet Computer. Every canister operation (execution, storage, messaging) burns cycles. When a canister runs out of cycles, it freezes and eventually gets deleted. 1 trillion cycles (1T) costs approximately 1 USD equivalent in ICP (the exact rate is set by the NNS and fluctuates with ICP price via the CMC).
+Cycles are the computation fuel for canisters on Internet Computer. Every canister operation (execution, storage, messaging) burns cycles. When a canister runs out of cycles, it freezes and is eventually uninstalled -- its code and data are deleted, but its metadata (canister ID, controllers, settings) survives. 1 trillion cycles (1T) costs approximately 1 USD equivalent in ICP (the exact rate is set by the NNS and fluctuates with ICP price via the CMC).
 
 **Note:** icp-cli uses the **cycles ledger** (`um5iw-rqaaa-aaaaq-qaaba-cai`) by default. The cycles ledger is a single canister that tracks cycle balances for all principals, similar to a token ledger. Commands like `icp cycles balance`, `icp cycles mint`, and `icp canister top-up` go through the cycles ledger. There is no legacy wallet concept in icp-cli. The programmatic patterns below (accepting cycles, creating canisters via management canister) remain the same regardless of which funding mechanism is used.
 
@@ -32,7 +32,7 @@ The Management Canister (`aaaaa-aa`) is a virtual canister -- it does not exist 
 
 ## Mistakes That Break Your Build
 
-1. **Running out of cycles silently freezes the canister** -- There is no warning. The canister stops responding to all calls. If cycles are not topped up before the freezing threshold, the canister and all its data will be permanently deleted. Set a freezing threshold and monitor balances.
+1. **Running out of cycles silently freezes the canister** -- There is no warning. A frozen canister stops executing messages but keeps paying rent for its memory and allocations, so the balance continues to drain. When it reaches zero the canister is uninstalled: code and data are gone permanently, and only the metadata (canister ID, controllers, settings) remains. Set a freezing threshold and monitor balances.
 
 2. **Not setting freezing_threshold** -- Default is 30 days. If your canister burns cycles fast (high traffic, large stable memory), 30 days may not be enough warning. Set it higher for production canisters. The freezing threshold defines how many seconds worth of idle cycles the canister must retain before it freezes.
 


### PR DESCRIPTION
Closes #270

## Problem

Two skills gave materially different answers for what happens when a canister runs out of cycles:

- `skills/canister-security/SKILL.md:31` — "the canister is uninstalled — its code and memory are removed, though the canister ID and controllers survive"
- `skills/cycles-management/SKILL.md:14` — "it freezes and eventually gets deleted"
- `skills/cycles-management/SKILL.md:35` — "the canister and all its data will be permanently deleted"

`canister-security` is correct. Verified against the IC docs on the freezing threshold ([source](https://github.com/dfinity/portal/blob/master/docs/building-apps/canister-management/settings.mdx#L150-L163)):

> If a canister runs out of cycles and the freezing threshold expires, then it gets uninstalled, meaning that its code and data are deleted. A canister will only retain its metadata such as the canister ID, controllers, settings, etc.

> A frozen canister does not execute messages and pays only for renting resources such as compute allocation, memory allocation, and memory usage.

The old wording also implied freezing is a terminal state reached at zero cycles. It isn't — freezing happens above zero, and the frozen canister keeps paying rent until the balance actually reaches zero.

## Change

Only `cycles-management` changed; `canister-security` was already correct and is untouched.

- **Line 14** — "freezes and eventually gets deleted" → "freezes and is eventually uninstalled -- its code and data are deleted, but its metadata (canister ID, controllers, settings) survives".
- **Pitfall 1** — replaced "the canister and all its data will be permanently deleted" with the actual sequence: frozen canister stops executing messages but keeps paying rent, balance drains to zero, canister is uninstalled, metadata remains.

## Evals

Added one output eval to `evaluations/cycles-management.json`. The prompt deliberately avoids priming the answer — it asks the practical question (do I need a new canister ID?) rather than "what survives?", which every configuration answers correctly.

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| With skill (old text, pre-fix) | 1/3 |
| Without skill (baseline) | 2/3 |

The old text actively pushed the model to the wrong answer, scoring below the no-skill baseline.

<details>
<summary>Eval output</summary>

```
━━━ Zero cycles uninstalls the canister, it is not deleted ━━━

  WITH skill: 3/3 passed
    ✅ States that at zero cycles the canister is uninstalled -- its code and data are deleted
    ✅ States that the canister ID, controllers, and settings are retained
    ✅ Does NOT claim the canister itself is permanently deleted or that the canister ID is lost

  WITHOUT skill: 2/3 passed
    ✅ States that at zero cycles the canister is uninstalled -- its code and data are deleted
    ❌ States that the canister ID, controllers, and settings are retained
       → The output only mentions the canister ID persisting as an empty record and never
         mentions controllers or settings being retained.
    ✅ Does NOT claim the canister itself is permanently deleted or that the canister ID is lost

━━━ Summary ━━━
  Zero cycles uninstalls the canister, it is not deleted: WITH 3/3 | WITHOUT 2/3
```

Same case run against the pre-fix skill text (`--no-baseline`), showing the delta the fix closes:

```
  WITH skill: 1/3 passed
    ❌ States that at zero cycles the canister is uninstalled -- its code and data are deleted
       → The output explicitly claims the opposite, stating 'State, Wasm module, and the
         canister ID are all preserved' when frozen/out of cycles, never mentioning that the
         IC uninstalls the code and wipes memory at zero balance.
    ❌ States that the canister ID, controllers, and settings are retained
       → The output only explicitly states the canister ID is preserved; it never states that
         controllers or settings are retained.
    ✅ Does NOT claim the canister itself is permanently deleted or that the canister ID is lost
```

</details>

Existing eval cases 1 and 2 cover `icp canister top-up` vs `icp cycles transfer` — untouched by this change, so not re-run.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek