### PR TITLE
fix(https-outcalls): correct the 2MB byte value and the default-size cycle cost

### DIFF
--- a/evaluations/https-outcalls.json
+++ b/evaluations/https-outcalls.json
@@ -1,0 +1,26 @@
+{
+  "skill": "https-outcalls",
+  "description": "Evaluation cases for the https-outcalls skill. Tests whether agents use the correct 2MB response limit (2,000,000 bytes per the interface spec, not 2^21) and the correct cycle cost for omitting max_response_bytes on a 13-node subnet.",
+  "output_evals": [
+    {
+      "name": "2MB limit is 2,000,000 bytes and the default-size cost",
+      "prompt": "For an IC HTTPS outcall: what is the exact maximum value in bytes I can pass for max_response_bytes, and roughly how many cycles does a 13-node subnet charge if I leave max_response_bytes unset? Just the two numbers with a one-line justification each.",
+      "expected_behaviors": [
+        "States the maximum as 2,000,000 bytes (decimal), NOT 2_097_152 / 2^21 / 2 MiB",
+        "Gives the omitted-max_response_bytes cost as roughly 20.8-20.9 billion cycles",
+        "Does NOT state the cost as ~21.5 billion or ~21.86 billion cycles"
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "My canister needs to fetch a price from a REST API",
+      "Why does my canister's outcall fail consensus with different responses per replica?",
+      "How much does it cost in cycles to call an external HTTPS endpoint from a canister?"
+    ],
+    "should_not_trigger": [
+      "How do I read an Ethereum contract's state from my canister?"
+    ]
+  }
+}

--- a/skills/https-outcalls/SKILL.md
+++ b/skills/https-outcalls/SKILL.md
@@ -37,9 +37,9 @@ You do not deploy anything extra. The management canister is built into every su
 
 3. **Using HTTP instead of HTTPS.** The IC only supports HTTPS outcalls. Plain HTTP URLs are rejected. The target server must have a valid TLS certificate.
 
-4. **Exceeding the 2MB response limit.** The maximum response body is 2MB (2_097_152 bytes). If the external API returns more, the call fails. Use the `max_response_bytes` field to set a limit and design your queries to return small responses.
+4. **Exceeding the 2MB response limit.** The maximum response body is 2MB, which the spec defines as 2_000_000 bytes (decimal, not 2^21). If the external API returns more, the call fails. Use the `max_response_bytes` field to set a limit and design your queries to return small responses.
 
-5. **Omitting `max_response_bytes`.** If you do not set `max_response_bytes`, the system assumes the maximum (2MB) and charges cycles accordingly — roughly 21.5 billion cycles on a 13-node subnet. Always set this to a reasonable upper bound for your expected response.
+5. **Omitting `max_response_bytes`.** If you do not set `max_response_bytes`, the system assumes the maximum (2MB) and charges cycles accordingly — roughly 20.85 billion cycles on a 13-node subnet. Always set this to a reasonable upper bound for your expected response.
 
 6. **Non-idempotent POST requests without caution.** Because multiple replicas make the same request, a POST endpoint that is not idempotent (e.g., "create order") will be called N times (once per replica, typically 13 on a 13-node subnet). Use idempotency keys or design endpoints to handle duplicate requests.
 
@@ -329,7 +329,9 @@ Base cost:                      49_140_000 cycles  (= (3_000_000 + 60_000*13) * 
 + per max_response_bytes byte:  10_400 cycles      (= 800 * 13)
 
 IMPORTANT: The charge is against max_response_bytes, NOT actual response size.
-If you omit max_response_bytes, the system assumes 2MB and charges ~21.5B cycles.
+Omitting max_response_bytes assumes the 2MB maximum (2_000_000 bytes) and costs
+49_140_000 + 10_400 * 2_000_000 = 20_849_140_000 cycles (~20.85B), plus the
+per-request-byte term.
 ```
 
 Unused cycles are refunded to the canister, so it is safe to over-budget.


### PR DESCRIPTION
Closes #287

## The issue's premise was right, its proposed number was not

The issue reports that `~21.5B` (lines 42, 332) disagrees with the skill's own formula, and computes the correct value as `~21.86B` from `49_140_000 + 10_400 × 2_097_152`.

That arithmetic is right but the input is wrong. **`2_097_152` is not the IC's 2MB.** The interface spec says so twice, in the [`http_request` section](https://github.com/dfinity/portal/blob/fe646b2990d25d0f00714d50d9df283dac5d2e91/docs/references/ic-interface-spec.md#L3071):

> `max_response_bytes` - optional, specifies the maximal size of the response in bytes. If provided, the value must not exceed `2MB` (`2,000,000B`). The call will be charged based on this parameter. If not provided, the maximum of `2MB` will be used.

> The maximal number of bytes representing the response produced by the `transform` function is equal to `max_response_bytes`, if provided, otherwise the default value of `2MB` (`2,000,000B`) is used as the limit.

So 2MB here is **decimal**, and the skill's pitfall 4 (`2_097_152 bytes`) is a second, separate error that the issue's proposed figure inherited.

## Verifying the formula

The formula block itself checks out. From [`references/cycles-cost-formulas`](https://github.com/dfinity/portal/blob/master/docs/references/cycles-cost-formulas.mdx):

```
base_fee = (3_000_000 + 60_000 * n) * n
size_fee = (400 * request_bytes + 800 * max_response_bytes) * n
```

At `n = 13` that gives exactly the skill's constants — base `49_140_000`, `5_200`/request byte, `10_400`/response byte. Only the byte count and the prose figure were wrong.

| `max_response_bytes` | Total | Figure |
|---|---|---|
| **2,000,000 (spec)** | **20,849,140,000** | **~20.85B** ✅ |
| 2,097,152 (issue assumed) | 21,859,520,800 | ~21.86B ❌ |
| — | — | ~21.5B as written ❌ |

## Verified against the implementation, not just the spec

Pinned to `dfinity/ic@0d845e0` (2026-08-04). The spec is normative, but the replica is what actually charges, so I checked both.

**1. The 2MB limit is `2_000_000` in code** — [`rs/types/types/src/canister_http.rs#L92`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/types/types/src/canister_http.rs#L92):

```rust
/// Maximum number of response bytes for a canister http request.
pub const MAX_CANISTER_HTTP_RESPONSE_BYTES: u64 = 2_000_000;
```

`validate_max_response_bytes` rejects anything above it, so this is enforced, not advisory.

**2. The fee constants** — [`rs/config/src/subnet_config.rs#L483-L486`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/config/src/subnet_config.rs#L483-L486), application-subnet defaults:

```rust
http_request_linear_baseline_fee: Cycles::new(3_000_000),
http_request_quadratic_baseline_fee: Cycles::new(60_000),
http_request_per_byte_fee: Cycles::new(400),
http_response_per_byte_fee: Cycles::new(800),
```

**3. The fee function, including the omitted case** — [`rs/cycles_account_manager/src/cycles_account_manager.rs#L1223-L1243`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/cycles_account_manager/src/cycles_account_manager.rs#L1223-L1243):

```rust
let response_size = match response_size_limit {
    Some(response_size) => response_size.get(),
    // Defaults to maximum response size.
    None => MAX_CANISTER_HTTP_RESPONSE_BYTES,
};

let amount = (self.config.http_request_linear_baseline_fee
    + self.config.http_request_quadratic_baseline_fee * (subnet_size as u64)
    + self.config.http_request_per_byte_fee * request_size.get()
    + self.config.http_response_per_byte_fee * response_size)
    * (subnet_size as u64);
```

That is `(3_000_000 + 60_000n + 400·req + 800·resp) · n`. Expanded at `n = 13`: `49_140_000 + 5_200·req + 10_400·resp` — exactly the skill's constants. And `None` maps to `2_000_000`, which is the case pitfall 5 describes, giving **20,849,140,000**.

**4. The skill's `request_size` description is also correct** — [`variable_parts_size`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/types/types/src/canister_http.rs#L573-L585) sums exactly the URL, header names and values, body, transform method name, and transform context.

### One thing reviewers should know: a pricing change is staged but not live

`master` contains a second pricing model and two unused fee functions (`http_request_fee_v2`, `http_request_fee_beta`) with entirely different constants. I checked whether they are active, because if so this PR's figure would already be stale. They are not:

- `DEFAULT_HTTP_OUTCALLS_PRICING_VERSION = PRICING_VERSION_LEGACY` ([`http.rs#L67`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/types/management_canister_types/src/http.rs#L67))
- `ALLOWED_HTTP_OUTCALLS_PRICING_VERSIONS = &[PRICING_VERSION_LEGACY]` ([`http.rs#L72`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/types/management_canister_types/src/http.rs#L72)) — pay-as-you-go is not in the allowed set
- `FLEXIBLE_HTTP_REQUESTS_FEATURE: FlagStatus = FlagStatus::Disabled` ([`execution_environment.rs#L16`](https://github.com/dfinity/ic/blob/0d845e0276b06ebb800f86f9f93a1ec2d9f3d672/rs/config/src/execution_environment.rs#L16))
- `http_request_fee_beta` is called only to feed an `observe_http_outcall_price_change` metric, which the code comments describe as a "dark launch"

So legacy pricing — the formula this skill documents — is what is charged today. Under pay-as-you-go the model changes shape: only a non-refundable base fee is charged up front and the remainder is refunded based on resources actually consumed, so the "charged for `max_response_bytes` regardless of actual size" framing in pitfall 5 will need revisiting when that flag flips. Not actionable now, but this section has a shelf life.

It is also why the skill's existing advice to rely on `cost_http_request` rather than hard-coding the formula is the right default, and I left that intact.

## Change

Three places, all in `https-outcalls`:

- **Pitfall 4** — `2MB (2_097_152 bytes)` → 2MB as the spec defines it, `2_000_000` bytes (decimal, not 2^21).
- **Pitfall 5** — `~21.5 billion` → `~20.85 billion`.
- **Formula block** — the summary line now shows the arithmetic (`49_140_000 + 10_400 * 2_000_000 = 20_849_140_000`) rather than a bare figure, so it cannot silently drift from the formula above it again. That drift is what produced this issue.

## Evals

`evaluations/https-outcalls.json` did not exist — seeded it with one case covering both constants, plus trigger coverage.

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| With skill (old text) | **0/3** |
| Without skill (baseline) | 3/3 |

The old text scored **0/3 against a 3/3 baseline** — it pushed the model to both wrong numbers, making the skill actively worse than no skill. The judge on the old run:

> The output states ~21.5 billion cycles, outside the expected 20.8-20.9 billion range.

Trigger evals: should-trigger 3/3, should-not-trigger 1/1.

<details>
<summary>Eval output</summary>

With skill (this PR):

```
━━━ 2MB limit is 2,000,000 bytes and the default-size cost ━━━

  WITH skill: 3/3 passed
    ✅ States the maximum as 2,000,000 bytes (decimal), NOT 2_097_152 / 2^21 / 2 MiB
    ✅ Gives the omitted-max_response_bytes cost as roughly 20.8-20.9 billion cycles
    ✅ Does NOT state the cost as ~21.5 billion or ~21.86 billion cycles

  WITHOUT skill: 3/3 passed
    ✅ States the maximum as 2,000,000 bytes (decimal), NOT 2_097_152 / 2^21 / 2 MiB
    ✅ Gives the omitted-max_response_bytes cost as roughly 20.8-20.9 billion cycles
    ✅ Does NOT state the cost as ~21.5 billion or ~21.86 billion cycles
```

Same case against the pre-fix skill text:

```
  WITH skill: 0/3 passed
    ❌ States the maximum as 2,000,000 bytes (decimal), NOT 2_097_152 / 2^21 / 2 MiB
    ❌ Gives the omitted-max_response_bytes cost as roughly 20.8-20.9 billion cycles
       → The output states ~21.5 billion cycles, outside the expected 20.8-20.9 billion range.
    ❌ Does NOT state the cost as ~21.5 billion or ~21.86 billion cycles
       → The output explicitly states ~21.5 billion cycles, directly violating this behavior.
```

Trigger evals:

```
  Should trigger: 3/3 correct
    ✅ "My canister needs to fetch a price from a REST API"
    ✅ "Why does my canister's outcall fail consensus with different responses per replica?"
    ✅ "How much does it cost in cycles to call an external HTTPS endpoint from a canister?"

  Should NOT trigger: 1/1 correct
    ✅ "How do I read an Ethereum contract's state from my canister?"
```

</details>

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
