### PR TITLE
fix(stable-memory): scope the "heap is wiped" claim by language

### DIFF
--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -11,7 +11,10 @@ metadata:
 # Stable Memory & Canister Upgrades
 
 ## What This Is
-Stable memory is persistent storage on Internet Computer that survives canister upgrades. Heap memory (regular variables) is wiped on every upgrade. Any data you care about MUST be in stable memory, or it will be lost the next time the canister is deployed.
+Stable memory is persistent storage on Internet Computer that survives canister upgrades. Whether ordinary variables survive depends on the language:
+
+- **Rust** -- heap data (`thread_local! { RefCell<T> }`, plain `static`s) is wiped on every upgrade. Any data you care about must live in stable memory, either through `ic-stable-structures` or by serializing it yourself in `pre_upgrade`/`post_upgrade`.
+- **Motoko** -- enhanced orthogonal persistence is on by default, so `let` and `var` in a `persistent actor` already survive upgrades with no `stable` keyword and no upgrade hooks. Only `transient` declarations are wiped.
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #276

> **Stacked on #314.** Base branch is `fix/274-plain-vs-persistent-actor`, not `main` — both PRs edit `skills/stable-memory/SKILL.md`. Merge #314 first; GitHub will retarget this to `main` automatically. The diff here shows only this change.

## Problem

- `skills/stable-memory/SKILL.md:14` — "Heap memory (regular variables) is wiped on every upgrade. Any data you care about MUST be in stable memory."
- `skills/motoko/SKILL.md:19,30,43` — enhanced orthogonal persistence is on by default; ordinary actor variables persist without `stable`.

The claim is stated language-neutrally. It is correct for Rust and false for Motoko. It also contradicts **this skill's own Implementation section**, which already says `// These survive upgrades automatically -- no "stable" keyword needed` (line 62) and lists `NO pre_upgrade / post_upgrade needed` (line 101).

## Verification

I deployed and upgraded a real canister on a local replica (`icp 1.2.0`, moc 1.8.2, core 2.5.0) with **no `stable` keyword anywhere**:

```motoko
persistent actor {
  var counter : Nat = 0;              // plain var
  transient var ephemeral : Nat = 0;
  ...
}
```

Bumped both to 3, added a `version()` method to force a genuine upgrade, redeployed, then read the state back:

| Declaration | Before upgrade | After upgrade |
|---|---|---|
| `var counter` | 3 | **3 — persisted** |
| `transient var ephemeral` | 3 | **0 — wiped** |

`version()` returned `"v2"`, confirming the upgrade actually happened rather than a fresh install.

## Change

One paragraph in "What This Is", now split by language: Rust heap is wiped and needs `ic-stable-structures` or manual serialization; Motoko `let`/`var` in a `persistent actor` already survive, and only `transient` is wiped.

## Evals — deliberately none

I wrote a case for this (balances must persist, sessionCache must reset) and ran it three ways:

| Configuration | Score |
|---|---|
| With skill (this PR) | 3/3 |
| With skill (old, incorrect wording) | 3/3 |
| Without skill at all | 3/3 |

It passes in every configuration, including against the text this PR removes, so it could never catch a regression — it would just cost tokens on every future run. The existing Implementation section already pins this behavior, and eval 1 covers the "no `stable` keyword" output. Per the repo's "keep the suite lean" guidance I dropped it rather than commit a dead test.

Worth noting for reviewers: the wrong summary did **not** flip model output in testing. Its cost is the contradiction itself — an agent that reads line 14 and the Implementation section gets opposite instructions from one file.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek