### PR TITLE
fix(ckbtc): set created_at_time on ledger calls so retries deduplicate

### DIFF
--- a/evaluations/ckbtc.json
+++ b/evaluations/ckbtc.json
@@ -1,0 +1,27 @@
+{
+  "skill": "ckbtc",
+  "description": "Evaluation cases for the ckbtc skill. Tests whether agents generate ckBTC transfers that set created_at_time for ICRC-1 deduplication rather than leaving it null.",
+  "output_evals": [
+    {
+      "name": "ckBTC transfer sets created_at_time for dedup",
+      "prompt": "Write the Motoko function for my canister that transfers ckBTC from the caller's subaccount to another principal on mainnet. Just the function, no imports, no type definitions, no deploy steps.",
+      "expected_behaviors": [
+        "Sets created_at_time to a real timestamp derived from Time.now(), NOT to null",
+        "Uses fee = ?10 (10 satoshis) rather than null or a different fee",
+        "Passes an ICRC-1 Account record { owner; subaccount } as 'to', not a raw Principal or an AccountIdentifier hex string"
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "How do I give each user their own BTC deposit address in my canister?",
+      "My users need to withdraw ckBTC back to a real Bitcoin address",
+      "Why does update_balance return NoNewUtxos after I sent BTC?"
+    ],
+    "should_not_trigger": [
+      "How do I transfer ICP from my canister to a user?",
+      "Set up an ICRC-1 ledger for my own token locally"
+    ]
+  }
+}

--- a/skills/ckbtc/SKILL.md
+++ b/skills/ckbtc/SKILL.md
@@ -80,6 +80,8 @@ Each user gets a unique deposit address derived from their principal + an option
 
 8. **Forgetting `owner` in `get_btc_address` args.** If you omit `owner`, Candid sub-typing assigns null, and the minter returns the deposit address of the caller (the canister) instead of the user.
 
+9. **Leaving `created_at_time` null on `icrc1_transfer` / `icrc2_approve`.** The ICRC-1 spec says a ledger SHOULD NOT deduplicate a transaction whose `created_at_time` is unset, so a retried transfer executes a second time and moves real BTC-backed value twice. Set it, and retry with the **same** timestamp — the ledger only matches duplicates when every argument is identical, so a fresh `Time.now()` on retry defeats dedup. A retry that was already applied returns `#Err(#Duplicate { duplicate_of })`, which is a success, not a failure.
+
 ## Implementation
 
 ### Motoko
@@ -117,6 +119,8 @@ import Blob "mo:core/Blob";
 import Nat "mo:core/Nat";
 import Nat8 "mo:core/Nat8";
 import Nat64 "mo:core/Nat64";
+import Int "mo:core/Int";
+import Time "mo:core/Time";
 import Array "mo:core/Array";
 import Result "mo:core/Result";
 import Error "mo:core/Error";
@@ -309,13 +313,14 @@ persistent actor Self {
   public shared ({ caller }) func transfer(to : Principal, amount : Nat) : async TransferResult {
     if (Principal.isAnonymous(caller)) { Runtime.trap("Authentication required") };
     let fromSubaccount = principalToSubaccount(caller);
+    let now = Nat64.fromNat(Int.abs(Time.now()));
     await ckbtcLedger.icrc1_transfer({
       from_subaccount = ?fromSubaccount;
       to = { owner = to; subaccount = null };
       amount = amount;
       fee = ?10; // 10 satoshis
       memo = null;
-      created_at_time = null;
+      created_at_time = ?now; // required for dedup — see Pitfall 9
     })
   };
 
@@ -326,6 +331,7 @@ persistent actor Self {
 
     // Step 1: Approve the minter to spend ckBTC from the user's subaccount
     let fromSubaccount = principalToSubaccount(caller);
+    let now = Nat64.fromNat(Int.abs(Time.now()));
     let approveResult = await ckbtcLedger.icrc2_approve({
       from_subaccount = ?fromSubaccount;
       spender = {
@@ -337,7 +343,7 @@ persistent actor Self {
       expires_at = null;
       fee = ?10;
       memo = null;
-      created_at_time = null;
+      created_at_time = ?now; // required for dedup — see Pitfall 9
     });
 
     switch (approveResult) {
@@ -580,7 +586,7 @@ async fn transfer(to: Principal, amount: Nat) -> Result<Nat, TransferError> {
         amount,
         fee: Some(Nat::from(10u64)), // 10 satoshis
         memo: None,
-        created_at_time: None,
+        created_at_time: Some(ic_cdk::api::time()), // required for dedup — see Pitfall 9
     };
 
     let (result,): (Result<Nat, TransferError>,) = Call::unbounded_wait(ledger_id(), "icrc1_transfer")
@@ -613,7 +619,7 @@ async fn withdraw(btc_address: String, amount: u64) -> RetrieveBtcResult {
         expires_at: None,
         fee: Some(Nat::from(10u64)),
         memo: None,
-        created_at_time: None,
+        created_at_time: Some(ic_cdk::api::time()), // required for dedup — see Pitfall 9
     };
 
     let (approve_result,): (Result<Nat, ApproveError>,) = Call::unbounded_wait(ledger_id(), "icrc2_approve")
@@ -685,6 +691,8 @@ icp canister call mqygn-kiaaa-aaaar-qaadq-cai update_balance \
   -e ic
 
 # Transfer ckBTC (amount in e8s — 1 ckBTC = 100_000_000)
+# created_at_time is null here: no dedup, which is fine for a one-off manual
+# call but not for canister code — see Pitfall 9.
 icp canister call mxzaz-hqaaa-aaaar-qaada-cai icrc1_transfer \
   '(record {
     to = record { owner = principal "RECIPIENT-PRINCIPAL"; subaccount = null };


### PR DESCRIPTION
Closes #273

## Problem

`icrc-ledger` Pitfall 5 says to always set `created_at_time`, and every one of its own examples does (`created_at_time = ?now` in Motoko, `Some(ic_cdk::api::time())` in Rust). Every `ckbtc` example did the opposite — `null`/`None` at all six call sites.

I checked this against the [ICRC-1 spec](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md#transaction_deduplication) rather than taking either skill's word for it:

> If the client did not set the `created_at_time` field, the ledger SHOULD NOT deduplicate the transaction.

So `icrc-ledger` is correct and `ckbtc` was the skill to fix. A retried ckBTC transfer with `created_at_time = null` executes a second time and moves real BTC-backed value twice.

`icrc2_approve` carries the same `created_at_time`, `Duplicate`, `TooOld`, and `CreatedInFuture` machinery in [ICRC-2](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-2/README.md), so the approve call in the withdraw flow needed the same fix.

## Change

Only `ckbtc` changed; `icrc-ledger` was already correct and is untouched.

- **Motoko** (`icrc1_transfer`, `icrc2_approve`) — `created_at_time = ?now` with `let now = Nat64.fromNat(Int.abs(Time.now()));`, the same expression `icrc-ledger` uses. Added the `Int` and `Time` imports this requires.
- **Rust** (`icrc1_transfer`, `icrc2_approve`) — `created_at_time: Some(ic_cdk::api::time())`.
- **Pitfall 9** — added, covering the part that makes the field actually useful: the retry must reuse the **same** timestamp, because the ledger only matches duplicates when every argument and the caller are identical (spec: "structurally equal transfer payload"), so a fresh `Time.now()` on retry silently defeats dedup. Also notes that `#Err(#Duplicate { duplicate_of })` on a retry is a success, not a failure.
- **CLI examples** — left at `null`, since a shell cannot compute a nanosecond timestamp inside a Candid literal. Added a note that this is acceptable for a one-off manual call but not for canister code. The note is placed **outside** the Candid argument string: Candid's text format has no `#` comment, so a comment inside the record would have broken the call.

The `TransferError`/`ApproveError` types in the examples already included `Duplicate`, `TooOld`, and `CreatedInFuture`, so no type changes were needed.

## Evals

`evaluations/ckbtc.json` did not exist — seeded it with one output case covering this change plus trigger coverage.

| | Score |
|---|---|
| Output eval, with skill | **3/3** |
| Output eval, without skill | 2/3 |
| Trigger evals | should-trigger 3/3, should-not-trigger 2/2 |

The one behavior the baseline misses is exactly the one this PR fixes.

<details>
<summary>Eval output</summary>

```
━━━ ckBTC transfer sets created_at_time for dedup ━━━

  WITH skill: 3/3 passed
    ✅ Sets created_at_time to a real timestamp derived from Time.now(), NOT to null
    ✅ Uses fee = ?10 (10 satoshis) rather than null or a different fee
    ✅ Passes an ICRC-1 Account record { owner; subaccount } as 'to', not a raw Principal
       or AccountIdentifier hex string

  WITHOUT skill: 2/3 passed
    ❌ Sets created_at_time to a real timestamp derived from Time.now(), NOT to null
       → The code explicitly sets created_at_time = null instead of deriving a timestamp
         from Time.now().
    ✅ Uses fee = ?10 (10 satoshis) rather than null or a different fee
    ✅ Passes an ICRC-1 Account record { owner; subaccount } as 'to', not a raw Principal
       or an AccountIdentifier hex string

━━━ Trigger Evals ━━━

  Should trigger: 3/3 correct
    ✅ "How do I give each user their own BTC deposit address in my canister?"
    ✅ "My users need to withdraw ckBTC back to a real Bitcoin address"
    ✅ "Why does update_balance return NoNewUtxos after I sent BTC?"

  Should NOT trigger: 2/2 correct
    ✅ "How do I transfer ICP from my canister to a user?"
    ✅ "Set up an ICRC-1 ledger for my own token locally"
```

</details>

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek