### PR TITLE
fix(cycles-management): explain -n vs -e instead of normalising the flags

### DIFF
--- a/evaluations/cycles-management.json
+++ b/evaluations/cycles-management.json
@@ -29,6 +29,15 @@
         "States that the canister ID, controllers, and settings are retained",
         "Does NOT claim the canister itself is permanently deleted or that the canister ID is lost"
       ]
+    },
+    {
+      "name": "-n vs -e: canister names need an environment",
+      "prompt": "Using icp-cli, give me the two mainnet commands to (a) check the cycle balance of my canister named `backend`, and (b) check my own cycles-ledger balance. Just the two commands, no explanation.",
+      "expected_behaviors": [
+        "The command targeting the canister named `backend` uses -e ic (or --environment ic), NOT -n ic",
+        "Does NOT pass both -n and -e on the same command",
+        "Uses `icp canister status backend -e ic` for the canister and `icp cycles balance` for the personal cycles-ledger balance"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/cycles-management/SKILL.md
+++ b/skills/cycles-management/SKILL.md
@@ -46,6 +46,16 @@ The Management Canister (`aaaaa-aa`) is a virtual canister -- it does not exist 
 
 7. **Using `icp cycles transfer` to fund a canister** -- `icp cycles transfer <amount> <principal>` moves cycles between cycles-ledger balances, the same as a token transfer between accounts. Passing a canister's principal as the recipient credits that principal's cycles-ledger balance, not the canister's actual execution/compute cycle balance -- `icp canister status` will not show the cycles as received, and the canister keeps burning down its real balance toward freezing with no indication anything went wrong. Use `icp canister top-up <canister> --amount <N> -e ic` instead, which deposits cycles directly onto the canister via the management canister. See "Top Up a Canister" below for both commands side by side.
 
+8. **Using `-n ic` on a command that names a canister** -- `-n`/`--network` and `-e`/`--environment` are different selectors and conflict with each other; passing both is an error. A canister **name** can only be resolved through an environment, so `-n` fails on it:
+
+   ```bash
+   icp canister status backend -n ic
+   # Error: Specifying a network is not supported if you are targeting a canister
+   # by name, specify an environment instead
+   ```
+
+   So `-e ic` for anything naming a canister (`top-up`, `status`, `settings update`, `create`), and `-n ic` for commands that take a principal or no canister at all (`cycles mint`, `cycles balance`, `cycles transfer`). This is why the mainnet examples below mix the two flags. Load `icp-cli` for the full flag rules.
+
 ## Implementation
 
 ### Motoko
@@ -261,7 +271,7 @@ icp canister top-up backend --amount 1000000000000
 icp canister top-up backend --amount 1000000000000 -e ic
 
 # Convert ICP to cycles and top up in one step (mainnet)
-icp cycles mint --icp 1.0 -e ic
+icp cycles mint --icp 1.0 -n ic   # no canister argument, so -n is fine (see Pitfall 8)
 icp canister top-up backend --amount 1000000000000 -e ic
 ```
 


### PR DESCRIPTION
Closes #290

## The issue's read is inverted

The issue flags the lone `-n ic` at `cycles-management:273` as the inconsistency, since every other command in the file uses `-e ic`. The obvious fix — normalise them all — **would break six commands with a hard error.**

`-n`/`--network` and `-e`/`--environment` are not two spellings of the same thing. From `icp cycles transfer --help`:

> `-n, --network <NETWORK>` — Name or URL of the network to target, **conflicts with environment argument**
> `-e, --environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used

## Verified against `icp 1.2.0`

```
$ icp canister status backend -n ic
Error: Specifying a network is not supported if you are targeting a canister by name,
specify an environment instead

$ icp cycles balance -n ic
Balance: 0 cycles

$ icp cycles balance -e ic
Balance: 0 cycles

$ icp cycles balance -n ic -e ic
error: the argument '--network <NETWORK>' cannot be used with '--environment <ENVIRONMENT>'
```

Both flags exist on every command I checked (`cycles transfer/mint/balance`, `token balance`, `canister top-up/status`), and both resolve `ic` even in a project whose `icp.yaml` declares no `environments` block. The constraint is narrower than "which flag do cycles ops take":

**A canister *name* can only be resolved through an environment.** Principals and canister-less commands accept either.

Auditing the file against that rule, nothing was actually wrong:

| Line | Command | Flag | Correct? |
|---|---|---|---|
| 247, 261, 265, 270, 285, 298, 318 | names `backend` / `my_canister` | `-e ic` | ✅ required |
| 250 | `canister status <principal>` | `-e ic` | ✅ works |
| 273 | `cycles transfer … <principal>` | `-n ic` | ✅ correct |
| 264 | `cycles mint --icp 1.0` | `-e ic` | works, but `-n` per icp-cli's rule |

`icp-cli:52` already states the rule ("For token and cycles operations, use `-n` since they don't reference project canisters"), and `icp-cli` is internally consistent with itself at lines 210–211. So the cross-file wrinkle the issue describes is not a contradiction either.

## Change

The real defect is that nothing in `cycles-management` explains *why* the flags differ, which is what makes it read as sloppy and invites a breaking normalisation.

- **New pitfall 8** — states the rule and includes the verbatim error you get from `-n` on a canister name, so the mixture is legible and nobody makes it uniform.
- **Line 264** — `icp cycles mint --icp 1.0 -e ic` → `-n ic`, the one place a cycles op with no canister argument used `-e`. Both work; this aligns it with icp-cli's stated rule and removes the visible inconsistency.

**Line 273 is left alone — it was never wrong.**

I did not execute `icp cycles mint` to test its flag, since that spends real ICP. `--help` shows both flags, and `cycles mint` takes no canister argument, so it falls under the same rule as `cycles balance`, which I did verify.

## Evals

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| Without skill (baseline) | 1/3 |

The baseline emitted `icp-cli canister status backend --network ic` — precisely the form that hard-errors.

<details>
<summary>Eval output</summary>

```
━━━ -n vs -e: canister names need an environment ━━━

  WITH skill: 3/3 passed
    ✅ The command targeting the canister named `backend` uses -e ic (or --environment ic), NOT -n ic
    ✅ Does NOT pass both -n and -e on the same command
    ✅ Uses `icp canister status backend -e ic` for the canister and `icp cycles balance` for the
       personal cycles-ledger balance

  WITHOUT skill: 1/3 passed
    ❌ The command targeting the canister named `backend` uses -e ic (or --environment ic), NOT -n ic
       → The output uses `--network ic` instead of `-e ic`/`--environment ic`.
    ✅ Does NOT pass both -n and -e on the same command
    ❌ Uses `icp canister status backend -e ic` for the canister and `icp cycles balance` for the
       personal cycles-ledger balance
       → The output instead gives `icp-cli canister status backend --network ic` and
         `icp-cli cycles balance --network ic`.
```

</details>

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
