### PR TITLE
fix(icp-cli): correct @icp-sdk/bindgen CLI flags in binding-generation reference

### DIFF
--- a/skills/icp-cli/references/binding-generation.md
+++ b/skills/icp-cli/references/binding-generation.md
@@ -61,7 +61,7 @@ export const backend = createActor(
 
 Use the `@icp-sdk/bindgen` CLI to generate bindings manually:
 ```bash
-npx @icp-sdk/bindgen --did ../backend/backend.did --out ./src/bindings
+npx @icp-sdk/bindgen --did-file ../backend/backend.did --out-dir ./src/bindings
 ```
 
 ## `opt T` is `T | null` in the wrapper, not `[] | [T]`


### PR DESCRIPTION
`skills/icp-cli/references/binding-generation.md` documents the non-Vite CLI as `npx @icp-sdk/bindgen --did <path> --out <dir>`, but the real flags (verified via `npx @icp-sdk/bindgen --help`, @icp-sdk/bindgen@0.3.0) are `--did-file` / `--out-dir`. An agent copying the documented command fails immediately. The Vite-plugin config (`didFile`/`outDir`) in the same doc was already correct; only the CLI line is fixed.

Draft: surfaced while building on the IC; batching with related skill-doc fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)