### PR TITLE
fix(stable-memory): plain `actor` is a compile error, not a stable-annotation choice

### DIFF
--- a/evaluations/stable-memory.json
+++ b/evaluations/stable-memory.json
@@ -12,6 +12,15 @@
         "Imports mo:core/Nat, which is what lets the compiler derive Map's implicit compare argument",
         "Declares the map with Map.empty<Nat, User>() and no `stable` keyword"
       ]
+    },
+    {
+      "name": "Adversarial: M0219 on a plain actor — the compiler's own suggestion is the wrong fix",
+      "prompt": "My Motoko canister won't compile. Inside `actor { ... }` I have `var users = Map.empty<Nat, User>()` and moc reports: type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`. I need users to survive canister upgrades. What is the fix? Just the fix, no full rewrite.",
+      "expected_behaviors": [
+        "Says to declare the actor as `persistent actor` (or equivalently to enable the --default-persistent-actors compiler flag)",
+        "Does NOT tell the user to add `transient` to the declaration, even though the error message suggests it -- that would discard users on upgrade",
+        "Does NOT claim plain `actor` can be made to persist by adding `stable`, `pre_upgrade`, or `post_upgrade`"
+      ]
     }
   ],
 

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -35,7 +35,21 @@ No external canister dependencies. Stable memory is a local canister feature.
 
 6. **Serializing large data in pre_upgrade (Rust)** -- `pre_upgrade` has a fixed instruction limit. If you serialize a large HashMap to stable memory in pre_upgrade, it will hit the limit and trap, bricking the canister. Use `StableBTreeMap` which writes directly to stable memory and needs no serialization step.
 
-7. **Using `actor { }` instead of `persistent actor { }` (Motoko)** -- Plain `actor` in mo:core requires explicit `stable` annotations and pre/post_upgrade hooks. `persistent actor` makes everything stable by default. Always use `persistent actor`.
+7. **Using `actor { }` instead of `persistent actor { }` (Motoko)** -- Plain `actor` does not compile under enhanced orthogonal persistence. There is no annotation that rescues it: the error is on the actor itself, so `stable`, `transient`, and `pre_upgrade`/`post_upgrade` hooks all still fail.
+
+   ```motoko
+   actor {
+     stable var users = Map.empty<Nat, Text>();   // M0220: this actor or actor class
+   };                                             // should be declared `persistent`
+
+   persistent actor {
+     let users = Map.empty<Nat, Text>();          // compiles; persisted automatically
+   };
+   ```
+
+   If the actor body has un-annotated `let`/`var`, moc reports `[M0219] this declaration is currently implicitly transient, please declare it explicitly transient` on those lines and M0220 never appears. Do not follow that suggestion — `transient` discards the data on upgrade, and the actor still fails with M0220. The fix is always `persistent` on the actor.
+
+   `persistent actor` compiles whether or not the `--default-persistent-actors` compiler flag is set (with the flag the keyword is merely redundant, warning M0217), whereas plain `actor` compiles **only** with that flag — which is why the `motoko` skill writes plain `actor`.
 
 ## Implementation
 

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -38,21 +38,30 @@ No external canister dependencies. Stable memory is a local canister feature.
 
 6. **Serializing large data in pre_upgrade (Rust)** -- `pre_upgrade` has a fixed instruction limit. If you serialize a large HashMap to stable memory in pre_upgrade, it will hit the limit and trap, bricking the canister. Use `StableBTreeMap` which writes directly to stable memory and needs no serialization step.
 
-7. **Using `actor { }` instead of `persistent actor { }` (Motoko)** -- Plain `actor` does not compile under enhanced orthogonal persistence. There is no annotation that rescues it: the error is on the actor itself, so `stable`, `transient`, and `pre_upgrade`/`post_upgrade` hooks all still fail.
+7. **Mismatching the actor form and the `--default-persistent-actors` flag (Motoko)** -- Both plain `actor` and `persistent actor` are correct; which one compiles depends on that compiler flag. Enabling it is the recommended setup, because it keeps the code less verbose:
+
+   ```toml
+   # mops.toml — recommended; see `mops-cli`
+   [moc]
+   args = ["--default-persistent-actors"]
+   ```
+
+   With the flag, every actor is persistent, so write plain `actor { }`; the `persistent` keyword still compiles but is redundant (warning M0217). Without the flag, `persistent actor { }` is required, and plain `actor` fails with `[M0220] this actor or actor class should be declared persistent`. No annotation rescues it — `stable`, `transient`, and `pre_upgrade`/`post_upgrade` hooks all still fail, because the error is on the actor itself:
 
    ```motoko
+   // without --default-persistent-actors
    actor {
-     stable var users = Map.empty<Nat, Text>();   // M0220: this actor or actor class
-   };                                             // should be declared `persistent`
+     stable var users = Map.empty<Nat, Text>();   // M0220 — `stable` does not help
+   };
 
    persistent actor {
      let users = Map.empty<Nat, Text>();          // compiles; persisted automatically
    };
    ```
 
-   If the actor body has un-annotated `let`/`var`, moc reports `[M0219] this declaration is currently implicitly transient, please declare it explicitly transient` on those lines and M0220 never appears. Do not follow that suggestion — `transient` discards the data on upgrade, and the actor still fails with M0220. The fix is always `persistent` on the actor.
+   The examples below use `persistent actor`, which compiles either way.
 
