### PR TITLE
fix(caffeine-app): resolve three internal mismatches

### DIFF
--- a/skills/caffeine-app/SKILL.md
+++ b/skills/caffeine-app/SKILL.md
@@ -2,7 +2,7 @@
 name: caffeine-app
 description: "Scaffold and build a complete Caffeine app (caffeine.ai) from scratch — the project layout, the caffeine.toml workspace + canister manifests, the mops.toml for the single Motoko `backend` canister, the React/Vite frontend, and the caffeine CLI build loop (auth login, doctor, install, check --fix, preview --build). Use whenever the user wants to create, scaffold, set up, or build a Caffeine app or a caffeine.ai project, asks about caffeine.toml or mops.toml structure, or needs the caffeine CLI workflow — even if they do not say the words 'from scratch'. Always pair it with the `motoko` skill for the backend code. Do NOT use it for Motoko language syntax or compiler errors (use the `motoko` skill), and do NOT use it for generic Internet Computer / dfx / icp deployment (use the `icp-cli` skill)."
 license: Apache-2.0
-compatibility: "@caffeineai/cli (the `caffeine` command), Node.js >= 18, pnpm, network access + a caffeine.ai account"
+compatibility: "@caffeineai/cli (the `caffeine` command), Node.js >= 18.17, pnpm, network access + a caffeine.ai account"
 metadata:
   title: "Caffeine App (build from scratch)"
   category: Integration
@@ -270,7 +270,7 @@ invoked by the backend canister's `[build]` step (`pnpm bindgen`).
   "name": "@caffeine/template-app",
   "type": "module",
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=18.17.0",
     "pnpm": ">=7.0.0",
     "npm": "please use pnpm"
   },
@@ -401,8 +401,9 @@ returns its URL. Promote a draft to a live URL in the caffeine.ai web app (open 
 
 If you cannot run the CLI locally (no shell, no toolchain), drive Caffeine's hosted AI
 instead: describe the app in natural language with `caffeine chat send "<prompt>"` (or
-the caffeine.ai web chat) and it scaffolds, builds, and deploys for you. This skill is
-for the **local, hand-authored** path.
+the caffeine.ai web chat). Caffeine's hosted AI then scaffolds, builds, and deploys it
+server-side — `chat send` only submits the prompt, so this does not contradict the CLI
+having no deploy command. This skill is for the **local, hand-authored** path.
 
 ## Common Pitfalls
 

--- a/skills/caffeine-app/references/frontend-template.md
+++ b/skills/caffeine-app/references/frontend-template.md
@@ -413,7 +413,7 @@ export default {
 ## `src/frontend/env.json`
 
 Placeholders only — Caffeine injects real values when it serves the app. The `build`
-script copies this file into `dist/` (the `copy:env` step). Keep all four keys.
+script copies this file into `dist/` (the `copy:env` step). Keep all five keys.
 
 ```json
 {


### PR DESCRIPTION
Closes #293

Two of the three were real. The third is a misreading, and I've said so rather than "fixing" working text.

## 1. Node floor — real

`SKILL.md:5` required Node.js >= 18; the package.json template at `:273` declared `"node": ">=16.0.0"`.

Resolved from the template's own dependency tree rather than by preference. Its only devDependency:

```
$ npm view sharp@0.34.4 engines
{ node: '^18.17.0 || ^20.3.0 || >=21.0.0' }
```

So the template **cannot install** on Node 16 — and `>= 18` was loose too, since 18.0–18.16 are excluded. Both now say **18.17**.

## 2. env.json keys — real

`references/frontend-template.md:416` said "Keep all four keys." directly above a block with five (`backend_host`, `backend_canister_id`, `project_id`, `ii_derivation_origin`, `storage_gateway_url`), matching the five listed in `SKILL.md:355-356`. Now says five.

## 3. Deploy story — not a contradiction

`:44` says the CLI has no deploy command; `:402-404` says the hosted AI "scaffolds, builds, and deploys for you". I checked the published CLI rather than assuming either side was wrong. From `@caffeineai/cli@0.1.0-dev.46`'s command table:

| Group | Command | Description |
|---|---|---|
| Build | `preview` | Upload a built project as a draft |
| Chat | `chat send <message>` | Send a prompt and stay attached until stable |

**There is no `deploy` or `publish` command** — `preview` uploading a draft is exactly what `:44` claims. And `chat send` submits a prompt; the *hosted service* does the deploying. The two statements are compatible.

What made it look contradictory is the bare "it" in "and it scaffolds, builds, and deploys for you" — the subject is Caffeine's hosted AI, not the CLI the sentence just named. Made the subject explicit instead of changing the meaning.

## Evals

No new case. Both corrected values sat directly beside a correct one — the JSON block already showed five keys, and `compatibility` already said 18 — which is the pattern where an eval can't discriminate (same as #276, #283, #289 in this batch).

Re-ran the two existing cases whose content this touches:

| Case | Result |
|---|---|
| 9 — "Deploy to a live URL" | 3/3 |
| 12 — "env.json purpose and build step" | 2/2 |

<details>
<summary>Eval output</summary>

```
━━━ Deploy to a live URL ━━━
  WITH skill: 3/3 passed
    ✅ Says the CLI builds a draft via caffeine preview --build (returns a draft URL)
    ✅ Says promoting a draft to a live URL happens in the caffeine.ai web app, not the CLI
    ✅ Does not claim a `caffeine deploy`/`publish` command or dfx deploy exists

━━━ env.json purpose and build step ━━━
  WITH skill: 2/2 passed
    ✅ Explains it holds runtime config placeholders that Caffeine fills in when serving
    ✅ Says it must be copied into dist/ at build (the copy:env step)
```

</details>

Also checked no other skill still carries the stale values: `grep -rn "all four keys\|>=16.0.0" skills/` returns nothing.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
