### PR TITLE
docs(deploy-to-cloud-engine): pin the II derivation origin at first deploy

### DIFF
--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -1,7 +1,6 @@
 {
   "skill": "deploy-to-cloud-engine",
   "description": "Evaluation cases for the deploy-to-cloud-engine skill. Tests whether agents drive the correct cloud-engine deploy flow (link the CLI identity against the console origin, target the engine's subnet with icp deploy), use the default console origin https://opencloud.org unless the user names another, ask for the subnet id instead of guessing, set the `__META_*` environment variables so the console shows a named app with labelled canisters and an app icon (`__META_BASE_URL` + `__META_ICON_PATH` on the main canister), and avoid the documented pitfalls.",
-
   "output_evals": [
     {
       "name": "Deploy a built project to a cloud engine",
@@ -167,9 +166,18 @@
         "Sets `service:version` with an explicit version value under the recipe configuration's `metadata` list (and no git-derived entries), noting it should be bumped on each deploy",
         "Does NOT put the metadata under `settings.environment_variables` (that is for `__META_*` console variables, not wasm metadata)"
       ]
+    },
+    {
+      "name": "Adversarial: II app on an engine with a custom domain planned",
+      "prompt": "My multi-canister app is deployed to my OpenCloud cloud engine and uses Internet Identity. We will move it to a custom domain later. Which exact URL should I use as the Internet Identity derivation origin, and when do I set it? Be specific about which canister. No full deploy walkthrough.",
+      "expected_behaviors": [
+        "Names the MAIN canister (the one marked __META_MAIN_CANISTER: \"true\") as the one whose address is the derivation origin — not an arbitrary or backend canister",
+        "Gives the canister address form https://<main-canister-id>.icp.net and notes it is the same URL as __META_BASE_URL",
+        "Says to set it on the first deploy, before the app has users, because it cannot be applied retroactively without orphaning existing accounts",
+        "Does NOT recommend using the future custom domain as the derivation origin"
+      ]
     }
   ],
