### PR TITLE
fix(ic-dashboard): correct the canister-ID group structure

### DIFF
--- a/skills/ic-dashboard/SKILL.md
+++ b/skills/ic-dashboard/SKILL.md
@@ -48,7 +48,7 @@ Full URLs for specs and UI:
 
 1. **Wrong base URL or API version.** IC API uses `/api/v3/` (and v4 for canisters/subnets); ICRC has `/api/v1/` and `/api/v2/` (ICRC API does not serve mainnet ICP — use Ledger API). Ledger API uses unversioned paths for some endpoints (e.g. `/accounts`, `/supply/total/latest`) and `/v2/` for cursor-paginated lists. Metrics API uses `/api/v1/`. Using the wrong prefix returns 404 or wrong schema.
 
-2. **Canister ID format.** Canister IDs in paths and queries must match the principal-like pattern: 27 characters, five groups of five plus a final three (e.g. `ryjl3-tyaaa-aaaaa-aaaba-cai`). Subnet IDs use the longer pattern (e.g. 63 chars). Sending a raw principal string in the wrong encoding or length causes 422 or 400.
+2. **Canister ID format.** Canister IDs in paths and queries are principal text: lowercase Base32 of `CRC32(blob) · blob`, split into 5-character groups where only the last group may be shorter (1–5 characters). A mainnet canister ID is 27 characters — **four** groups of five plus a final three, e.g. `ryjl3-tyaaa-aaaaa-aaaba-cai`. Principals are not fixed-length: subnet IDs reach the 63-character maximum (ten groups of five plus a final three), and short ones such as the management canister `aaaaa-aa` are also valid principals. Sending a raw principal string in the wrong encoding or length causes 422 or 400.
 
 3. **Using ICRC API for mainnet ICP.** ICRC API exposes **test ICP (TestICP) only**, not mainnet ICP. For mainnet ICP token data (accounts, transactions, supply) use **Ledger API** (`ledger-api.internetcomputer.org`). Use ICRC API for other ICRC ledgers (e.g. ckBTC, SNS tokens) and for TestICP.
 


### PR DESCRIPTION
Closes #283

## Problem

`skills/ic-dashboard/SKILL.md:51` — "Canister IDs … must match the principal-like pattern: 27 characters, **five groups of five plus a final three** (e.g. `ryjl3-tyaaa-aaaaa-aaaba-cai`)."

Those two halves cannot both be true: five groups of five plus a final three is 33 characters, not 27. The skill's own example is four groups of five plus a final three.

## Verification

Counted the group structure directly:

| Principal | Chars | Groups |
|---|---|---|
| `ryjl3-tyaaa-aaaaa-aaaba-cai` | 27 | `[5,5,5,5,3]` |
| `mxzaz-hqaaa-aaaar-qaada-cai` | 27 | `[5,5,5,5,3]` |
| `aaaaa-aa` | 8 | `[5,2]` |
| `tdb26-jop6k-…-vb5e6-eqe` | 63 | `[5×10,3]` |

And against the interface spec's [textual representation](https://github.com/dfinity/portal/blob/master/docs/references/ic-interface-spec.md) rules:

> The textual representation of a blob `b` is `Grouped(Base32(CRC32(b) · b))` …
> `Grouped` takes an ASCII string and inserts the separator `-` (dash) every 5 characters. **The last group may contain less than 5 characters.**

> Because the maximum size of a principal is 29 bytes, the textual representation will be **no longer than 63 characters** (10 times 5 plus 3 characters with 10 separators in between them).

So `27` was correct, "five groups of five" was wrong, and the blanket "must match" phrasing also conflicts with `aaaaa-aa` — which the two skills the issue cites handle correctly already (`canhelp`'s regex allows a 1–5 char final group; `caffeine-app` uses `aaaaa-aa`).

## Change

Pitfall 2 only. It now gives the grouping rule, the 27-character canister-ID case with the corrected **four** groups, and both ends of the range (`aaaaa-aa` short, 63-char subnet IDs long) so neither looks invalid.

## Evals — deliberately none

I wrote a case asking for a validation regex plus its character count and group structure, and ran it three ways:

| Configuration | Score |
|---|---|
| With skill (this PR) | 3/3 |
| With skill (old wording) | 3/3 |
| Without skill at all | 3/3 |

No discrimination, and the reason is structural: the correct example `ryjl3-tyaaa-aaaaa-aaaba-cai` sits in the same sentence as the wrong description, so a model reads the example and gets it right regardless.

This is the third issue in a row with that shape (also #276, #289) — wrong prose adjacent to a correct example. The fix is still worth making, because the cost lands on a human who writes a validator from the prose: "five groups of five" produces a pattern that rejects **every real canister ID**. But it is not a model-behaviour regression, so `evaluations/ic-dashboard.json` stays absent rather than carrying one case that can never fail.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
