### PR TITLE
fix: converge recipe versions on @dfinity/motoko@v5.0.0 and @dfinity/rust@v3.3.0

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -9,7 +9,7 @@
         "Uses icp (not dfx) commands throughout",
         "Configuration file is icp.yaml, NOT dfx.json",
         "Canisters are a YAML array of objects (- name: ...), NOT a keyed map",
-        "Rust canister uses a recipe with a version pin (e.g., @dfinity/rust@v3.2.0)",
+        "Rust canister uses a recipe with a version pin (e.g., @dfinity/rust@v3.3.0)",
         "Frontend/asset canister uses a recipe with a version pin",
         "Asset canister recipe includes explicit build commands (e.g., npm install, npm run build)",
         "Shows how to start the local network (icp network start -d)"
@@ -32,7 +32,8 @@
       "expected_behaviors": [
         "Shows icp.yaml with recipe-based canister configuration",
         "Motoko canister uses @dfinity/motoko recipe with a version pin",
-        "Asset canister uses @dfinity/asset-canister recipe with a version pin",
+        "Does NOT map dfx.json's \"main\" to recipe.configuration.main in icp.yaml -- under the @dfinity/motoko@v5+ recipe main belongs in mops.toml as [canisters.<name>].main",
+        "Frontend canister uses a version-pinned recipe -- @dfinity/static-site (recommended) or @dfinity/asset-canister (legacy) is acceptable",
         "Mentions identity migration (export from dfx, import into icp) or references dfx-migration.md",
         "Mentions canister ID migration via .icp/data/mappings/ic.ids.json or references dfx-migration.md",
         "Uses correct icp identity commands ('icp identity default' not 'icp identity use') or references dfx-migration.md for the command mapping"
@@ -43,7 +44,7 @@
       "prompt": "Here's my icp.yaml, does it look right?\n\ncanisters:\n  - name: backend\n    recipe:\n      type: \"@dfinity/rust\"\n      configuration:\n        package: backend",
       "expected_behaviors": [
         "Identifies that the recipe is missing a version pin",
-        "Recommends pinning to a specific version (e.g., @dfinity/rust@v3.2.0)",
+        "Recommends pinning to a specific version (e.g., @dfinity/rust@v3.3.0)",
         "Explains that icp-cli rejects unpinned recipe references"
       ]
     },