-
   "trigger_evals": {
     "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
     "should_trigger": [

--- a/evaluations/deploy-to-cloud-engine.json
+++ b/evaluations/deploy-to-cloud-engine.json
@@ -168,13 +168,12 @@
       ]
     },
     {
-      "name": "Adversarial: II app on an engine with a custom domain planned",
-      "prompt": "My multi-canister app is deployed to my OpenCloud cloud engine and uses Internet Identity. We will move it to a custom domain later. Which exact URL should I use as the Internet Identity derivation origin, and when do I set it? Be specific about which canister. No full deploy walkthrough.",
+      "name": "Adversarial: II derivation origin when __META_BASE_URL is a custom domain",
+      "prompt": "My multi-canister app is deployed to my OpenCloud cloud engine and uses Internet Identity for sign-in. My frontend canister is abcde-aaaaa-aaaaa-aaaaa-cai, and I already set __META_BASE_URL to our marketing domain https://app.example.com. What exact URL should I use as the Internet Identity derivationOrigin, and when do I set it? No full deploy walkthrough.",
       "expected_behaviors": [
-        "Names the MAIN canister (the one marked __META_MAIN_CANISTER: \"true\") as the one whose address is the derivation origin — not an arbitrary or backend canister",
-        "Gives the canister address form https://<main-canister-id>.icp.net and notes it is the same URL as __META_BASE_URL",
-        "Says to set it on the first deploy, before the app has users, because it cannot be applied retroactively without orphaning existing accounts",
-        "Does NOT recommend using the future custom domain as the derivation origin"
+        "Gives the frontend canister address https://abcde-aaaaa-aaaaa-aaaaa-cai.icp.net as the derivation origin",
+        "Explicitly does NOT use the custom domain https://app.example.com as the derivation origin, even though __META_BASE_URL is set to it",
+        "Says to set it on the first deploy, before the app has users, because it cannot be applied retroactively without orphaning existing accounts"
       ]
     }
   ],

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -218,6 +218,22 @@ Icon specifics (the console builds the icon as `__META_BASE_URL` + `__META_ICON_
 - `__META_ICON_PATH` is a **path to an asset your frontend actually serves** (e.g. `/favicon.svg`), not an inline image. The resolved URL is rendered as an `<img>` `src`, so it must return an image. Do **not** put a `data:` URI here: engine env values are length-capped (≤128 chars observed), so it would not fit, and the field is a path by design.
 - The frontend canister's id is only known **after** the first deploy. The usual flow is: deploy once, read the frontend canister id from the output, set `__META_BASE_URL` to `https://<that-id>.icp.net` (and `__META_ICON_PATH`), then re-deploy to apply. If you control a custom domain for the app, you can set it up front instead.
 
+### Pin the Internet Identity derivation origin (if the app signs users in)
+
+Internet Identity derives a principal **per origin**. An app reached at both its canister address and a custom domain signs the same person in as two different users.
+
+The engine console names the app's **canister address** as the origin to derive from — it cannot be renamed or removed, so it survives adding, changing, or dropping a custom domain. It is the URL of the canister you marked `__META_MAIN_CANISTER: "true"` — the same value you set as `__META_BASE_URL`:
+
+```
+https://<main-canister-id>.icp.net
+```
+
+**Do this before the app has users, not after.** A domain that has already collected sign-ins cannot be repointed at a derivation origin without orphaning every account created under it. If the app might ever get a custom domain, set `derivationOrigin` on the first deploy even while the canister address is the only origin — it costs nothing then and cannot be applied retroactively without losing accounts.
+
+For the mechanics — the `derivationOrigin` option and the `.well-known/ii-alternative-origins` file, including the `_headers` entry the `@dfinity/static-site` recipe needs — load the **`internet-identity`** skill.
+
+Caffeine apps are the exception: Caffeine owns their address, so it is not the app's to derive from. The console withholds the canister-address row for them.
+
 ### Version metadata (recommended)
 
 Embed build provenance into each canister's wasm so tooling and the console can show what version is running (console support is rolling out; the metadata is already readable — see the verify note below). Add this **by default on every deploy** — do not wait for the user to ask. All official recipes (motoko, rust, static-site, asset-canister, prebuilt) accept a `metadata` list under the recipe `configuration`; each entry is baked into the wasm as a custom section. Values are interpolated into a shell command at build time, so `$(…)` command substitution works. (Verified by live builds against `@dfinity/motoko` v4.1.0 and v5.0.0 on icp-cli 1.0.2.)
@@ -362,6 +378,7 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 15. **Expecting the delegation handoff to fix a missing network.** The handoff moves signing authority, not connectivity — `icp deploy` still needs the network from the shell that runs it. If the CLI shell has no network at all (a sandboxed device bridge: DNS blocked, HTTPS fails), no `icp` network command can run there, link or deploy. Do not offer to "do the rest" from that shell and do not tunnel — hand the user one script for their real terminal (see "No-network CLI host" in Step 1.0), where the normal link flow works because terminal and browser share a loopback.
 16. **Build timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a build time (`$(date)`) changes every build even with identical source, breaking reproducibility and changing the module hash on every deploy. The deterministic alternative is the last commit's date, `service:git:updated_at` = `$(git log -1 --format=%cI)` — a property of the source tree, not the build. The deploy time itself comes from the canister history recorded by the network, never from metadata.
 17. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
+18. **Letting an engine app collect sign-ins before pinning a derivation origin.** Internet Identity principals are per-origin, so adding a custom domain later turns every existing user into a stranger at the new address — and the fix cannot be applied retroactively without orphaning the accounts already made under the old origin. On the first deploy of any app that uses II, set `derivationOrigin` to the main canister's address (`https://<main-canister-id>.icp.net` — the same URL as `__META_BASE_URL`), even when that is currently the app's only origin. See the `internet-identity` skill for the `.well-known/ii-alternative-origins` half.
 
 ## Related Skills
 

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -222,11 +222,15 @@ Icon specifics (the console builds the icon as `__META_BASE_URL` + `__META_ICON_
 
 Internet Identity derives a principal **per origin**. An app reached at both its canister address and a custom domain signs the same person in as two different users.
 
-The engine console names the app's **canister address** as the origin to derive from — it cannot be renamed or removed, so it survives adding, changing, or dropping a custom domain. It is the URL of the canister you marked `__META_MAIN_CANISTER: "true"` — the same value you set as `__META_BASE_URL`:
+The engine console names the app's **canister address** as the origin to derive from. It cannot be renamed or removed, so it survives adding, changing, or dropping a custom domain. It is the address of the canister that **serves your frontend** (the asset/static-site canister the browser loads the app from), built from that canister's id:
 
 ```
-https://<main-canister-id>.icp.net
+https://<frontend-canister-id>.icp.net
 ```
+
+That is usually the canister you marked `__META_MAIN_CANISTER: "true"`, but that flag is a console display setting, not a guarantee. If you marked a backend canister, still derive from the frontend canister. A backend canister cannot be a derivation origin: the browser is never on it, and it cannot serve the `.well-known/ii-alternative-origins` file Internet Identity fetches from that origin to validate the claim.
+
+Build the value from the canister id, **not** from `__META_BASE_URL`. The two match only while `__META_BASE_URL` still points at the canister address. Pointing it at a custom domain is normal and supported (see the icon notes above), and the two then differ. A custom domain is the one value that must never become the derivation origin.
 
 **Do this before the app has users, not after.** A domain that has already collected sign-ins cannot be repointed at a derivation origin without orphaning every account created under it. If the app might ever get a custom domain, set `derivationOrigin` on the first deploy even while the canister address is the only origin — it costs nothing then and cannot be applied retroactively without losing accounts.
 
@@ -378,7 +382,7 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 15. **Expecting the delegation handoff to fix a missing network.** The handoff moves signing authority, not connectivity — `icp deploy` still needs the network from the shell that runs it. If the CLI shell has no network at all (a sandboxed device bridge: DNS blocked, HTTPS fails), no `icp` network command can run there, link or deploy. Do not offer to "do the rest" from that shell and do not tunnel — hand the user one script for their real terminal (see "No-network CLI host" in Step 1.0), where the normal link flow works because terminal and browser share a loopback.
 16. **Build timestamps in wasm metadata.** Metadata is baked into the wasm and must be deterministic — a build time (`$(date)`) changes every build even with identical source, breaking reproducibility and changing the module hash on every deploy. The deterministic alternative is the last commit's date, `service:git:updated_at` = `$(git log -1 --format=%cI)` — a property of the source tree, not the build. The deploy time itself comes from the canister history recorded by the network, never from metadata.
 17. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
-18. **Letting an engine app collect sign-ins before pinning a derivation origin.** Internet Identity principals are per-origin, so adding a custom domain later turns every existing user into a stranger at the new address — and the fix cannot be applied retroactively without orphaning the accounts already made under the old origin. On the first deploy of any app that uses II, set `derivationOrigin` to the main canister's address (`https://<main-canister-id>.icp.net` — the same URL as `__META_BASE_URL`), even when that is currently the app's only origin. See the `internet-identity` skill for the `.well-known/ii-alternative-origins` half.
+18. **Letting an engine app collect sign-ins before pinning a derivation origin.** Internet Identity principals are per-origin, so adding a custom domain later turns every existing user into a stranger at the new address — and the fix cannot be applied retroactively without orphaning the accounts already made under the old origin. On the first deploy of any app that uses II, set `derivationOrigin` to the address of the canister that serves the frontend, built from its canister id (`https://<frontend-canister-id>.icp.net`), even when that is currently the app's only origin. Do **not** copy `__META_BASE_URL`: it is allowed to point at a custom domain, and a custom domain is exactly what must not become the derivation origin. See the `internet-identity` skill for the `.well-known/ii-alternative-origins` half.
 
 ## Related Skills
 


### PR DESCRIPTION
# Motivation

The engine console now shows an app's canister address and names it as the origin an Internet Identity app should derive from (dfinity/control-panel#3394, dfinity/control-panel#3398). The console can only tell the user — the canisters are the user's to write, so the agent deploying them is the one that has to act. And it cannot be fixed later: a domain that has already collected sign-ins cannot be repointed at a derivation origin without orphaning every account made under it.

# Changes

- Added a subsection to Step 2 saying to pin the derivation origin on the first deploy, before the app has users.
- Pointed at the canister that **serves the frontend** as the one whose address to use, built from its canister id.
- Called out that `__META_BASE_URL` is not the answer. It is allowed to hold a custom domain, and a custom domain is the one value that must never become the derivation origin.
- Demoted `__META_MAIN_CANISTER` to the usual case rather than the rule. It is a console display flag and does not promise the canister serves HTTP.
- Noted the Caffeine exception: Caffeine owns those apps' addresses, so the address is not the app's to derive from.
- Added Pitfall 18 and one eval case. Left the mechanics in `internet-identity` and linked to it.

<details>
<summary>Eval 17 — Adversarial: II derivation origin when __META_BASE_URL is a custom domain (WITH 3/3 | WITHOUT 1/3)</summary>

```
━━━ Adversarial: II derivation origin when __META_BASE_URL is a custom domain ━━━

  WITH skill: 3/3 passed
    ✅ Gives the frontend canister address https://abcde-aaaaa-aaaaa-aaaaa-cai.icp.net as the derivation origin
    ✅ Explicitly does NOT use the custom domain https://app.example.com as the derivation origin, even though __META_BASE_URL is set to it
    ✅ Says to set it on the first deploy, before the app has users, because it cannot be applied retroactively without orphaning existing accounts

  WITHOUT skill: 1/3 passed
    ❌ Gives the frontend canister address https://abcde-aaaaa-aaaaa-aaaaa-cai.icp.net as the derivation origin
       → The output gives https://abcde-aaaaa-aaaaa-aaaaa-cai.icp0.io instead of the expected icp.net domain.
    ✅ Explicitly does NOT use the custom domain https://app.example.com as the derivation origin, even though __META_BASE_URL is set to it
    ❌ Says to set it on the first deploy, before the app has users, because it cannot be applied retroactively without orphaning existing accounts
       → The output only warns that login fails if the alternative-origins file is missing, but never states that derivationOrigin must be set before any users exist or that changing it later orphans existing accounts.
```

The case does **not** isolate the `__META_BASE_URL` correction. I ran it against the pre-fix text and that scores 3/3 too, because the rest of the section says the canister address "survives adding, changing, or dropping a custom domain", so an agent reads past the bad clause instead of following it literally. Treat this as a regression guard for the corrected guidance, not as evidence for the correction. The correction stands on the text having been self-contradictory.

I dropped a fourth behavior I had drafted ("lists the custom domain as an alternative origin") because it tests the `.well-known` mechanics this skill deliberately delegates to `internet-identity`.

</details>

---

Prev. #339
