### PR TITLE
fix(icp-cli): point both doc links at the current 1.2 reference

### DIFF
--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -116,7 +116,7 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 13. **Passing `{ agent }` to `createActor` from `@icp-sdk/bindgen`.** The old `@dfinity/agent` pattern was `createActor(canisterId, { agent })`. The `@icp-sdk/bindgen` pattern is `createActor(canisterId, { agentOptions: { host, rootKey } })` — the binding creates the agent internally. Passing `{ agent }` to the new API **silently creates an anonymous identity** — no error is thrown, but calls return empty data or access denied. See `references/binding-generation.md` for the correct pattern.
 
-14. **Mixing canister-level fields across config styles.** When using a recipe, the only valid canister-level fields are `name`, `recipe`, `sync`, `settings`, and `init_args`. Fields like `candid`, `build`, or `wasm` are **not** valid at canister level alongside a recipe — recipe-specific options go inside `recipe.configuration`. When using bare `build` (no recipe), valid canister-level fields are `name`, `build`, `sync`, `settings`, and `init_args`. The field `init_arg_file` does not exist — use `init_args.path` instead (e.g., `init_args: { path: ./args.bin, format: bin }`). For the authoritative field reference, consult the [icp-cli configuration reference](https://cli.internetcomputer.org/0.2/reference/configuration.md).
+14. **Mixing canister-level fields across config styles.** When using a recipe, the only valid canister-level fields are `name`, `recipe`, `sync`, `settings`, and `init_args`. Fields like `candid`, `build`, or `wasm` are **not** valid at canister level alongside a recipe — recipe-specific options go inside `recipe.configuration`. When using bare `build` (no recipe), valid canister-level fields are `name`, `build`, `sync`, `settings`, and `init_args`. The field `init_arg_file` does not exist — use `init_args.path` instead (e.g., `init_args: { path: ./args.bin, format: bin }`). For the authoritative field reference, consult the [icp-cli configuration reference](https://cli.internetcomputer.org/1.2/reference/configuration.md).
     ```yaml
     # Wrong — candid is not a canister-level field when using a recipe
     canisters:
@@ -466,7 +466,7 @@ const backendId = safeGetCanisterEnv()?.["PUBLIC_CANISTER_ID:backend"];
 - User-defined variables (`settings.environment_variables` in `icp.yaml`) are static YAML strings shared across environments: a create-class install (first install or `--mode reinstall`) re-applies them, overwriting anything set with `icp canister settings update --add-environment-variable`. Re-assert environment-specific values (e.g. production origins) after such a deploy.
 - The replica caps an environment-variable *value* at 128 characters.
 
-Full reference: [icp-cli environment variables](https://cli.internetcomputer.org/1.0/reference/environment-variables/).
+Full reference: [icp-cli environment variables](https://cli.internetcomputer.org/1.2/reference/environment-variables/).
 
 ### Web identity flows
 


### PR DESCRIPTION
Closes #300

## Problem

Two links to the same tool's documentation pinned different versions:

- `skills/icp-cli/SKILL.md:119` → `.../0.2/reference/configuration.md`, cited as "the authoritative field reference"
- `skills/icp-cli/SKILL.md:469` → `.../1.0/reference/environment-variables/`

## Which version is correct

The docs site states it in the unversioned index the skill already links at `:480`:

```
# ICP CLI Documentation (v1.2)
This documentation is for v1.2. Other versions are available:
- v1.1, v1.0, v0.3, v0.2, v0.1, Development (main)
```

v1.2 also matches the CLI this skill describes — `icp --version` → `icp 1.2.0`, consistent with the `-n`/`-e` and `--id-only` behaviours verified elsewhere in this repo.

## Checked the URL shapes before choosing one

My first instinct was to drop the version entirely so the links can't go stale. That does not work:

| URL | Status |
|---|---|
| `/0.2/reference/configuration.md` | 200 |
| `/1.0/reference/configuration.md` | 200 |
| `/1.2/reference/configuration.md` | 200 |
| `/reference/configuration.md` | **404** |
| `/latest/reference/configuration.md` | **404** |
| `/reference/environment-variables/` | **404** |
| `/llms.txt` | 200 |

A version prefix is mandatory for reference pages; only `llms.txt` resolves unversioned, which is why `:480` needs no change.

## The 0.2 link was materially behind, not just renumbered

| Version | Size | Notes |
|---|---|---|
| 0.2 | 14,688 bytes | |
| 1.0 | 16,716 bytes | |
| 1.2 | 17,541 bytes | adds a "Plugin Sync" section absent from 0.2 |

I also confirmed the new target actually agrees with the pitfall it backs. The 1.2 **Canister Properties** table lists exactly `name`, `build`, `sync`, `settings`, `init_args`, `recipe` — matching both field lists in pitfall 14 — and `init_arg_file` appears nowhere in the doc, as the pitfall claims.

## Change

Both links now point at `1.2`. All three `cli.internetcomputer.org` links in the file return 200.

## Evals — none

A URL correction with no effect on generated code, and no case in `evaluations/icp-cli.json` references these URLs (checked: 0 matches), so nothing needed re-running.

## Worth knowing

Because there is no `latest` alias, these two links will drift again on the next icp-cli release — this fix is inherently perishable. The durable pattern is the unversioned `llms.txt` at `:480`, which tracks current automatically. If the docs site ever adds a `latest` alias, these two are the ones to switch over.

`npm run validate` passes (including its link check): 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
