### PR TITLE
fix(https-outcalls): scope cycle-cost guidance to Application subnets; normalize cross-reference sections

### DIFF
--- a/evaluations/https-outcalls.json
+++ b/evaluations/https-outcalls.json
@@ -1,6 +1,6 @@
 {
   "skill": "https-outcalls",
-  "description": "Evaluation cases for the https-outcalls skill. Tests whether agents use the correct 2MB response limit (2,000,000 bytes per the interface spec, not 2^21) and the correct cycle cost for omitting max_response_bytes on a 13-node subnet.",
+  "description": "Evaluation cases for the https-outcalls skill. Tests whether agents use the correct 2MB response limit (2,000,000 bytes per the interface spec, not 2^21), the correct cycle cost for omitting max_response_bytes on a 13-node subnet, and that the Application-subnet cost formula does not apply on a cloud engine.",
   "output_evals": [
     {
       "name": "2MB limit is 2,000,000 bytes and the default-size cost",
@@ -9,6 +9,15 @@
         "States the maximum as 2,000,000 bytes (decimal), NOT 2_097_152 / 2^21 / 2 MiB",
         "Gives the omitted-max_response_bytes cost as roughly 20.8-20.9 billion cycles",
         "Does NOT state the cost as ~21.5 billion or ~21.86 billion cycles"
+      ]
+    },
+    {
+      "name": "Adversarial: outcall cycle cost on a cloud engine",
+      "prompt": "My canister runs on a cloud engine (a CloudEngine subnet) and makes an HTTPS outcall with the standard Call.httpRequest wrapper. Roughly how many cycles should I budget for this outcall, and do I need to attach any? Answer briefly.",
+      "expected_behaviors": [
+        "States the cost is 0 on a cloud engine, not the ~20.8 billion Application-subnet figure",
+        "Says no cycles need to be attached and the standard wrapper already handles this correctly",
+        "Does NOT instruct topping up the canister with cycles or attaching a hardcoded non-zero fee"
       ]
     }
   ],

--- a/skills/cloud-engine-canisters/SKILL.md
+++ b/skills/cloud-engine-canisters/SKILL.md
@@ -172,10 +172,8 @@ For the management-canister key methods (`sign_with_ecdsa`, `ecdsa_public_key`, 
 8. **Topping up the proxy without first asking what it was relaying.** On `ProxyError::InsufficientCycles`, check the call type before treating it as a funding problem. **An HTTPS outcall does not belong on the proxy at all** (Rule 3, pitfall 4): move it onto your own canister, where it is free, rather than buying budget for work that should cost nothing — raising the balance only delays the same stall. A drained balance is a genuine funding problem only for the proxy's real jobs (XRC, threshold signing, vetKD): top it up, or enable auto top-up, on the console's Proxy canisters page. Deploying and funding the proxy is a console action, not an `icp` command.
 9. **Expecting a direct-call key through the proxy.** Threshold-key derivation via the proxy is caller-isolated, so the derived key/address is not the same as a direct management-canister call. Fetch the public key and sign through the proxy consistently; do not mix direct and proxied key calls for the same identity.
 
-## Related Skills
+## Additional References
 
-If a referenced skill is not already available, install it the same way this one was installed — `npx skills add dfinity/icskills --skill <name>` — or read it at `https://skills.internetcomputer.org/skills/<name>/`.
-
-- **deploy-to-cloud-engine** — getting the app onto the engine: CLI identity linking, subnet-targeted deploy, console app metadata.
-- **https-outcalls** — everything about outcalls that is not engine-specific: transform functions, `max_response_bytes`, idempotency, debugging consensus failures.
-- **multi-canister** — inter-canister call design, bounded vs unbounded wait semantics, and `SYS_UNKNOWN` handling.
+- Load `deploy-to-cloud-engine` for getting the app onto the engine: CLI identity linking, subnet-targeted deploy, console app metadata.
+- Load `https-outcalls` for everything about outcalls that is not engine-specific: transform functions, `max_response_bytes`, idempotency, debugging consensus failures.
+- Load `multi-canister` for inter-canister call design, bounded vs unbounded wait semantics, and `SYS_UNKNOWN` handling.

--- a/skills/deploy-to-cloud-engine/SKILL.md
+++ b/skills/deploy-to-cloud-engine/SKILL.md
@@ -318,10 +318,8 @@ A cloud engine runs on a **`CloudEngine` subnet** with protocol-level call rules
 13. **Git metadata substitutions in a non-git project.** Outside a git repository, `$(git rev-parse HEAD)` does not fail the build — it silently bakes garbage: `service:git:sha` becomes the literal `+dirty` and `service:git:origin` comes out empty. Check for a git repo first (`git rev-parse HEAD` succeeds); if there is none, set only `service:version` with an explicit value (or `git init` and commit before deploying, if version control is wanted anyway).
 14. **Letting an engine app collect sign-ins before pinning a derivation origin.** Internet Identity principals are per-origin, so adding a custom domain later turns every existing user into a stranger at the new address — and the fix cannot be applied retroactively without orphaning the accounts already made under the old origin. On the first deploy of any app that uses II, set `derivationOrigin` to the address of the canister that serves the frontend, built from its canister id (`https://<frontend-canister-id>.icp.net`), even when that is currently the app's only origin. Do **not** copy `__META_BASE_URL`: it is allowed to point at a custom domain, and a custom domain is exactly what must not become the derivation origin. See the `internet-identity` skill for the `.well-known/ii-alternative-origins` half.
 
-## Related Skills
+## Additional References
 
-If a referenced skill is not already available, install it the same way this one was installed — `npx skills add dfinity/icskills --skill <name>` — or read it at `https://skills.internetcomputer.org/skills/<name>/`.
-
-- **cloud-engine-canisters** — the call rules for code that runs on the engine: never attach cycles, bounded-wait cross-subnet calls, direct HTTPS outcalls, and the console proxy for cycle-bearing cross-subnet targets (XRC, threshold signing, vetKD). Load it before writing or debugging engine canister code.
-- **icp-cli** — general icp CLI usage (`icp.yaml`, recipes, environments, bindings, identities). Load it for anything beyond this cloud-engine deploy flow — in particular when the project does not build or package yet.
-- **internet-identity** — details of the Internet Identity sign-in that Step 1 triggers in the browser.
+- Load `cloud-engine-canisters` for the call rules for code that runs on the engine: never attach cycles, bounded-wait cross-subnet calls, direct HTTPS outcalls, and the console proxy for cycle-bearing cross-subnet targets (XRC, threshold signing, vetKD). Load it before writing or debugging engine canister code.
+- Load `icp-cli` for general icp CLI usage (`icp.yaml`, recipes, environments, bindings, identities). Load it for anything beyond this cloud-engine deploy flow — in particular when the project does not build or package yet.
+- Load `internet-identity` for details of the Internet Identity sign-in that Step 1 triggers in the browser.

--- a/skills/https-outcalls/SKILL.md
+++ b/skills/https-outcalls/SKILL.md
@@ -33,7 +33,7 @@ You do not deploy anything extra. The management canister is built into every su
 
 1. **Forgetting the transform function.** Without a transform, the raw HTTP response often differs between replicas (different headers, different ordering in JSON fields, timestamps). Consensus fails and the call is rejected. ALWAYS provide a transform function.
 
-2. **Not attaching cycles to the call.** HTTPS outcalls are not free. The calling canister must attach cycles to cover the cost. If you attach zero cycles, the call fails immediately. Both Motoko and Rust have wrappers that compute and attach the required cycles automatically: in Motoko, use `await Call.httpRequest(args)` from the `ic` mops package (`import Call "mo:ic/Call"`); in Rust, use `ic_cdk::management_canister::http_request` (available since ic-cdk 0.18). Under the hood, both use the `ic0.cost_http_request` system API to calculate the exact cost from `request_size` and `max_response_bytes`.
+2. **Not attaching cycles to the call.** On a normal Application subnet, HTTPS outcalls are not free — the calling canister must attach cycles to cover the cost, and attaching zero fails the call. Both Motoko and Rust have wrappers that compute and attach the required cycles automatically: in Motoko, use `await Call.httpRequest(args)` from the `ic` mops package (`import Call "mo:ic/Call"`); in Rust, use `ic_cdk::management_canister::http_request` (available since ic-cdk 0.18). Under the hood, both use the `ic0.cost_http_request` system API to calculate the exact cost from `request_size` and `max_response_bytes` — the API is cost-schedule aware, so the same wrapper attaches the correct amount on any subnet type. On a **cloud engine** (`CloudEngine` subnet), that amount is always 0 by design; do not "fix" a working outcall by attaching a hardcoded non-zero fee there — see the `cloud-engine-canisters` skill.
 
 3. **Using HTTP instead of HTTPS.** The IC only supports HTTPS outcalls. Plain HTTP URLs are rejected. The target server must have a valid TLS certificate.
 
@@ -336,6 +336,8 @@ per-request-byte term.
 
 Unused cycles are refunded to the canister, so it is safe to over-budget.
 
+This formula applies on a normal **Application subnet**. It does not apply on a **cloud engine** (`CloudEngine` subnet): there, `ic0.cost_http_request` returns 0 regardless of `request_size` or `max_response_bytes`, because engines run under a free cost schedule. Load the `cloud-engine-canisters` skill for the engine's call rules before writing or debugging outcall code that will run there.
+
 ## Deploy & Test
 
 ### Local Deployment
@@ -430,3 +432,9 @@ fn transform_normalize(args: TransformArgs) -> HttpRequestResult {
     }
 }
 ```
+
+## Related Skills
+
+If a referenced skill is not already available, install it the same way this one was installed — `npx skills add dfinity/icskills --skill <name>` — or read it at `https://skills.internetcomputer.org/skills/<name>/`.
+
+- **cloud-engine-canisters** — call rules for canisters running on a cloud engine, including why outcall cost drops to 0 there and why outcalls must never be routed through the engine's console proxy.

--- a/skills/https-outcalls/SKILL.md
+++ b/skills/https-outcalls/SKILL.md
@@ -433,8 +433,6 @@ fn transform_normalize(args: TransformArgs) -> HttpRequestResult {
 }
 ```
 
-## Related Skills
+## Additional References
 
-If a referenced skill is not already available, install it the same way this one was installed — `npx skills add dfinity/icskills --skill <name>` — or read it at `https://skills.internetcomputer.org/skills/<name>/`.
-
-- **cloud-engine-canisters** — call rules for canisters running on a cloud engine, including why outcall cost drops to 0 there and why outcalls must never be routed through the engine's console proxy.
+- Load `cloud-engine-canisters` for canisters running on a cloud engine, including why outcall cost drops to 0 there and why outcalls must never be routed through the engine's console proxy.


### PR DESCRIPTION
## What this does

**1. Cycle-cost fix (follow-up to #354).** That PR introduced `cloud-engine-canisters` but explicitly held back a related `https-outcalls` fix for its own PR — this is that fix. `https-outcalls` Pitfall 2 said "if you attach zero cycles, the call fails immediately," and the cost-estimation section gives a ~20.8B-cycle formula for the default `max_response_bytes`. Both are Application-subnet-only: on a `CloudEngine` subnet, `ic0.cost_http_request` returns 0 by design, so the same wrapper attaches nothing there. Left unscoped, an agent debugging an engine outcall could "fix" a working call by attaching a hardcoded non-zero fee — the opposite of correct.

- Reworded Pitfall 2 to scope the "attach zero fails" claim and the auto-attach behavior to Application subnets, with a cloud-engine callout.
- Added a note to the Cycle Cost Estimation section that the formula doesn't apply on a `CloudEngine` subnet.

**2. Cross-reference section normalization.** #354 introduced a `## Related Skills` heading with a repeated npx-install paragraph on `cloud-engine-canisters` and `deploy-to-cloud-engine`, diverging from this repo's established `## Additional References` convention (already used by 6 other skills, and the heading CLAUDE.md documents by name in its upstream-sync table). The install paragraph is also redundant — any agent that discovered a given skill already knows the collection-level mechanism to fetch a named sibling; repeating it per-skill adds no capability, just duplicated boilerplate. Normalized all three affected skills (`cloud-engine-canisters`, `deploy-to-cloud-engine`, `https-outcalls`) to the lean, established form: `## Additional References` with a plain `Load `X` for Y` bullet list, no install instructions.

## Evaluations

New adversarial eval case for the cycle-cost fix, run with baseline:

<details>
<summary>Raw eval output</summary>

```
━━━ Adversarial: outcall cycle cost on a cloud engine ━━━

  WITH skill: 3/3 passed
    ✅ States the cost is 0 on a cloud engine, not the ~20.8 billion Application-subnet figure
    ✅ Says no cycles need to be attached and the standard wrapper already handles this correctly
    ✅ Does NOT instruct topping up the canister with cycles or attaching a hardcoded non-zero fee

  WITHOUT skill: 0/3 passed
    ❌ States the cost is 0 on a cloud engine, not the ~20.8 billion Application-subnet figure
       → The output never mentions zero cost; instead it applies the standard subnet cost formula and suggests budgeting 20-50 billion cycles.
    ❌ Says no cycles need to be attached and the standard wrapper already handles this correctly
       → The output explicitly states 'Yes, you must attach cycles' and instructs calling Cycles.add(amount) before the call.
    ❌ Does NOT instruct topping up the canister with cycles or attaching a hardcoded non-zero fee
       → The output tells the user to attach cycles via Cycles.add and gives a hardcoded rule-of-thumb range of 20-50 billion cycles.

━━━ Summary ━━━
  Adversarial: outcall cycle cost on a cloud engine: WITH 3/3 | WITHOUT 0/3
```

</details>

The cross-reference normalization is a pure structure/heading change with no behavioral content, so no new evals were added for it.

## Checks

- `npm run validate` — 29 skills, all passed (16 pre-existing warnings, none new)