### PR TITLE
fix(stable-memory): types may live in the actor body or an imported module

### DIFF
--- a/skills/stable-memory/SKILL.md
+++ b/skills/stable-memory/SKILL.md
@@ -87,7 +87,8 @@ import Time "mo:core/Time";
 
 persistent actor {
 
-  // Types -- must be inside actor body
+  // Types: in the actor body (as here) or in an imported module -- but never
+  // between the imports and the actor, which is M0141. See the `motoko` skill.
   type User = {
     id : Nat;
     name : Text;


### PR DESCRIPTION
Closes #278

## Problem

- `skills/stable-memory/SKILL.md:90` — `// Types -- must be inside actor body`
- `skills/motoko/SKILL.md:354-366` — types before the actor give M0141; the recommended fix is `types.mo` + import.

"Must" reads as the only option, which conflicts with the module split. Both placements work; only the absolute wording was wrong.

## Verification

All three placements, moc 1.8.2:

| Placement | Result |
|---|---|
| `type` before the actor | **M0141** |
| `type` inside the actor body | compiles — 247,629-byte wasm |
| `type` in an imported module | compiles — 247,629-byte wasm |

**A methodology note I think is worth recording**, because it nearly sent me the wrong way: `moc --check` does **not** surface M0141. The type-before-actor case passes `--check` silently and only fails on a full `moc -c` canister compile:

```
$ moc $(mops sources) --check t/a_before.mo
(no output)

$ moc $(mops sources) -c t/a_before.mo -o t/a.wasm
t/a_before.mo:1.1-1.18: type error [M0141], move these declarations into the body of
  the main actor or actor class
t/a_before.mo:2.1-4.2: type error [M0141], an actor or actor class must be the only
  non-imported declaration in a program
```

My first pass used `--check` and I briefly concluded the `motoko` skill was mistaken about M0141. It isn't — I was using the wrong flag. Same applies to `let` and `var` before the actor, both M0141.

## The two skills were never really in conflict

The compiler's own message is "move these declarations into the body of the main actor or actor class" — so the actor body is a legitimate destination, exactly what `stable-memory` said. `motoko` recommends the module split as better architecture. Both true; only "must" overstated it.

`motoko`'s pitfall 1 is correct and untouched (it is upstream-tracked, so a local edit there would need an upstream issue regardless).

## Change

One comment in `stable-memory`, now naming both valid placements and stating what is actually forbidden:

```motoko
  // Types: in the actor body (as here) or in an imported module -- but never
  // between the imports and the actor, which is M0141. See the `motoko` skill.
```

## Evals

No new case — the comment sits directly above types correctly declared in the actor body (the adjacency pattern that has made four earlier cases in this batch non-discriminating), and `motoko` already teaches the module split.

Re-ran the existing case whose example contains this comment: **case 1 "mo:core Map call style in a persistent actor" — 4/4**.

`npm run validate` passes: 26 skills validated, all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
