### PR TITLE
fix(stable-memory): correct the upgrade type-change rules

### DIFF
--- a/evaluations/stable-memory.json
+++ b/evaluations/stable-memory.json
@@ -21,6 +21,16 @@
         "Does NOT tell the user to add `transient` to the declaration, even though the error message suggests it -- that would discard users on upgrade",
         "Does NOT claim plain `actor` can be made to persist by adding `stable`, `pre_upgrade`, or `post_upgrade`"
       ]
+    },
+    {
+      "name": "Adversarial: widening is safe and a rejected upgrade is not data loss",
+      "prompt": "My deployed Motoko persistent actor has `var balance : Nat` and an obsolete `var legacyFlag : Bool`. I want to change balance to `var balance : Int` and delete legacyFlag. Users' balances must not be lost. Which of these two changes needs migration code, and what happens to the data if the upgrade gets rejected? Short answer, no full actor rewrite.",
+      "expected_behaviors": [
+        "States that widening balance from Nat to Int needs no migration and preserves the existing value",
+        "States that deleting legacyFlag DOES require an explicit migration expression",
+        "States that a rejected upgrade aborts and leaves the canister running the previous version with its data intact",
+        "Does NOT claim the data is unrecoverable, lost, or that the canister is bricked if the upgrade is rejected"
+      ]
     }
   ],
 

--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -34,7 +34,16 @@ No external canister dependencies. Stable memory is a local canister feature.
 
 4. **Confusing heap memory limits with stable memory limits (Rust)** -- Heap (Wasm linear) memory is limited to 4GB for wasm32 and 6GB for wasm64. Stable memory can grow up to hundreds of GB (the subnet storage limit). The real danger: if you use `pre_upgrade`/`post_upgrade` hooks to serialize heap data to stable memory and deserialize it back, you are limited by the heap memory size AND by the instruction limit for upgrade hooks. Large datasets will trap during upgrade, bricking the canister. The solution is to use stable structures (`StableBTreeMap`, `StableCell`, etc.) that read/write directly to stable memory, bypassing the heap entirely. Use `MemoryManager` to partition stable memory into virtual memories so multiple structures can coexist without overwriting each other.
 
-5. **Changing record field types between upgrades (Motoko)** -- Altering the type of a persistent field (e.g., `Nat` to `Int`, or renaming a record field) will trap on upgrade and data is unrecoverable. Only ADD new optional fields. Never remove or rename existing ones.
+5. **Treating a rejected upgrade as data loss (Motoko)** -- Enhanced orthogonal persistence checks the new program against the existing state and either accepts the upgrade or rejects it *before* it takes effect. A rejected upgrade is not data loss: the canister keeps running the previous version with its state intact, so you fix the code and redeploy. What actually differs is which changes need a migration:
+
+   | Change to a persistent field | Needs a migration? |
+   |---|---|
+   | Adding a field | No |
+   | Widening a `var` field, e.g. `Nat` → `Int` | No — the value is preserved |
+   | Removing a field | **Yes** |
+   | Renaming a field, or a non-widening type change | **Yes** |
+
+   Removing a field without one is rejected at compile time with `[M0169] the stable variable <name> of the previous version cannot be implicitly discarded`, and at runtime with `RTS error: Memory-incompatible program upgrade`. Both abort the upgrade; neither loses data. Load `migrating-motoko` for the migration-expression syntax.
 
 6. **Serializing large data in pre_upgrade (Rust)** -- `pre_upgrade` has a fixed instruction limit. If you serialize a large HashMap to stable memory in pre_upgrade, it will hit the limit and trap, bricking the canister. Use `StableBTreeMap` which writes directly to stable memory and needs no serialization step.
 


### PR DESCRIPTION
Closes #275

## Problem

- `skills/stable-memory/SKILL.md:37` — "Altering the type of a persistent field (e.g., `Nat` to `Int`, or renaming a record field) will trap on upgrade and data is unrecoverable. Only ADD new optional fields. Never remove or rename existing ones."
- `skills/migrating-motoko/SKILL.md:22-27, 30-34` — widening `Nat` → `Int` and removing fields are implicit; renaming and type changes work via explicit migration.
- `skills/migrating-motoko/SKILL.md:77` — "If the migration traps, the upgrade is aborted and the canister stays on the old version".

