### PR TITLE
fix(sns-launch): describe the config's real unit conventions

### DIFF
--- a/skills/sns-launch/SKILL.md
+++ b/skills/sns-launch/SKILL.md
@@ -67,7 +67,13 @@ When an SNS launch succeeds, SNS-W deploys these canisters on an SNS subnet:
 This is the single source of truth for all launch parameters. Copy the template from the `dfinity/sns-testing` repo and customize:
 
 ```yaml
-# Note: numeric values are in e8s (1 token = 100_000_000 e8s). Time values are in seconds.
+# Units: token-valued fields (transaction_fee, rejection_fee, stake, treasury, the swap
+# *_icp limits) carry an explicit suffix -- "tokens", "token", or "e8s"
+# (1 token = 100_000_000 e8s). Duration fields (initial_voting_period, dissolve_delay,
+# vesting_period, ...) carry a time suffix and may be concatenated: seconds, minutes,
+# hours, days, weeks, months (30.44 days), years (365.25 days) -- e.g. "4 days", "1w 2d 3h".
+# Plain counts such as minimum_participants take no suffix.
+# An e8s-only, seconds-only config is the older format; do not mix the two conventions.
 
 # === PROJECT METADATA ===
 name: MyProject


### PR DESCRIPTION
Closes #289

## Problem

`skills/sns-launch/SKILL.md:70` — `# Note: numeric values are in e8s (1 token = 100_000_000 e8s). Time values are in seconds.`

Every value in the 60 lines beneath it contradicts that: `transaction_fee: 0.0001 tokens`, `rejection_fee: 1 token`, `stake: 2_000_000 tokens`, `initial_voting_period: 4 days`, `duration: 8 years`.

## Verification

The skill tells you to copy the template from `dfinity/sns-testing`, so I checked [`example_sns_init.yaml`](https://github.com/dfinity/sns-testing/blob/main/example_sns_init.yaml) — which documents its own conventions in the header:

> in the previous version, all fields relating to token values **had to be specified in e8s** (fractions of 10E-8 of a governance token). **In this version**, similar fields can be specified in whole tokens, tokens with decimals, or e8s.

> For fields that represent token values (such as `transaction_fee` or `rejection_fee`), devs can specify decimal strings ending in **"tokens"** (plural), decimal strings ending in **"token"** (singular), or integer strings (base 10) ending in **"e8s"**.

> For fields that represent duration values … devs can specify durations as a concatenation of time spans … `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` (30.44 days), `years` (365.25 days). For example, `"1w 2d 3h"`.

So the skill's comment describes the **superseded** format, on both counts. Two details worth getting right:

1. **No single unit is mandated** — the upstream template itself mixes them (`transaction_fee: 10_000 e8s` sits a few lines from `rejection_fee: 1 token`). The rule is that token fields carry *a* suffix, not that they must be tokens.
2. **Not every number takes a suffix.** `minimum_participants: 57` is a plain count, in both the template and this skill. I nearly wrote "bare numbers are not accepted" before checking — that would have been a new wrong claim replacing the old one.

## Change

One comment block in `sns-launch`, now stating the token-suffix rule, the duration-suffix rule with the month/year definitions, and the fact that plain counts take no suffix. The config body below it was already correct and is untouched.

## Evals — deliberately none

I wrote a case for this and ran it three ways:

| Configuration | Score |
|---|---|
| With skill (this PR) | 3/3 |
| With skill (old, incorrect header) | 3/3 |
| Without skill at all | 3/3 |

It passes everywhere, including against the text this PR removes, so it could not catch a regression. I tried twice to make it discriminate — first asking for YAML lines, then asking directly what units the config expects — and neither worked, for a clear reason: the 60 lines of correctly-suffixed YAML in the same code block already outweigh the single wrong comment, so a model reading the skill infers the right convention regardless.

That also locates the actual cost of the bug: it misleads a person reading the header and hand-converting values (where a units error in a launch config is unrecoverable), not the generated output. Worth fixing, not worth a permanent test. `evaluations/sns-launch.json` therefore stays absent rather than existing with one case that can never fail — the missing file is already surfaced as a validator warning.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
