### PR TITLE
fix(autosync-ic-skills, canhelp): match the docs to what the code does

### DIFF
--- a/skills/autosync-ic-skills/SKILL.md
+++ b/skills/autosync-ic-skills/SKILL.md
@@ -26,8 +26,8 @@ needs this link again — the installed `SessionStart` hook does the work from t
 The script is a **differential mirror**. It fetches the discovery index once and
 compares each skill's published `hash` against a stored manifest, re-downloading only
 the skills that actually changed (and pruning ones removed upstream). Unchanged skills
-are skipped with no per-file downloads, and the script stays silent unless something
-changed. If the server does not publish a `hash` for a skill, the script falls back to
+are skipped with no per-file downloads, and the script writes nothing to stdout unless
+something changed. If the server does not publish a `hash` for a skill, the script falls back to
 re-downloading it every run, so it remains correct either way.
 
 ## Important: tell the user what to expect
@@ -89,8 +89,11 @@ sync logic stays correct as it is updated upstream.
   replaces a changed skill's whole directory via an atomic staging swap — so files
   renamed or removed upstream don't linger inside a skill, and an interrupted
   download leaves the existing copy intact.
-- Prints a one-line `added / updated / removed` summary only when something changed;
-  otherwise it is silent.
+- Writes nothing to stdout on a no-op sync. When something changed it prints one JSON
+  object whose `systemMessage` carries the `added / updated / removed` summary — that
+  string is what the user sees, because SessionStart hooks surface JSON fields rather
+  than raw output. Its diagnostics (interrupted-sync recovery, unsafe skill names) go to
+  stderr and so are not displayed.
 - Degrades gracefully: exits cleanly (keeping cached skills) if the network is down or
   `jq` is missing, and falls back to re-downloading skills the server publishes no
   `hash` for.

--- a/skills/canhelp/scripts/resolve-canister-id.sh
+++ b/skills/canhelp/scripts/resolve-canister-id.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 INPUT="${1:?Usage: resolve-canister-id.sh <canister-id-or-name>}"
 
 # Principal: Base32(CRC32 · blob) grouped into 5-char chunks separated by dashes.
-# Each group is exactly 5 lowercase alphanumeric chars, except the last which is 1-5.
+# Each group is exactly 5 base32 chars -- a-z and 2-7 per RFC 4648, so 0, 1, 8 and 9
+# never occur -- except the last group, which is 1-5 chars.
 # Max 63 chars (29-byte blob → 53 base32 chars + 10 dashes). Must have at least 2 groups.
 if [[ "$INPUT" =~ ^[a-z2-7]{5}(-[a-z2-7]{5})*(-[a-z2-7]{1,5})$ ]]; then
     echo "$INPUT"


### PR DESCRIPTION
Closes #296

Two documentation-vs-code mismatches. Both confirmed by reading the scripts rather than reasoning about them.

## 1. autosync-ic-skills: output description

`SKILL.md:93` claimed the script "Prints a one-line `added / updated / removed` summary only when something changed; otherwise it is silent."

`scripts/sync-ic-skills.sh:196-206` actually emits a multi-line JSON object via `jq -n` — `systemMessage` plus `hookSpecificOutput` (`reloadSkills`, `hookEventName`, `additionalContext`). The script's own comment explains why, and it is the key detail the doc was missing:

```sh
# SessionStart hook stdout/stderr is NOT shown in the Claude Code UI —
# only JSON fields are surfaced. We emit a single JSON object on stdout:
#   - systemMessage    -> rendered to the USER as a visible system notice
```

So the one-line summary is what the **user** sees, delivered via `systemMessage`; stdout itself is JSON. The doc conflated the two.

"Otherwise it is silent" is also not quite right — the interrupted-sync recovery notice (`:58`) and the unsafe-name warnings (`:105`, `:118`) can fire when `added + updated + removed == 0`. They go to **stderr**, which a SessionStart hook does not surface, so the practical effect is invisible, but that is worth stating rather than implying nothing is ever written.

One thing the issue lists that is **not** a counterexample: the prune message at `:109`. It sits directly beside `removed=$((removed + 1))`, so any run that prints it did change something. I left that out rather than repeating it.

Also softened `:32` from "stays silent unless something changed" to "writes nothing to stdout unless something changed".

## 2. canhelp: charset comment

`scripts/resolve-canister-id.sh:7` said "Each group is exactly 5 lowercase **alphanumeric** chars" while the regex on `:9` is `[a-z2-7]` — base32 per RFC 4648, which excludes `0`, `1`, `8` and `9`. "Alphanumeric" is strictly looser than what the code accepts. The comment now says base32 and names the excluded digits.

## Verification

Comment and prose only — no behaviour change. Confirmed:

```
$ bash -n skills/canhelp/scripts/resolve-canister-id.sh
syntax OK

ryjl3-tyaaa-aaaaa-aaaba-cai -> ryjl3-tyaaa-aaaaa-aaaba-cai
aaaaa-aa                    -> aaaaa-aa
bad0-id19                   -> <no direct match>
```

`bad0-id19` failing to match is the charset claim demonstrated: it contains `0`, `1` and `9`.

## Evals — none

Neither change is model-behaviour. One is a comment inside a script an agent does not reproduce; the other describes hook output format. `evaluations/canhelp.json` exists, but its references to "summary" are about the tool's own output presentation, not this comment, so nothing it covers was touched and it was not re-run. No `evaluations/autosync-ic-skills.json` exists and I did not create one for a doc-accuracy fix.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