## Verification: real deploy + upgrade cycles

I ran actual upgrades on a local replica (`icp 1.2.0`, moc 1.8.2, core 2.5.0) rather than reasoning from either skill. To isolate *stable state* compatibility from *Candid interface* compatibility, every version kept an identical public interface (`read() : async Text`) — my first attempt failed on the Candid check instead, which would have been the wrong conclusion.

Starting state: `var counter : Nat` bumped to `5`, plus `var note : Text`.

| Change (no migration expression) | Result |
|---|---|
| Add a field | ✅ upgrade succeeds; `counter` still 5, new field initialised |
| Widen `var counter : Nat` → `Int` | ✅ upgrade succeeds; **value preserved** (5 stayed 5) |
| Remove a field | ❌ rejected: `RTS error: Memory-incompatible program upgrade` |
| Remove + rename, **with** explicit migration | ✅ succeeds; old `extra` value carried to new `tally` |

**On every rejection the canister stayed on the previous version and kept serving its old state** (`read()` still returned `5|v1-note`). So "data is unrecoverable" is backwards: a rejected upgrade is the safe outcome.

The static check states the removal rule exactly:

```
$ moc --stable-compatible old.most new.most
Compatibility error [M0169], the stable variable `note` of the previous version
cannot be implicitly discarded. The variable can only be dropped by an explicit
migration function
```

## Change

Only `stable-memory` changed. Pitfall 5 is now a table of which changes need a migration, plus the point that a rejection costs nothing, with both the compile-time (`M0169`) and runtime (`RTS error`) messages so either one is recognisable.

## Evals

Added one adversarial case combining both corrections: widen one field, delete another, and say what happens on rejection.

| Configuration | Score |
|---|---|
| With skill (this PR) | **4/4** |
| With skill (old text) | **2/4** |
| Without skill (baseline) | 3/4 |

The old text scored **below baseline** because it inverted *both* migration answers — it told the model `Nat` → `Int` needs a migration (it does not) and that deleting a field does not (it does).

<details>
<summary>Eval output</summary>

With skill (this PR):

```
  WITH skill: 4/4 passed
    ✅ States that widening balance from Nat to Int needs no migration and preserves the existing value
    ✅ States that deleting legacyFlag DOES require an explicit migration expression
    ✅ States that a rejected upgrade aborts and leaves the canister running the previous version with its data intact
    ✅ Does NOT claim the data is unrecoverable, lost, or that the canister is bricked if the upgrade is rejected
```

Old text, same case:

```
  WITH skill: 2/4 passed
    ❌ States that widening balance from Nat to Int needs no migration and preserves the existing value
       → The output claims the opposite — that Nat→Int requires an explicit migration expression.
    ❌ States that deleting legacyFlag DOES require an explicit migration expression
       → The output claims the opposite — that deleting legacyFlag needs no migration and is
         'safe by default'.
```

Baseline:

```
  WITHOUT skill: 3/4 passed
    ❌ States that deleting legacyFlag DOES require an explicit migration expression
       → The output claims the opposite, stating deleting legacyFlag is 'always allowed' with
         'no migration hook required'.
```

</details>

## Follow-up: `migrating-motoko` is also wrong here

The issue treats `migrating-motoko` as the correct side. It mostly is, but one line is not: it lists **"Removing actor fields"** under *"Implicit migration (no code needed)"*. Both my tests contradict that — removal is rejected at compile time with `M0169` and at runtime with `RTS error: Memory-incompatible program upgrade`, and `M0169` explicitly says the variable "can only be dropped by an explicit migration function".

Independent signal: the no-skill baseline made exactly this mistake, claiming removal is "always allowed" with "no migration hook required" — so this is a live hallucination, not a theoretical one.

I did not touch it. `migrating-motoko` tracks `caffeinelabs/motoko` and that line is not in the icskills-owned list in `.claude/upstream.md`, so correcting it locally would create untracked divergence. It needs an upstream issue plus an owned-section entry. Happy to file that separately.

(I also confirmed `--enhanced-migration` is not the explanation — it takes an argument and is the multi-migration directory flag, not a boolean that relaxes the implicit rules.)

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
