### PR TITLE
fix(https-outcalls): make the Verify commands actually runnable

### DIFF
--- a/skills/https-outcalls/SKILL.md
+++ b/skills/https-outcalls/SKILL.md
@@ -362,16 +362,18 @@ icp deploy -e ic backend
 
 ```bash
 # 1. Test the GET outcall (fetch price)
-icp canister call backend fetchPrice
+icp canister call backend getIcpPriceUsd '()'   # Motoko example above
+icp canister call backend fetch_price '()'      # Rust example above
 # Expected: Something like '("{\"internet-computer\":{\"usd\":12.34}}")'
 # (actual price will vary)
 
 # 2. Test the POST outcall
-icp canister call backend postData '("{\"test\": \"hello\"}")'
+icp canister call backend postData '("{\"test\": \"hello\"}")'    # Motoko
+icp canister call backend post_data '("{\"test\": \"hello\"}")'   # Rust
 # Expected: JSON response from httpbin.org echoing back your data
 
 # 3. If using Rust with the typed parser:
-icp canister call backend get_icp_price_usd
+icp canister call backend get_icp_price_usd '()'
 # Expected: '("ICP price: $12.34")'
 
 # 4. Check canister cycle balance (outcalls consume cycles)


### PR DESCRIPTION
Closes #288

## Problem

`skills/https-outcalls/SKILL.md:365` — `icp canister call backend fetchPrice`. That method exists in neither example:

- Motoko example (line 79) exposes `getIcpPriceUsd`
- Rust example (line 198) exposes `fetch_price`

While checking the rest of the section I found the naming problem is broader than the one line, plus a second defect the issue didn't mention.

## What I checked

Enumerated every method the file actually defines against every method the Verify section calls:

| Verify step | Called | Defined? |
|---|---|---|
| 1 | `fetchPrice` | **no — nowhere in the file** |
| 2 | `postData` | yes, but Motoko only (Rust is `post_data`) |
| 3 | `get_icp_price_usd` | yes, Rust — correctly labelled |

So step 1 was broken outright and step 2 silently assumed Motoko while step 1 presented itself as language-neutral.

**Second defect: the no-arg calls could not run non-interactively.** `icp canister call --help` says `[ARGS]` … "If not provided, an interactive prompt will be launched". I verified what that means in practice against **icp 1.2.0** on a local replica, for both a query and an update method:

```
$ icp canister call backend read < /dev/null
()

Do you want to send this message? [y/N]
User cancelled.

$ icp canister call backend read '()' < /dev/null
(0 : nat, 0 : nat)
```

```
$ icp canister call backend bump < /dev/null
Do you want to send this message? [y/N]
User cancelled.

$ icp canister call backend bump '()' < /dev/null
(1 : nat, 1 : nat)
```

Without `'()'` the call is **never made** — it prints "User cancelled." and exits 0, so a scripted or agent-driven verify step silently does nothing and looks like it succeeded.

## Change

Verify steps 1–3 only. Each step now names the Motoko and Rust method side by side, and every no-arg call passes `'()'`.

```bash
# 1. Test the GET outcall (fetch price)
icp canister call backend getIcpPriceUsd '()'   # Motoko example above
icp canister call backend fetch_price '()'      # Rust example above

# 2. Test the POST outcall
icp canister call backend postData '("{\"test\": \"hello\"}")'    # Motoko
icp canister call backend post_data '("{\"test\": \"hello\"}")'   # Rust

# 3. If using Rust with the typed parser:
icp canister call backend get_icp_price_usd '()'
```

## Evals — deliberately none

`evaluations/https-outcalls.json` does not exist, and I did not create one for this change. The defect was a static inconsistency between our own code blocks, not a behavior a model reproduces: an agent that writes this canister picks its own method names and is self-consistent, so there is nothing for an output eval to catch. Seeding a file with unrelated cases to satisfy the convention would be scope creep on a two-line fix. The missing file is already surfaced as a validator warning.

## Follow-up not taken here

**The `'()'` requirement is undocumented in `icp-cli`.** Silently cancelling instead of defaulting to `()` is a footgun for every skill that shows a no-arg `icp canister call`, and `icp-cli` is the right place to document it — not this skill. Worth filing separately; I did not widen this PR to sweep other skills for the same omission.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek