### PR TITLE
chore(writing-motoko): sync caffeinelabs/skills 02e5316 → 6173cbc (null coalesce `??`, break/continue)

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -10,9 +10,9 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (this repo has no releases/tags). Watch for changes to the skill folder between the pinned commit and `main`; the per-skill `version:` frontmatter field is a secondary signal.
-- **Commit:** 02e531673bad43eaff75f4222bee56bf85e381db
-- **Upstream version:** 0.1.3 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-06
+- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
+- **Upstream version:** 0.1.5 (skill frontmatter `version:`)
+- **Last synced:** 2026-08-12
 - **Upstream files:**
   - `skills/writing-motoko/SKILL.md`
   - `skills/writing-motoko/api-reference.md → references/api-reference.md`
@@ -31,9 +31,9 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (no releases/tags). Same as `writing-motoko`.
-- **Commit:** 02e531673bad43eaff75f4222bee56bf85e381db
+- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
 - **Upstream version:** 0.2.2 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-06
+- **Last synced:** 2026-08-12
 - **Upstream files:**
   - `skills/migrating-motoko-actors/SKILL.md`
   - `skills/migrating-motoko-actors/examples.md → references/examples.md`
@@ -48,9 +48,9 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (no releases/tags). Same as `writing-motoko`.
-- **Commit:** 02e531673bad43eaff75f4222bee56bf85e381db
+- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
 - **Upstream version:** 0.1.3 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-06
+- **Last synced:** 2026-08-12
 - **Upstream file:** `skills/troubleshooting-motoko-migrations/SKILL.md`
 - **icskills-owned sections (do not overwrite from upstream):**
   - **Frontmatter (entire block):** same transform as the other two. Body is otherwise 1:1 with upstream (the `## Related skills` heading is kept as-is).

--- a/evaluations/writing-motoko.json
+++ b/evaluations/writing-motoko.json
@@ -179,6 +179,24 @@
         "Does NOT include `.mo` extension: NOT `../types.mo`",
         "Does NOT use the path from main.mo's perspective: NOT `import Types \"types\"`"
       ]
+    },
+    {
+      "name": "Null coalesce for unwrap-or-trap",
+      "prompt": "In Motoko with mo:core, write a single statement binding `let user` by unwrapping `users.find(func(u : User) : Bool { u.id == caller })`, trapping with Runtime.trap(\"User not found\") when the option is null. Just the statement, no surrounding function.",
+      "expected_behaviors": [
+        "Uses the `??` null-coalescing operator (e.g. `... ?? Runtime.trap(\"User not found\")`)",
+        "Does NOT use a two-arm `switch` with `case (?u)` / `case (null)` merely to unwrap the option",
+        "Traps via `Runtime.trap` on the null case"
+      ]
+    },
+    {
+      "name": "break and continue in loops",
+      "prompt": "In Motoko (mo:core, moc 1.11+), write a `for` loop over `items.values()` that skips items whose `item.archived` is true and stops at the first item whose `id` equals `targetId`, setting `result := ?item` before stopping. Just the loop.",
+      "expected_behaviors": [
+        "Uses `continue` to skip archived items",
+        "Uses a plain `break` to exit the loop",
+        "Does NOT claim `break`/`continue` are unsupported, and does NOT require a labeled loop (`label ... break search`) or a helper function with early return"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/writing-motoko/SKILL.md
+++ b/skills/writing-motoko/SKILL.md
@@ -31,6 +31,8 @@ Motoko is an under-represented language for the Internet Computer Protocol, so y
 
 - `mo:core` library version 2.5.0+ (compiler `moc` 1.11.2+)
 - Contextual dot notation -- `list.add(item)`, `map.get(key)`
+- Null coalesce `??` for unwrap-or-default and unwrap-or-trap (`opt ?? default`, `opt ?? Runtime.trap(...)`) -- prefer over a two-arm `switch` on `?T` (requires `moc >= 1.7.0`)
+- Plain `break` / `continue` to exit or skip a loop iteration -- they work inside `for`, `while`, and `loop` just like in other languages
 - Enhanced orthogonal persistence (state persists without `stable` keyword)
 - Principled Motoko Architecture -- `types.mo` (types), `lib/` (domain logic), `mixins/` (API endpoints), `main.mo` (composition root, NO public methods)
 - **API reference for uncertain APIs**: Use [api-reference.md](references/api-reference.md) to verify exact method signatures when you are about to use an unfamiliar `mo:core` API or when a compile diagnostic points at an API mismatch. Do NOT guess API shapes — a targeted lookup of a symbol you are unsure about is always worth the step; skipping it to save steps ships hallucinated APIs and costs far more in compile repair.
@@ -172,6 +174,43 @@ Pass the same binding to each mixin. Never build a new record at the `include` �
 ```motoko
 include GoogleApi({ var connection = google.connection });   // WRONG: NEVER DO THIS!
 ```
+
+### Null Coalesce (`??`)
+
+Prefer `??` over a two-arm `switch` that only unwraps an option or supplies a default / trap. Requires `moc >= 1.7.0`.
+
+```motoko
+// Default when absent
+let name = optName ?? "anonymous";
+
+// Fail-fast unwrap — null means a bug / missing invariant
+let user = users.find(func(u : User) : Bool { u.id == caller })
+  ?? Runtime.trap("User not found");
+
+// Nested options — chain instead of nested switches
+let start = event.start.dateTime ?? event.start.date ?? "";
+
+// RHS is lazy; may be a block. Bare record literals need extra braces/parens:
+let n = opt ?? { let x = 1; x };
+let rec = opt ?? ({ x = 0 });
+```
+
+**Use `switch` instead** when the `?v` arm transforms the value, runs side effects, or you are matching variants / multiple cases — `??` only unwraps or substitutes.
+
+```motoko
+// Keep switch: Some arm transforms / branches on the inner value
+switch (users.get(caller)) {
+  case (?u) { u.isAdmin };
+  case null { false };
+};
+
+switch (result) {
+  case (#ok value) { value };
+  case (#err e) { Runtime.trap(e) };
+};
+```
+
+See [references/control-flow.md](references/control-flow.md).
 
 ### Implicit Parameters
 
@@ -474,18 +513,29 @@ Avoid `Nat` subtraction unless the compiler can prove the result is non-negative
 
 ## Option Handling
 
+**Prefer `??` for unwrap-or-default and unwrap-or-trap.** Do not write a nested `switch` solely to peel `?T`.
+
 ```motoko
 // Unwrap with trap when null means something is wrong
-let user = switch (users.find(func(u : User) : Bool { u.id == caller })) {
-  case (?u) { u };
-  case (null) { Runtime.trap("User not found") };
-};
+let user = users.find(func(u : User) : Bool { u.id == caller })
+  ?? Runtime.trap("User not found");
+
+// Default when absence is fine
+let label = optLabel ?? "(untitled)";
 
 // Only return ?T when absence is a normal, expected outcome
 public query func findUserByName(name : Text) : async ?User {
   users.find(func(u : User) : Bool { u.name == name });
 };
 
+// Keep switch when the Some arm maps / mutates / has side effects
+switch (todos.find(func(todo : Types.Todo) : Bool { todo.id == targetId })) {
+  case (?todo) {
+    todo.completed := not todo.completed;
+    ?toView(todo);
+  };
+  case null { null };
+};
 ```
 
 ## Common Patterns
@@ -628,7 +678,7 @@ Attaching cycles to an inter-canister call (`await (with cycles = ...) <call>`) 
 
 **Basic Types:** `Nat` `Int` `Text` `Bool` `Principal` `?T` `[T]` `[var T]` `Blob` `Float` — `Time.now()` returns `Int` (nanoseconds)
 
-**Common Operations:** `debug_show(value)` → Text | `assert condition` | `# "text"` concatenation | `label name while` for break/continue
+**Common Operations:** `debug_show(value)` → Text | `assert condition` | `# "text"` concatenation | `break` / `continue` inside `for`, `while`, `loop`
 
 | Structure | Use Case         | Key Operations     | Complexity  |
 | --------- | ---------------- | ------------------ | ----------- |
@@ -644,7 +694,7 @@ Attaching cycles to an inter-canister call (`await (with cycles = ...) <call>`) 
 1. Always `mo:core`, never `mo:base`
 2. No `stable` keyword — enhanced orthogonal persistence handles state
 3. Dot notation for all `self`-parameter functions
-4. Unwrap with `switch` + `Runtime.trap()` on null; `?T` only when absence is expected
+4. Unwrap with `??` (`opt ?? Runtime.trap(...)` or `opt ?? default`); reserve `switch` for transforms/side effects/variants; `?T` only when absence is expected
 5. types.mo / lib/ / mixins/ / main.mo structure
 6. Mixins receive only needed state slices
 7. Queries for read-only, updates for state changes
@@ -654,7 +704,7 @@ Attaching cycles to an inter-canister call (`await (with cycles = ...) <call>`) 
 
 ## Additional References
 
-- **Control flow**: [references/control-flow.md](references/control-flow.md) — switch statements, for loops
+- **Control flow**: [references/control-flow.md](references/control-flow.md) — `??`, switch statements, loops, `break` / `continue`
 - **Type conversions**: [references/type-conversions.md](references/type-conversions.md) — Nat/Int size conversions
 - **Actor migrations**: Load `migrating-motoko-actors` when upgrading canisters or changing actor state shape
 - **Migration failures**: Load `troubleshooting-motoko-migrations` for unexplained compatibility diagnostics, frozen migration files, or converted legacy projects

--- a/skills/writing-motoko/references/control-flow.md
+++ b/skills/writing-motoko/references/control-flow.md
@@ -1,16 +1,37 @@
 # Control Flow
 
-Reference for Motoko control flow patterns. Load when you need switch statement or loop syntax.
+Reference for Motoko control flow patterns. Load when you need `??`, switch, or loop syntax.
+
+## Null Coalesce (`??`) — prefer this for `?T`
+
+`e1 ?? e2` unwraps `e1` when it is `?v`, otherwise evaluates `e2` (lazily). Prefer it over a two-arm `switch` that only unwraps or supplies a default.
+
+Requires `moc >= 1.7.0`.
+
+```motoko
+// Default when absent
+let name = optName ?? "anonymous";
+
+// Trap when null means a bug / invariant break
+let value = map.get(key) ?? Runtime.trap("Key not found");
+
+// Nested options — chain instead of nested switches
+let start = event.start.dateTime ?? event.start.date ?? "";
+
+// RHS may be a block (parsed as a block, not a record)
+let n = opt ?? { let x = 1; x };
+
+// Bare record literal on the RHS needs extra braces or parens
+let rec = opt ?? ({ x = 0 });
+```
+
+Do **not** use `??` when the `?v` arm transforms the value, runs side effects, or matches variants — keep `switch` for those.
 
 ## Switch Statements
 
-```motoko
-// Option unwrapping — trap on unexpected null
-let value = switch (map.get(key)) {
-  case (?v) { v };
-  case (null) { Runtime.trap("Key not found") };
-};
+Use `switch` for variants, multi-way matches, and option arms that are not plain unwrap/default:
 
+```motoko
 // Variant matching
 type Status = { #active; #inactive; #pending : Text };
 switch (status) {
@@ -26,6 +47,11 @@ switch (statusCode) {
   case _ { "Unknown" };
 };
 
+// Option with a transform or side effect on the Some arm — keep switch
+switch (users.get(caller)) {
+  case (?u) { u.isAdmin };
+  case null { false };
+};
 ```
 
 ## For Loops
@@ -49,23 +75,25 @@ for (score in scores.values()) {
 
 ```
 
-## Labeled Loops
+## Break and Continue
 
-Motoko does not support `break` as a keyword. Use labeled loops for early exit:
+`break` and `continue` work as in most other languages: `break` leaves the enclosing loop, `continue` skips to its next iteration. Both are available in `for`, `while`, and `loop`:
 
 ```motoko
-label search while (true) {
-  switch (iter.next()) {
-    case (?item) {
-      if (item.id == targetId) {
-        result := ?item;
-        break search;
-      };
-    };
-    case null { break search };
+for (item in items.values()) {
+  if (item.archived) { continue };
+  if (item.id == targetId) {
+    result := ?item;
+    break;
   };
 };
 
+while (true) {
+  switch (iter.next()) {
+    case (?item) { total += item.score };
+    case null { break };
+  };
+};
 ```
 
-Alternatively, refactor to a helper function with early `return` instead of using labeled loops.
+Alternatively, refactor to a helper function with early `return` when that reads better than a loop with an early exit.

--- a/skills/writing-motoko/references/examples.md
+++ b/skills/writing-motoko/references/examples.md
@@ -254,19 +254,15 @@ mixin (
 ) {
 
   public shared ({ caller }) func createPost(title : Text) : async Nat {
-    let maybeUser = users.find(func(u) { u.id == caller });
+    let author = users.find(func(u) { u.id == caller })
+      ?? Runtime.trap("User not registered");
 
-    switch (maybeUser) {
-      case (null) { Runtime.trap("User not registered") };
-      case (?author) {
-        let pid = state.nextPostId;
-        state.nextPostId += 1;
+    let pid = state.nextPostId;
+    state.nextPostId += 1;
 
-        let newPost = PostLib.new(pid, author, title);
-        posts.add(newPost);
-        pid;
-      };
-    };
+    let newPost = PostLib.new(pid, author, title);
+    posts.add(newPost);
+    pid;
   };
 
   public shared ({ caller }) func publishPost(postId : Nat) : async Bool {


### PR DESCRIPTION
Closes #349

Syncs `writing-motoko` from `caffeinelabs/skills` `02e5316` → `6173cbc` (upstream `version:` 0.1.3 → 0.1.5). Only `writing-motoko` changed content upstream; `migrating-motoko-actors` and `troubleshooting-motoko-migrations` share the pinned commit and get a pin bump only.

## What upstream added

- **Null coalesce `??`** for unwrap-or-default / unwrap-or-trap (`opt ?? default`, `opt ?? Runtime.trap(...)`), preferred over a two-arm `switch` that only peels `?T`. Requires `moc >= 1.7.0`.
- **Plain `break` / `continue`** now documented as working inside `for` / `while` / `loop` — replacing the old (incorrect) claim that `break` is unsupported and requires labeled loops or a helper with early `return`.

## Files changed

- **`skills/writing-motoko/SKILL.md`** — two new "ALWAYS use" bullets, new **Null Coalesce (`??`)** section, rewritten **Option Handling**, updated Common Operations line, best-practice #4, and the control-flow Additional-References link.
- **`skills/writing-motoko/references/control-flow.md`** — restructured: `??` first, `switch` narrowed to variants/transforms, "Labeled Loops" replaced by **Break and Continue**.
- **`skills/writing-motoko/references/examples.md`** — `createPost` uses `?? Runtime.trap(...)`.
- **`.claude/upstream.md`** — all three `caffeinelabs/skills` entries pinned to `6173cbc`, `Last synced` → 2026-08-12, `writing-motoko` upstream version → 0.1.5.
- **`evaluations/writing-motoko.json`** — +2 cases for the new behaviors.

## icskills-owned sections

Preserved per `.claude/upstream.md`: frontmatter (our schema, tuned `description`), the `mops-cli` cross-ref rewrite, `## Additional References` rename + `mops tooling` bullet, and `references/` paths. No owned section is now covered by upstream, so none were dropped. `compatibility` unchanged — our floor `moc >= 1.11.2` already exceeds the `??` requirement of 1.7.0.

## Compiler verification

Validated the two new behaviors against `moc` directly (not just trusting the newer prose):

| Test | moc 1.11.2 | moc 1.6.0 (<1.7) |
|------|-----------|------------------|
| plain `break` / `continue` in a `for` loop | ✅ clean | ✅ clean |
| `opt ?? 0` | ✅ clean | ❌ `M0001` syntax error |

Confirms break/continue work and the `?? requires moc >= 1.7.0` note is accurate.

## Known upstream defect (not patched locally)

Upstream added the working break/continue guidance but left a now-contradictory row in the Common Compile Error Patterns table:

```
| `unexpected token 'break'` | `break` reserved | Use helper function with early return |
```

Compiler-verified: plain `break` in a loop compiles fine; `unexpected token 'break'` only occurs when `break` is used as an **identifier**, whose correct fix is "rename the identifier" (not a helper). Our file matches upstream verbatim; per repo policy this is flagged upstream rather than diverged locally. Upstream issue: caffeinelabs/skills (linked once filed).

## Evals

Added 2 cases (`??` unwrap-or-trap; `break`/`continue` in loops), each run with baseline.

<details>
<summary>Eval results (with-skill vs baseline)</summary>

```
Null coalesce for unwrap-or-trap:  WITH 3/3 | WITHOUT 1/3
  WITHOUT: falls back to a two-arm switch to unwrap the option

break and continue in loops:       WITH 3/3 | WITHOUT 1/3
  WITHOUT: wraps the loop in `label done for (...)` and uses `break done` / `continue done`
```

`npm run validate`: all 27 skills pass (warnings only).
</details>