--- a/evaluations/multi-canister.json
+++ b/evaluations/multi-canister.json
@@ -13,6 +13,16 @@
       ]
     },
     {
+      "name": "Adversarial: Motoko v5 recipe puts each canister's main in mops.toml",
+      "prompt": "Set up an icp-cli project with two Motoko canisters, user_service (src/user_service/main.mo) and content_service (src/content_service/main.mo), using the @dfinity/motoko@v5.0.0 recipe. Show ONLY the icp.yaml and the mops.toml, each in one fenced block, no prose and no deploy steps.",
+      "expected_behaviors": [
+        "icp.yaml lists both canisters with recipe type @dfinity/motoko@v5.0.0 and NO recipe.configuration block on either",
+        "Does NOT put main (or candid) under recipe.configuration in icp.yaml -- that is the v4 layout, removed in v5",
+        "mops.toml has a separate [canisters.user_service] and [canisters.content_service] section, each with a main field pointing at that canister's .mo entry point",
+        "The [canisters.<name>] keys exactly match the canister name values in icp.yaml"
+      ]
+    },
+    {
       "name": "Adversarial: reading the factory's own cycle balance",
       "prompt": "In my canister factory, how do I check the factory's own cycle balance before creating a child canister? Give just the Motoko call and the Rust call, no surrounding function.",
       "expected_behaviors": [

--- a/skills/ckbtc/SKILL.md
+++ b/skills/ckbtc/SKILL.md
@@ -96,7 +96,12 @@ version = "0.1.0"
 [dependencies]
 core = "2.0.0"
 icrc2-types = "1.1.0"
+
+[canisters.backend]
+main = "src/backend/main.mo"
 ```
+
+The `@dfinity/motoko@v5+` recipe compiles via `mops build <canister-name>`, so `main` lives here â€” not in `recipe.configuration` in `icp.yaml`. The `[canisters.<name>]` key must exactly match the canister `name` in `icp.yaml`.
 
 #### icp.yaml
 
@@ -106,9 +111,7 @@ Your backend canister calls the ckBTC ledger and minter by principal directly â€
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: src/backend/main.mo
+      type: "@dfinity/motoko@v5.0.0"
 ```
 
 #### src/backend/main.mo

--- a/skills/evm-rpc/SKILL.md
+++ b/skills/evm-rpc/SKILL.md
@@ -89,9 +89,7 @@ The `evm_rpc` canister definition is only needed for local development — the l
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.2.0"
-      configuration:
-        package: backend
+      type: "@dfinity/rust@v3.3.0"
   - name: evm_rpc
     build:
       steps:

--- a/skills/icp-cli/references/dfx-migration.md
+++ b/skills/icp-cli/references/dfx-migration.md
@@ -95,12 +95,12 @@ Steps:
 
 | dfx.json | icp.yaml |
 |----------|----------|
-| `"type": "rust"` | `recipe.type: "@dfinity/rust@v3.2.0"` |
-| `"type": "motoko"` | `recipe.type: "@dfinity/motoko@v4.1.0"` |
+| `"type": "rust"` | `recipe.type: "@dfinity/rust@v3.3.0"` |
+| `"type": "motoko"` | `recipe.type: "@dfinity/motoko@v5.0.0"` |
 | `"type": "assets"` | `recipe.type: "@dfinity/static-site@v0.3.3"` (recommended) or `@dfinity/asset-canister@v2.2.1` (legacy). Not a drop-in: static-site is a different canister using `_headers`/`_redirects` (not `.ic-assets.json5`), and switching a deployed canister needs a reinstall — see the `static-site` skill's migration guide. |
-| `"package": "X"` | `recipe.configuration.package: X` |
+| `"package": "X"` | `recipe.configuration.package: X` — optional as of `@dfinity/rust@v3.3.0`, which defaults it to the canister `name`. Drop it when the Cargo `[package] name` already matches. |
 | `"candid": "X"` | `recipe.configuration.candid: X` |
-| `"main": "X"` | `recipe.configuration.main: X` |
+| `"main": "X"` | **Not** `recipe.configuration.main`. The `@dfinity/motoko@v5+` recipe compiles via `mops build`, so `main` moves to `mops.toml` as `[canisters.<canister-name>] main = "X"`. The `[canisters.<name>]` key must exactly match the canister `name` in `icp.yaml`. |
 | `"source": ["dist"]` | `recipe.configuration.dir: dist` |
 | `"dependencies": [...]` | Not needed — use Canister Environment Variables |
 | `"output_env_file": ".env"` | Not needed — use `ic_env` cookie |

--- a/skills/multi-canister/SKILL.md
+++ b/skills/multi-canister/SKILL.md
@@ -114,14 +114,28 @@ my-project/
 canisters:
   - name: user_service
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: src/user_service/main.mo
+      type: "@dfinity/motoko@v5.0.0"
   - name: content_service
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: src/content_service/main.mo
+      type: "@dfinity/motoko@v5.0.0"
+```
+
+### mops.toml
+
+The `@dfinity/motoko@v5+` recipe compiles via `mops build <canister-name>`, so each canister's `main` lives in `mops.toml`, not in `recipe.configuration` in `icp.yaml`. Every canister `name` in `icp.yaml` must have an exactly matching `[canisters.<name>]` key here, or the build fails with `No Motoko canisters found in mops.toml configuration`.
+
+```toml
+[toolchain]
+moc = "1.9.0"
+
+[dependencies]
+core = "2.1.0"
+
+[canisters.user_service]
+main = "src/user_service/main.mo"
+
+[canisters.content_service]
+main = "src/content_service/main.mo"
 ```
 
 ### Motoko
@@ -347,17 +361,17 @@ members = [
 canisters:
   - name: user_service
     recipe:
-      type: "@dfinity/rust@v3.2.0"
+      type: "@dfinity/rust@v3.3.0"
       configuration:
-        package: user_service
         candid: src/user_service/user_service.did
   - name: content_service
     recipe:
-      type: "@dfinity/rust@v3.2.0"
+      type: "@dfinity/rust@v3.3.0"
       configuration:
-        package: content_service
         candid: src/content_service/content_service.did
 ```
+
+`package` is omitted: recipe >= v3.3.0 defaults it to the canister `name`, and each workspace member's `[package] name` already matches. Set `package` explicitly only when a crate name differs from its canister name.
 
 #### src/user_service/Cargo.toml
 


### PR DESCRIPTION
Skills were split across two recipe majors for both Motoko and Rust. The Motoko split was the damaging one: `@dfinity/motoko@v4.1.0` puts `main` in `recipe.configuration` in `icp.yaml`, while `v5.0.0` delegates compilation to `mops build` and reads it from `[canisters.<name>]` in `mops.toml`. Mixing the two produces projects that fail to build with `No Motoko canisters found in mops.toml configuration`.

## Which version to converge on

**`@dfinity/motoko@v5.0.0` and `@dfinity/rust@v3.3.0`** — what `skills/icp-cli/SKILL.md` (the repo's authoritative recipe reference, incl. Pitfalls 17 and 21) already documents in depth, and what the official [`icp new` templates](https://github.com/dfinity/icp-cli-templates) generate.

Newer recipes exist (`motoko-v5.1.0`, `rust-v3.4.0`) but add only an optional `visibility` field on `metadata` entries, which no skill documents. Precedent in this repo is to bump when there's a reason (static-site went to v0.3.3 with the certified-assets adoption in #256), not to track latest unconditionally.

## Changes

| File | Change |
|------|--------|
| `skills/multi-canister/SKILL.md` | motoko `v4.1.0` → `v5.0.0`; per-canister `configuration.main` replaced with a new `### mops.toml` section carrying both `[canisters.*]` keys. rust `v3.2.0` → `v3.3.0` with the now-redundant `package` dropped from both workspace members. |
| `skills/ckbtc/SKILL.md` | Same v5 move; `[canisters.backend]` added to the existing `mops.toml` block. |
| `skills/evm-rpc/SKILL.md` | rust `v3.2.0` → `v3.3.0`; redundant `package: backend` dropped (canister name already matches). |
| `skills/icp-cli/references/dfx-migration.md` | Contradicted its own SKILL.md. rust/motoko rows updated; the `"main": "X"` row now points at `mops.toml` instead of `recipe.configuration.main`; the `"package"` row notes it is optional as of v3.3.0. |

`skills/icp-cli/SKILL.md` and `skills/deploy-to-cloud-engine/SKILL.md` were already on v5.0.0/v3.3.0 and are unchanged.

## Verification

Both layouts were built against the real toolchain (`icp 1.2.0`), not just proofread:

- Two-canister Motoko project with `[canisters.user_service]` / `[canisters.content_service]` in `mops.toml` and no `recipe.configuration` → `Canisters built successfully`
- Rust workspace with two members and `package` omitted from both recipes → `Canisters built successfully`

`npm run validate`: 26 skills validated, all passed, 15 warnings (unchanged from baseline).

## Evals

**Added** — `multi-canister` #2, covering the v5 two-canister config split. This is the exact failure mode the change fixes: without the skill the model gets `icp.yaml` right but omits `[canisters.*]` from `mops.toml` entirely, which is the `No Motoko canisters found` build failure.

**Fixed** — `icp-cli` #3 "Migrate from dfx" carried a stale expectation demanding `@dfinity/asset-canister` and was penalizing the model for using the recommended `@dfinity/static-site` recipe (stale since #256, pre-existing — not caused by this change). Broadened to accept either, and added a check that `main` is not mapped into `recipe.configuration`.

Also updated two illustrative `(e.g., @dfinity/rust@v3.2.0)` strings in `icp-cli` #1 and #4 expectations; both re-run and still 3/3 and 7/7 with the skill.

<details>
<summary>Eval results</summary>

```
━━━ multi-canister #2 — Adversarial: Motoko v5 recipe puts each canister's main in mops.toml (NEW) ━━━

  WITH skill: 4/4 passed
    ✅ icp.yaml lists both canisters with recipe type @dfinity/motoko@v5.0.0 and NO recipe.configuration block on either
    ✅ Does NOT put main (or candid) under recipe.configuration in icp.yaml -- that is the v4 layout, removed in v5
    ✅ mops.toml has a separate [canisters.user_service] and [canisters.content_service] section, each with a main field
    ✅ The [canisters.<name>] keys exactly match the canister name values in icp.yaml

  WITHOUT skill: 2/4 passed
    ✅ icp.yaml lists both canisters with recipe type @dfinity/motoko@v5.0.0 and NO recipe.configuration block on either
    ✅ Does NOT put main (or candid) under recipe.configuration in icp.yaml -- that is the v4 layout, removed in v5
    ❌ mops.toml has a separate [canisters.user_service] and [canisters.content_service] section, each with a main field
       → mops.toml only contains [package] and [dependencies] sections with no [canisters.*] sections at all.
    ❌ The [canisters.<name>] keys exactly match the canister name values in icp.yaml
       → There are no [canisters.<name>] sections in mops.toml to compare against icp.yaml's canister names.

  Summary: WITH 4/4 | WITHOUT 2/4


━━━ icp-cli #3 — Migrate from dfx (CHANGED) ━━━

  WITH skill: 7/7 passed
    ✅ Shows icp.yaml with recipe-based canister configuration
    ✅ Motoko canister uses @dfinity/motoko recipe with a version pin
    ✅ Does NOT map dfx.json's "main" to recipe.configuration.main in icp.yaml
    ✅ Frontend canister uses a version-pinned recipe -- static-site (recommended) or asset-canister (legacy) is acceptable
    ✅ Mentions identity migration (export from dfx, import into icp) or references dfx-migration.md
    ✅ Mentions canister ID migration via .icp/data/mappings/ic.ids.json or references dfx-migration.md
    ✅ Uses correct icp identity commands ('icp identity default' not 'icp identity use')

  WITHOUT skill: 0/7 passed
    (baseline produced no config at all — it stopped to ask for web-search permission)

  Summary: WITH 7/7 | WITHOUT 0/7
  (Before the fix this case scored WITH 5/6 — the sole failure was the stale asset-canister expectation.)


━━━ icp-cli #1 — New project setup (CHANGED: e.g. version string) ━━━

  WITH skill: 7/7 passed
    ✅ Rust canister uses a recipe with a version pin (e.g., @dfinity/rust@v3.3.0)
    ✅ (+ 6 others)
  WITHOUT skill: 0/7 passed  (answered entirely in dfx)

  Summary: WITH 7/7 | WITHOUT 0/7


━━━ icp-cli #4 — Recipe version pinning (CHANGED: e.g. version string) ━━━

  WITH skill: 3/3 passed
  WITHOUT skill: 3/3 passed

  Summary: WITH 3/3 | WITHOUT 3/3


━━━ multi-canister #4 — core pin must allow Runtime.envVar (regression check) ━━━
  Re-run because this PR adds a mops.toml block to the same skill.

  WITH skill: 3/3 passed
  WITHOUT skill: 1/3 passed

  Summary: WITH 3/3 | WITHOUT 1/3 — no regression
```

</details>

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEm1Tbkypzi8SuXhrMfBek