-   `persistent actor` compiles whether or not the `--default-persistent-actors` compiler flag is set (with the flag the keyword is merely redundant, warning M0217), whereas plain `actor` compiles **only** with that flag — which is why the `motoko` skill writes plain `actor`.
+   One trap when the flag is off: if the actor body has un-annotated `let`/`var`, moc reports `[M0219] this declaration is currently implicitly transient, please declare it explicitly transient` on those lines and M0220 never appears. Do not follow that suggestion — `transient` discards the data on upgrade, and the actor still fails M0220. The fix is `persistent` on the actor, or the flag.
 
 ## Implementation
 

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -11,7 +11,10 @@ metadata:
 # Stable Memory & Canister Upgrades
 
 ## What This Is
-Stable memory is persistent storage on Internet Computer that survives canister upgrades. Heap memory (regular variables) is wiped on every upgrade. Any data you care about MUST be in stable memory, or it will be lost the next time the canister is deployed.
+Stable memory is persistent storage on Internet Computer that survives canister upgrades. Whether ordinary variables survive depends on the language:
+
+- **Rust** -- heap data (`thread_local! { RefCell<T> }`, plain `static`s) is wiped on every upgrade. Any data you care about must live in stable memory, either through `ic-stable-structures` or by serializing it yourself in `pre_upgrade`/`post_upgrade`.
+- **Motoko** -- enhanced orthogonal persistence is on by default, so `let` and `var` in a `persistent actor` already survive upgrades with no `stable` keyword and no upgrade hooks. Only `transient` declarations are wiped.
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #274

## Problem

- `skills/motoko/SKILL.md:45` — plain `actor` is a hard error (M0220); use `--default-persistent-actors` or write `persistent actor`.
- `skills/stable-memory/SKILL.md:38` — "Plain `actor` in mo:core requires explicit `stable` annotations and pre/post_upgrade hooks."

`stable-memory` framed plain `actor` as a working-but-worse option. It doesn't compile at all.

## Verification

Rather than trusting either skill, I compiled every combination with `mops` + `moc --check`. Identical results on **moc 1.7.0** (the floor both skills declare) and **moc 1.8.2** (the pinned upstream tag), against `core 2.5.0`:

| Code | Flag | Result |
|---|---|---|
| `actor { }` | — | error **M0220** `this actor or actor class should be declared persistent` |
| `actor { stable var x = … }` | — | error **M0220** |
| `actor { transient var x = … }` | — | error **M0220** |
| `actor { var x = … }` | — | error **M0219** `implicitly transient, please declare it explicitly transient` — M0220 never appears |
| `actor { }` | `--default-persistent-actors` | compiles |
| `persistent actor { }` | — | compiles |
| `persistent actor { }` | `--default-persistent-actors` | compiles, warning M0217 (`persistent` redundant) |
| `persistent actor { stable var x = … }` | — | compiles, warning M0218 (`stable` redundant) |

So `motoko` is correct and `stable-memory` was the skill to fix. Two findings beyond what the issue reported:

1. **M0219 masks M0220** whenever the actor body has un-annotated `let`/`var` — which is the common real case. Its message tells you to write `transient`, which discards the data on upgrade *and* still leaves the actor failing M0220. An agent that follows the compiler's own suggestion gets both a data-loss bug and a non-compiling actor.
2. **`persistent actor` compiles in both flag configurations**; plain `actor` compiles only with the flag. That is the whole reason the two skills look like they disagree on style — both are valid, in different build configurations. `stable-memory`'s `mops.toml` sets no `[toolchain] args`, so `persistent actor` is the correct form for its examples, which is what they already use.

## Change

Only `stable-memory` changed. `motoko` is untouched — it is upstream-tracked (`caffeinelabs/motoko` 1.8.2) and its claim is correct.

Pitfall 7 now states that no annotation rescues plain `actor`, shows the verified contrast as code, warns against following M0219's `transient` suggestion, and explains the flag relationship so the `motoko` convention no longer reads as a contradiction.

## Evals

Added one adversarial case: the user is handed the real M0219 error and says the data must survive upgrades. The trap is that the compiler's own suggested fix is wrong.

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| With skill (first draft of the fix) | 1/3 |
| Without skill (baseline) | 0/3 |

My first draft of the pitfall was prose-only and scored 1/3 — the model opened with "add `transient`" and offered `stable var` inside a plain `actor` as a fallback, which is itself M0220. Adding the verified code contrast took it to 3/3. Existing eval 1 covers `Map` call style inside an already-`persistent` actor and is unaffected, so it was not re-run.

<details>
<summary>Eval output</summary>

With skill (this PR):

```
━━━ Adversarial: M0219 on a plain actor — the compiler's own suggestion is the wrong fix ━━━

  WITH skill: 3/3 passed
    ✅ Says to declare the actor as persistent actor
    ✅ Does NOT tell the user to add transient to the declaration
    ✅ Does NOT claim plain actor can persist via stable/pre_upgrade/post_upgrade
```

Baseline, same case:

```
  WITHOUT skill: 0/3 passed
    ❌ Says to declare the actor as `persistent actor` (or equivalent flag)
       → The output never mentions `persistent actor` or the compiler flag at all; it only
         proposes adding `stable`/`transient` to the var declaration.
    ❌ Does NOT tell the user to add `transient` to the declaration
       → The output's opening line literally instructs 'Add `transient` to the declaration:',
         which directly recommends the exact keyword that would discard user data on upgrade.
    ❌ Does NOT claim plain `actor` can be made to persist by adding `stable`
       → The output explicitly instructs the user to change `var` to `stable var` inside what
         remains a plain `actor`, which is exactly the disallowed claim.
```

</details>

## Follow-up not taken here

**M0219 is documented in no skill.** `motoko`'s error table has rows for M0220 and M0218 but not M0219, even though M0219 is what agents actually hit. That table is upstream content and not in the icskills-owned list in `.claude/upstream.md`, so adding a row would need an upstream issue plus an owned-section entry — out of scope for this PR. Worth filing separately.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek