### PR TITLE
fix(multi-canister): pin core 2.1.0, the version Runtime.envVar needs

### DIFF
--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -1,7 +1,6 @@
 {
   "skill": "multi-canister",
   "description": "Evaluation cases for the multi-canister skill. Tests whether agents avoid documented pitfalls: inventing a dependencies field in icp.yaml instead of using the injected PUBLIC_CANISTER_ID environment variables for inter-canister wiring.",
-
   "output_evals": [
     {
       "name": "Adversarial: dependencies field for deploy ordering",
@@ -22,14 +21,22 @@
         "Does NOT use ExperimentalCycles (mo:base/ExperimentalCycles is unavailable in a mo:core project)",
         "Does NOT use ic_cdk::api::canister_balance128 or canister_balance, removed in ic-cdk 0.20"
       ]
+    },
+    {
+      "name": "Adversarial: core pin must allow Runtime.envVar",
+      "prompt": "I have an icp-cli multi-canister project. My Motoko backend needs to read a sibling canister's ID at runtime. Give me the mops.toml [dependencies] section plus the single line that reads the ID. No explanation.",
+      "expected_behaviors": [
+        "Pins core to 2.1.0 or higher in [dependencies]",
+        "Does NOT pin core = \"2.0.0\" -- in core 2.0.0 the Runtime module has only trap and unreachable, so Runtime.envVar fails to compile with M0072",
+        "Reads the ID with Runtime.envVar<system>(\"PUBLIC_CANISTER_ID:<canister-name>\")"
+      ]
     }
   ],
-
   "trigger_evals": {
     "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
     "should_trigger": [
       "How do I split my IC app across multiple canisters that call each other?",
-      "My canister's inter-canister call sometimes returns SYS_UNKNOWN — what does that mean?",
+      "My canister's inter-canister call sometimes returns SYS_UNKNOWN \u2014 what does that mean?",
       "Design a canister factory that spins up a new canister per user"
     ],
     "should_not_trigger": [

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -16,7 +16,7 @@ Splitting an IC application across multiple canisters for scaling, separation of
 
 ## Prerequisites
 
-- For Motoko: `mops` package manager, `core = "2.0.0"` in mops.toml
+- For Motoko: `mops` package manager, `core = "2.1.0"` in mops.toml — `Runtime.envVar`, used below to discover a sibling canister's ID, was added in motoko-core 2.1.0
 - For Rust: `ic-cdk >= 0.19`, `candid`, `serde`, `ic-stable-structures`
 
 ## How It Works


### PR DESCRIPTION
Closes #284

> Note: this touches `skills/multi-canister/SKILL.md` (line 19) and `evaluations/multi-canister.json`, which #322 also touches (line ~967 and a different eval case). The hunks don't overlap, so they merge independently in either order.

## Problem

- `skills/multi-canister/SKILL.md:19` — Prerequisites pin `core = "2.0.0"`.
- `skills/multi-canister/SKILL.md:86` — pitfall 1 tells you to read a sibling's canister ID with `Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service")` and already annotates it "(motoko-core >= 2.1.0)".

The file contradicts itself, and the pin is the wrong half.

## Verification

motoko-core `Changelog.md`, under **2.1.0**:

> Add `Runtime.envVarNames` and `Runtime.envVar` functions (#465).

I didn't stop at the changelog — compiled the documented pattern against both versions with moc 1.8.2 to confirm the pin isn't cosmetic:

```motoko
import Runtime "mo:core/Runtime";
persistent actor {
  func siblingId<system>() : ?Text { Runtime.envVar<system>("PUBLIC_CANISTER_ID:user_service") };
  public func get() : async ?Text { siblingId<system>() };
}
```

```
=== core 2.0.0 ===
src/main.mo:3.46-3.52: type error [M0072], field envVar does not exist in type:
  module {trap : (errorMessage : Text) -> None; unreachable : () -> None}

=== core 2.1.0 ===
(clean)
```

On 2.0.0 the whole `Runtime` module is just `trap` and `unreachable` — so anyone following the Prerequisites and then pitfall 1 hits a hard compile error.

## Change

One line: `core = "2.0.0"` → `core = "2.1.0"`, with the reason inline.

**Why 2.1.0 and not 2.5.0:** the broader mo:core pin drift across skills (2.0.0 / 2.3.1 / 2.5.0) is #297, and unifying it here would pre-empt that issue. 2.1.0 is the exact minimum this skill needs. I checked it is also *sufficient* — the file imports only `Array`, `Error`, `Map`, `Nat`, `Principal`, `Result`, `Runtime`, `Time`, and uses nothing added after 2.1.0 (no `Base64` 2.3.0, `Float32` 2.4.0, `Principal.toActor` / `CallerAttributes` 2.5.0, `Array.toBlob` 2.6.0, `PriorityQueue` additions 2.2.0).

## Evals

Added a case covering the pin plus the `envVar` read.

| Configuration | Score |
|---|---|
| With skill (this PR) | **3/3** |
| With skill (old pin) | 3/3 |
| Without skill (baseline) | **1/3** |

Being straight about what this measures: it does **not** discriminate on my one-line change, because pitfall 1 already carried ">= 2.1.0" and the model reads that. It is a skill-vs-baseline guard — without the skill the model pins `base = "0.13.4"` with no `core` at all and reaches for `Principal.fromActor` instead of `envVar`. That guidance had no eval coverage before, so the case is worth keeping; the compile check above is the evidence for the change itself.

<details>
<summary>Eval output</summary>

```
━━━ Adversarial: core pin must allow Runtime.envVar ━━━

  WITH skill: 3/3 passed
    ✅ Pins core to 2.1.0 or higher in [dependencies]
    ✅ Does NOT pin core = "2.0.0"
    ✅ Reads the ID with Runtime.envVar<system>("PUBLIC_CANISTER_ID:<canister-name>")

  WITHOUT skill: 1/3 passed
    ❌ Pins core to 2.1.0 or higher in [dependencies]
       → The [dependencies] section only lists base = "0.13.4" and does not include core at all.
    ✅ Does NOT pin core = "2.0.0"
    ❌ Reads the ID with Runtime.envVar<system>("PUBLIC_CANISTER_ID:<canister-name>")
       → The code uses Principal.fromActor(Sibling) with a canister import alias instead of
         Runtime.envVar<system>.
```

</details>

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
