### PR TITLE
fix(multi-canister): restore the real identity instead of a nonexistent `default`

### DIFF
--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -1,7 +1,6 @@
 {
   "skill": "multi-canister",
   "description": "Evaluation cases for the multi-canister skill. Tests whether agents avoid documented pitfalls: inventing a dependencies field in icp.yaml instead of using the injected PUBLIC_CANISTER_ID environment variables for inter-canister wiring.",
-
   "output_evals": [
     {
       "name": "Adversarial: dependencies field for deploy ordering",
@@ -22,14 +21,22 @@
         "Does NOT use ExperimentalCycles (mo:base/ExperimentalCycles is unavailable in a mo:core project)",
         "Does NOT use ic_cdk::api::canister_balance128 or canister_balance, removed in ic-cdk 0.20"
       ]
+    },
+    {
+      "name": "Adversarial: there is no identity named `default`",
+      "prompt": "Using icp-cli, give me the bash to verify my canister rejects unregistered callers: make a throwaway identity, call the canister as it to see the rejection, then get back to the identity I normally use. Just the commands, no explanation.",
+      "expected_behaviors": [
+        "Saves the current identity into a variable, e.g. ORIGINAL=$(icp identity default), rather than assuming a fixed identity name",
+        "Restores using that saved variable, e.g. icp identity default \"$ORIGINAL\"",
+        "Does NOT switch back with `icp identity default default` -- no identity named `default` exists in icp-cli"
+      ]
     }
   ],
-
   "trigger_evals": {
     "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
     "should_trigger": [
       "How do I split my IC app across multiple canisters that call each other?",
-      "My canister's inter-canister call sometimes returns SYS_UNKNOWN — what does that mean?",
+      "My canister's inter-canister call sometimes returns SYS_UNKNOWN \u2014 what does that mean?",
       "Design a canister factory that spins up a new canister per user"
     ],
     "should_not_trigger": [

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -957,6 +957,11 @@ icp canister call user_service register '("testuser")'
 icp canister call content_service createPost '("Test Title", "Test Body")'
 # Expected: (variant { ok = record { ... } })
 
+# Remember the identity you registered with. There is no identity named
+# `default` -- `icp identity default` names the *role*, and a fresh icp-cli
+# install has only `anonymous`. (Notices go to stderr, so this captures cleanly.)
+ORIGINAL_IDENTITY=$(icp identity default)
+
 # Create a new identity that is NOT registered
 icp identity new unregistered --storage plaintext
 icp identity default unregistered
@@ -964,7 +969,7 @@ icp canister call content_service createPost '("Should Fail", "No user")'
 # Expected: (variant { err = "User not registered" })
 
 # Switch back
-icp identity default default
+icp identity default "$ORIGINAL_IDENTITY"
 ```
 
 ### Verify Cross-Canister Query


### PR DESCRIPTION
Closes #281

## Problem

`skills/multi-canister/SKILL.md:967` — `icp identity default default` ("Switch back"), against `icp-cli:200` and `deploy-to-cloud-engine:351` which both say the default identity is `anonymous`.

The issue's guess that the command "likely fails" is right, and the reason is worth stating precisely: **`default` is the name of the *role*, not of an identity.**

## Verification (icp 1.2.0)

A fresh install, run with an isolated `HOME`, has exactly one identity and it is already the default:

```
$ icp identity list
* anonymous 2vxsx-fae

$ icp identity default
anonymous
```

The on-disk store separates the two concepts explicitly:

- `~/.local/share/icp-cli/identity/identity_list.json` — the identities. `anonymous` appears with `"kind": "anonymous"` (built in); everything else is user-created.
- `~/.local/share/icp-cli/identity/identity_defaults.json` — just a pointer: `{"v": 1, "default": "opensaas"}` on my machine.

So `icp identity default default` asks to select an identity literally *named* `default`, which exists only if the reader happened to create one.

I deliberately did **not** run `icp identity default default` to confirm the failure: on a machine where such an identity did exist, that command would silently change the developer's active identity. `icp identity list` plus the store layout settle it without mutating anything.

## Change

Hardcoding `anonymous` would also be wrong — the identity registered earlier in this same walkthrough is whatever the reader actually uses (`opensaas` here, not `anonymous`). The snippet now captures it and restores that:

```bash
ORIGINAL_IDENTITY=$(icp identity default)
...
icp identity default unregistered
...
icp identity default "$ORIGINAL_IDENTITY"
```

I checked the command substitution is safe on a first run too: the telemetry notice goes to **stderr**, so `$(icp identity default)` captures only the name (`anonymous` on a fresh `HOME`, `opensaas` on a configured one).

## Evals

Added eval 3 to `evaluations/multi-canister.json`.

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| With skill (old text) | **1/3** |
| Without skill (baseline) | 3/3 |

The old text was **worse than no skill**: the broken example propagated, making the model hardcode `default` — and render it as `icp identity use default`, inventing a verb icp-cli does not have. Unlike the last three issues I looked at, the wrong command here had no correct version beside it to counteract it, which is exactly why this one is worth a permanent regression test and those were not.

Note my first version of the eval prompt scored 3/3 on the baseline because it told the model to "save whichever identity I'm currently using" — prescribing the fix. The committed prompt asks only to "get back to the identity I normally use".

<details>
<summary>Eval output</summary>

With skill (this PR):

```
  WITH skill: 3/3 passed
    ✅ Saves the current identity into a variable, e.g. ORIGINAL=$(icp identity default)
    ✅ Restores using that saved variable, e.g. icp identity default "$ORIGINAL"
    ✅ Does NOT switch back with `icp identity default default`
```

Old text, same prompt:

```
  WITH skill: 1/3 passed
    ❌ Saves the current identity into a variable
       → The output never captures the current identity into a variable; it just hardcodes
         'default' as the identity to switch back to.
    ❌ Restores using that saved variable
       → The final command is 'icp identity use default', a hardcoded literal rather than a
         restore using a saved variable.
    ✅ Does NOT switch back with `icp identity default default`
```

</details>

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
