### PR TITLE
chore(writing-motoko): sync caffeinelabs/skills 6173cbc → 9274f9b

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -10,17 +10,20 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (this repo has no releases/tags). Watch for changes to the skill folder between the pinned commit and `main`; the per-skill `version:` frontmatter field is a secondary signal.
-- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
-- **Upstream version:** 0.1.5 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-12
+- **Commit:** 9274f9bb5d34db77c29304ea32ec5ad7bdc3d6fc
+- **Upstream version:** 0.1.8 (skill frontmatter `version:`)
+- **Last synced:** 2026-08-24
 - **Upstream files:**
   - `skills/writing-motoko/SKILL.md`
   - `skills/writing-motoko/api-reference.md → references/api-reference.md`
   - `skills/writing-motoko/examples.md → references/examples.md`
   - `skills/writing-motoko/references/control-flow.md → references/control-flow.md`
+  - `skills/writing-motoko/references/equality.md → references/equality.md`
+  - `skills/writing-motoko/references/project-setup.md → references/project-setup.md`
+  - `skills/writing-motoko/references/reserved-keywords.md → references/reserved-keywords.md`
   - `skills/writing-motoko/references/type-conversions.md → references/type-conversions.md`
 - **icskills-owned sections (do not overwrite from upstream):**
-  - **Frontmatter (entire block):** upstream ships `version:`, an object `compatibility:` (`toolchain.moc`/`mops.core`), and `caffeineai-subscription:`, and no `metadata:` block. We replace it with our schema: owned `description` (tuned for repo-wide trigger evals), `license: Apache-2.0`, string `compatibility` (`moc >= 1.11.2, core >= 2.5.0`), and `metadata.title`/`category`.
+  - **Frontmatter (entire block):** upstream ships `version:`, an object `compatibility:` (`toolchain.moc`/`mops.core`/`mops` CLI major), and `caffeineai-subscription:`, and no `metadata:` block. We replace it with our schema: owned `description` (tuned for repo-wide trigger evals), `license: Apache-2.0`, string `compatibility` (`moc >= 1.11.2, core >= 2.5.0, mops >= 3.0.0`), and `metadata.title`/`category`.
   - **mops docs link → `mops-cli` skill:** the body's `https://docs.mops.one/` reference is rewritten to "Load the `mops-cli` skill …". Do not restore the external link on sync.
   - **`## Additional Resources` → `## Additional References`** (section renamed), plus an extra `- **mops tooling**: Load \`mops-cli\` …` bullet not in upstream.
   - **Reference-file paths:** upstream keeps `api-reference.md`/`examples.md` at the skill root; icskills places all non-SKILL files under `references/`, so intra-skill links are rewritten to `references/…`.
@@ -31,9 +34,9 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (no releases/tags). Same as `writing-motoko`.
-- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
-- **Upstream version:** 0.2.2 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-12
+- **Commit:** 9274f9bb5d34db77c29304ea32ec5ad7bdc3d6fc
+- **Upstream version:** 0.2.2 (skill frontmatter `version:`, unchanged — no content changes in this sync)
+- **Last synced:** 2026-08-24
 - **Upstream files:**
   - `skills/migrating-motoko-actors/SKILL.md`
   - `skills/migrating-motoko-actors/examples.md → references/examples.md`
@@ -48,9 +51,9 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 
 - **Upstream:** https://github.com/caffeinelabs/skills
 - **Tracking model:** commit-based (no releases/tags). Same as `writing-motoko`.
-- **Commit:** 6173cbcecefe3d9c6a8a0f657090d93b8483875b
-- **Upstream version:** 0.1.3 (skill frontmatter `version:`)
-- **Last synced:** 2026-08-12
+- **Commit:** 9274f9bb5d34db77c29304ea32ec5ad7bdc3d6fc
+- **Upstream version:** 0.1.3 (skill frontmatter `version:`, unchanged — no content changes in this sync)
+- **Last synced:** 2026-08-24
 - **Upstream file:** `skills/troubleshooting-motoko-migrations/SKILL.md`
 - **icskills-owned sections (do not overwrite from upstream):**
   - **Frontmatter (entire block):** same transform as the other two. Body is otherwise 1:1 with upstream (the `## Related skills` heading is kept as-is).

--- a/evaluations/writing-motoko.json
+++ b/evaluations/writing-motoko.json
@@ -21,8 +21,8 @@
         "Imports Map from mo:core/Map, NOT HashMap from mo:base",
         "Uses `Map.Map<K, V>` from mo:core as the store (with `Map.empty<K, V>()` where an initializer is shown)",
         "Uses dot notation: `profiles.add(id, profile)`, `profiles.get(id)`, NOT `Map.add(profiles, Nat.compare, id, profile)`",
-        "Does NOT pass explicit compare function — comparator is inferred",
-        "Defines the profile type in the actor body OR an imported `types.mo` module — not between the imports and the actor (M0141)",
+        "Does NOT pass explicit compare function — comparator is inferred (requires importing `mo:core/Nat` for the `Nat` key type)",
+        "Defines the profile type in the actor body OR an imported `types.mo` module",
         "Does NOT use HashMap, TrieMap, or Buffer"
       ]
     },
@@ -185,6 +185,7 @@
       "prompt": "In Motoko with mo:core, write a single statement binding `let user` by unwrapping `users.find(func(u : User) : Bool { u.id == caller })`, trapping with Runtime.trap(\"User not found\") when the option is null. Just the statement, no surrounding function.",
       "expected_behaviors": [
         "Uses the `??` null-coalescing operator (e.g. `... ?? Runtime.trap(\"User not found\")`)",
+        "Rewrites the predicate to the unannotated shorthand `func u = u.id == caller` rather than keeping the prompt's annotated `func(u : User) : Bool { ... }` form",
         "Does NOT use a two-arm `switch` with `case (?u)` / `case (null)` merely to unwrap the option",
         "Traps via `Runtime.trap` on the null case"
       ]
@@ -196,6 +197,44 @@
         "Uses `continue` to skip archived items",
         "Uses a plain `break` to exit the loop",
         "Does NOT claim `break`/`continue` are unsupported, and does NOT require a labeled loop (`label ... break search`) or a helper function with early return"
+      ]
+    },
+    {
+      "name": "Inline func arguments: instantiate the call, not the lambda",
+      "prompt": "Write a Motoko expression using mo:core that maps a `[PhotoInternal]` array called `internalPhotos` to `[Photo]` (a different record type) via `.map(...)`, where the compiler reports M0098 (no best choice for type parameter) without help. Just the expression.",
+      "expected_behaviors": [
+        "Adds explicit type parameters on the **call** — `.map<PhotoInternal, Photo>(...)`",
+        "Does NOT annotate the lambda's parameter or return type instead (e.g. does NOT write `func(p : PhotoInternal) : Photo { ... }`)",
+        "Uses the unannotated shorthand lambda form (`func p = { ... }`) alongside the call-level type parameters"
+      ]
+    },
+    {
+      "name": "do ? option chaining for multiple lookups",
+      "prompt": "Write a Motoko function `nameAndCity(id : Text) : ?Text` that looks up a nickname via `nick.get(id) : ?Text` and a city via `cityOf(id) : ?Text` (assume `cityOf` exists), returning `nickname # \" of \" # city` only when BOTH succeed, or null if either is null. Just the function.",
+      "expected_behaviors": [
+        "Uses a `do ? { ... }` block with postfix `!` to unwrap both `nick.get(id)!` and `cityOf(id)!` before concatenating",
+        "Does NOT use nested `switch` statements to combine the two independent option lookups",
+        "Does NOT use `!` outside of a `do ? { ... }` block (that fails with M0064)"
+      ]
+    },
+    {
+      "name": "Prefer equal/compare over == on records with var fields",
+      "prompt": "I have `type Todo = { id : Nat; var completed : Bool }` in Motoko and I wrote `a == b` to compare two `Todo` values, but it fails to compile. Why, and how do I fix it? Just the explanation and fix, no deploy steps.",
+      "expected_behaviors": [
+        "Explains `==` is compiler-generated structural equality that only exists for **shared** types, and a `var` field takes the record out of shared (M0060)",
+        "Recommends writing an explicit `equal` function for the record instead of `==`",
+        "Does NOT suggest making the field immutable just to restore `==` as the fix (that changes the data model instead of addressing the actual ask)",
+        "Does NOT claim `==` should still work once given a type annotation"
+      ]
+    },
+    {
+      "name": "Enabling persistent actors without a managed platform",
+      "prompt": "I'm setting up a brand-new mops project myself (no hosting platform managing mops.toml for me) and my `actor { var count = 0 }` fails to compile with M0220. What moc flag fixes this project-wide, and where does it go? Just the config, no deploy steps.",
+      "expected_behaviors": [
+        "Adds `args = [\"--default-persistent-actors\"]` under `[moc]` in mops.toml",
+        "Explains this makes every actor persistent by default so `stable` is never needed",
+        "Mentions `persistent actor { ... }` as the per-actor alternative if the flag can't be set",
+        "Does NOT suggest adding a `stable` keyword to fix M0220"
       ]
     }
   ],

--- a/skills/writing-motoko/SKILL.md
+++ b/skills/writing-motoko/SKILL.md
@@ -2,7 +2,7 @@
 name: writing-motoko
 description: "Motoko language pitfalls, modern syntax, and architecture patterns for the Internet Computer. Covers persistent actors, stable types, mo:core standard library, dot notation, mixins, and common compilation errors. Use when writing Motoko canister code, fixing Motoko compiler errors, or generating Motoko actors. Do NOT use for deployment, icp.yaml, or CLI commands."
 license: Apache-2.0
-compatibility: "moc >= 1.11.2, core >= 2.5.0"
+compatibility: "moc >= 1.11.2, core >= 2.5.0, mops >= 3.0.0"
 metadata:
   title: Writing Motoko
   category: Motoko
@@ -25,7 +25,8 @@ Motoko is an under-represented language for the Internet Computer Protocol, so y
 - Manual field-by-field record copying for immutable records -- Use record spread (`{ self with ... }`). For records with `var` fields, do not use record spread; mutate the `var` field directly or rebuild the record explicitly.
 - Single-file monolithic actors -- Use the multi-file architecture: types.mo, lib/, mixins/, main.mo
 - Stable state in a `mixin` block -- a bare `let`/`var` is silently stable and traps at runtime (`IC0503`). Pass state in as a parameter and keep constants in a module
-- Any Motoko reserved keyword as a declared identifier -- Before writing, check parameter, variable, function, type, field, and label names against Motoko's reserved words. `query` and `label` are reserved and must never be identifiers. Rename a colliding domain term instead of relying on its position or inferred meaning.
+- Any Motoko reserved keyword as a declared identifier -- Before writing, check parameter, variable, function, type, field, and label names against the full list in [references/reserved-keywords.md](references/reserved-keywords.md). `query` and `label` are reserved and must never be identifiers. Rename a colliding domain term instead of relying on its position or inferred meaning.
+- Type annotations on an inline `func` passed as a **call argument** -- write `xs.filter(func x = x > 1)`, not `xs.filter(func(x : Nat) : Bool { x > 1 })`. The call supplies the types. If a generic cannot be inferred, instantiate the call (`map<In, Out>`), never the lambda. This applies only in argument position — named declarations still carry full signatures. **One exception:** keep `: async ()` on an async callback (`func() : async () { ... }`) — it is what makes the body async, and removing it fails with M0096
 
 **ALWAYS use:**
 
@@ -47,21 +48,37 @@ All configuration is in `mops.toml`. Load the `mops-cli` skill for `mops.toml` c
 
 ### Dependency management
 
-- Never hand-edit `mops.toml` or `mops.lock`; use the `mops` CLI so dependency metadata and the lockfile stay atomic.
+- Never hand-edit dependency entries in `mops.toml`, and never touch `mops.lock`; use the `mops` CLI so dependency metadata and the lockfile stay atomic. (`[toolchain]` has a CLI too: `mops toolchain use <tool> [version]`.)
+- Leave `[moc] args` alone. Compiler flags are a one-time project-setup concern, and many platforms own `mops.toml` and set them for you — do not inspect or change them while writing code. If you are setting up a project yourself, see [references/project-setup.md](references/project-setup.md).
 - `mops add <pkg>` installs and exact-pins a published package. Use `@x.y.z` for a specific version, `<url>[#ref]` for GitHub, `./path` for a local package, and `--dev` for development dependencies.
 - `mops add` accepts exactly one package name. To install several packages, chain one-package commands with `&&`; never run multiple `mops add` invocations in parallel — they race on `mops.toml` and `mops.lock`.
 - `mops update [pkg]` updates a package and rewrites its exact pin.
 - `mops sync` reconciles imports after bulk `.mo` changes by adding missing dependencies and removing unused ones.
 - `mops.lock` is rewritten only by `mops add`, `mops update`, `mops sync`, `mops install`, and related supported mops commands.
-- On `Integrity check failed` or `Mismatched number of resolved packages`, run `mops install --lock update`. Never use `--lock ignore`, and never `chmod`, remove, or text-edit `mops.lock`.
+- On a lock or integrity failure, run `mops install` — it regenerates a `mops.lock` that is missing, stale, or inconsistent with `mops.toml`. `mops verify` reports a file-hash mismatch it cannot repair; `mops cache clean` forces a verified re-download. Never `chmod`, remove, or text-edit `mops.lock`.
 
 ### Check and build
 
-- **`mops install --lock update`** — Install dependencies and reconcile `mops.lock`. The explicit `--lock update` matters when `CI` is set, where the implicit action checks a stale lock instead of updating it.
-- **`mops check --fix`** (fast — use for iteration) — Auto-fixes warnings (dot-notation, redundant type instantiation, redundant implicit arguments) and reports remaining compile errors. Exit 0 = success. Error format: `file:startLine.startCol-endLine.endCol: severity [code], message`. Iterate on this until it passes.
+- **`mops install`** — Install dependencies and reconcile `mops.lock`, regenerating it when it is missing or no longer matches `mops.toml`.
+- **`mops check --fix`** (fast — use for iteration) — Reports compile errors and auto-fixes the style warnings, where the project has them enabled (dot-notation, redundant type instantiation, redundant implicit arguments). Follow this skill's rules whether or not `--fix` enforces them. Exit 0 = success. Error format: `file:startLine.startCol-endLine.endCol: severity [code], message`. Iterate on this until it passes.
 - **`mops build`** (slow — run ONCE at the end) — Produces the compiled `.wasm` and the candid interface file `.did`. Use only as final verification after `mops check --fix` passes; never put `mops build` inside the fix loop. The `.did` file drives generated client bindings — never edit it manually.
 
 If `mops check --fix` fails: read stderr first. Do NOT call `moc` directly. Fix `.mo` source and rerun the check.
+
+### Build feedback
+
+When building through Caffeine, enable complete subprocess output with `CAFFEINE_VERBOSE=1 caffeine build`; successful subprocess warnings are otherwise hidden. Hosted Caffeine sandboxes set this environment variable globally.
+
+- **`MOPS-WASM-COMPLEXITY`**: Focus on the canister, function, severity, limit usage, primary contributors, result, and suggested correction. Refactor the implicated function according to its largest contributors. This check is advisory; PocketIC is authoritative.
+- **`MOPS-CHECK-DEPLOY-SKIPPED`**: Focus on the canister and compatibility diagnostic. The canister was not tested, so NEVER treat this as deployment success.
+- **PocketIC failure**: Focus on the canister, descriptive message, semantic error code, measured values, and suggested correction.
+  - For `CanisterInvalidWasm`, use the descriptive message to identify the exact validation failure.
+  - For `CanisterWasmMemoryLimitExceeded`, compare peak usage with the configured limit and reduce or relocate the implicated allocations.
+  - For traps or Candid failures, inspect the trap details or generated constructor interface.
+
+**RULE:** For unfamiliar deployment failures, follow the documentation URL in the diagnostic before changing code. Do not guess when the descriptive message is unclear.
+
+Caffeine may repeat failed subprocess output. Deduplicate diagnostics, fix each distinct issue, and rerun the relevant check.
 
 ## Modern Motoko Features
 
@@ -87,11 +104,15 @@ Principal.toText(caller) Nat.toText(myNat) // WRONG (M0236)
 // Chaining
 let doubled = numbers.map(func x = x * 2).filter(func x = x > 10);
 
-// Two-arg functions are NOT dot notation
+// Equality: Principal declares `equal` with a self parameter, so it is dot notation too
+a.equal(b) // PREFERRED
 Principal.equal(a, b) // OK
-a == b // also OK
 
 ```
+
+**Prefer `equal` / `compare` over `==`.** `==` is compiler-generated structural equality and exists only for **shared** types, so one `var` field takes a record out of shared and `==` stops compiling (M0060). Use `==` only for the numeric primitives that have no receiver form: `Nat`, `Int`, `Float`, and the sized int types declare `equal(x, y)` without a `self` parameter, so `myNat.equal(other)` fails with M0070 and `a == b` is the right call. Other receiver methods on those types (`myNat.toText()`) are fine.
+
+Your own records and variants get nothing derived — a record `compare` must be an explicit function, and custom variants need both `equal` and `compare` written out. See [references/equality.md](references/equality.md).
 
 ### Mixins
 
@@ -184,7 +205,7 @@ Prefer `??` over a two-arm `switch` that only unwraps an option or supplies a de
 let name = optName ?? "anonymous";
 
 // Fail-fast unwrap — null means a bug / missing invariant
-let user = users.find(func(u : User) : Bool { u.id == caller })
+let user = users.find(func u = u.id == caller)
   ?? Runtime.trap("User not found");
 
 // Nested options — chain instead of nested switches
@@ -214,23 +235,43 @@ See [references/control-flow.md](references/control-flow.md).
 
 ### Implicit Parameters
 
-Compiler infers comparison functions automatically:
+`Map` and `Set` operations take the comparison function as an **implicit** argument. `Map.empty()` itself takes no arguments — the comparator is resolved at the operations that need it (`add`, `get`, `remove`, …), not at construction.
+
+Inference works by finding a `compare` in the module imported **for the key type**. So the import is what makes it work:
 
 ```motoko
+import Map "mo:core/Map";
+import Nat "mo:core/Nat"; // this import is what supplies Nat.compare
+
 let map = Map.empty<Nat, Text>();
-map.add(5, "hello"); // Nat.compare inferred
+map.add(5, "hello"); // compare resolved from the imported Nat
+```
 
-let ages = Map.empty<Text, Nat>();
-ages.add(Text.compare, "Alice", 30); // explicit when needed
+Without `import Nat`, the same code fails — the type is known, but there is no module to take `compare` from:
 
-// Define module with compare for custom types → auto-inferred
+```text
+type error [M0230], Cannot determine implicit argument `compare` of type (Nat, Nat) -> Order
+note: Did you mean to import mo:core/Int or mo:core/Nat?
+```
+
+Do **not** pass the comparator explicitly when it can be inferred; that is M0237, which `mops check --fix` removes:
+
+```motoko
+ages.add("Alice", 30);               // CORRECT
+ages.add(Text.compare, "Alice", 30); // WRONG (M0237)
+```
+
+A custom key type works the same way — give its module a `compare` and it is inferred:
+
+```motoko
 module Point {
   public func compare(a : Point, b : Point) : Order.Order { ... };
 };
 let points = Map.empty<Point, Text>();
 points.add({ x = 1; y = 2 }, "A"); // Point.compare inferred
-
 ```
+
+Type instantiation on `empty()` follows the usual rule — needed only when the binding is unannotated. `let m : Map.Map<Nat, Text> = Map.empty();` infers it, and `Map.empty<Nat, Text>()` there would be M0223.
 
 ## Architecture Pattern
 
@@ -269,6 +310,10 @@ import Types "backend/types";
 
 **Migration files** (`migrations/*.mo`) must be self-contained — they may only import from `mo:core/...`, never from `../types` or any project module. See `migrating-motoko-actors` for the full rules.
 
+### The Actor Must Come Last
+
+Imports and `type`/`let` declarations may precede the actor. Nothing may follow it — the actor is the file's result, so a trailing declaration makes the actor a non-`()` statement and fails with M0096 (`expression of type actor {...} cannot produce expected type ()`). Prefer keeping shared types in `types.mo` regardless.
+
 ### Import Hygiene
 
 Add an import only to the file that uses the imported identifier. `Time.now()` usually belongs in a domain `lib/*.mo` implementation file, so `import Time "mo:core/Time";` belongs in that file, not `main.mo`, unless `main.mo` itself calls `Time.now()`. Every capitalized namespace call must have a matching import in the same file: if a mixin calls `TodosLib.listTodos(...)`, the file must import `TodosLib "../lib/todos"` (or use the alias it actually imported). Treat unused-import warnings as failures: remove stale `Debug`, `Time`, or helper-module imports before finishing.
@@ -287,7 +332,7 @@ public type PostInternal = { id : Nat; likedBy : Set.Set<Principal> }; // intern
 public type Post = { id : Nat; likedBy : [Principal] }; // shared
 
 public func toPublic(self : Types.PostInternal) : Types.Post {
-  { self with likedBy = Set.toArray(self.likedBy) };
+  { self with likedBy = self.likedBy.toArray() };
 };
 
 ```
@@ -335,15 +380,13 @@ When a domain helper receives a core collection, type the parameter as the concr
 Core collections (`List.List<T>`, `Map.Map<K, V>`, `Set.Set<T>`, `Queue.Queue<T>`, `Stack.Stack<T>`) have receiver helpers because their modules define self-parameter APIs. A value of type `[T]` or `[var T]` is an array snapshot, not a `List.List<T>`.
 
 - After `let snapshot = list.toArray()`, only use array operations whose exact signatures are shown here or verified in the API reference — with receiver dot notation: `snapshot.filter(pred)`, `snapshot.map(mapper)`, `snapshot.sort(comparator)`, `snapshot.concat([item])`. Do not call those as module functions such as `Array.filter<T>(snapshot, pred)` or `Array.append(snapshot, [item])`.
-- If a value is an array (`[T]`) or came from `.toArray()` / `.filter(...)`, then `.map(...)` already returns an array; do not append `.toArray()` to that array-map result. (`List.List<T>.map(...)` may still need explicit type instantiation and `.toArray()` when mapping records to another type.)
+- If a value is an array (`[T]`) or came from `.toArray()` / `.filter(...)`, then `.map(...)` already returns an array; do not append `.toArray()` to that array-map result. (`List.List<T>.map(...)` returns a `List`, so it still needs `.toArray()` when the caller expects an array.)
 - Arrays DO support predicate search: `.find(predicate) : ?T`, `.findIndex(predicate) : ?Nat`, `.any(predicate)`, and `.all(predicate)` are all in `mo:core/Array` (see the API reference). The JS spellings `.some(...)` / `.every(...)` do not exist — use `.any` / `.all`.
 - Arrays have NO `.contains(...)`. Test membership with `.indexOf(element) != null` or a predicate:
 
 ```motoko
 // Overlap between two tag arrays
-let matched = leftTags.any(func(left : Text) : Bool {
-  rightTags.any(func(right : Text) : Bool { left == right })
-});
+let matched = leftTags.any(func left = rightTags.any(func right = left == right));
 ```
 
 - Do not copy a collection just to search it: prefer `templates.find(func ...)` on the original `List.List<T>` over `templates.toArray().find(func ...)` — the intermediate array is a wasted copy.
@@ -351,11 +394,37 @@ let matched = leftTags.any(func(left : Text) : Bool {
 
 **CRUD List patterns:** Do not invent helpers on `List`. There is no `filterInPlace`, and record spread fails on records with `var` fields.
 
-When a predicate uses a block body, declare the return type as `: Bool`. Do not write `func(todo : Types.Todo) { todo.id == id }`; that block can compile as a `()`-returning callback in argument position. Use `func(todo : Types.Todo) : Bool { todo.id == id }`.
+**An inline `func` passed as a call argument takes no type annotations.** The call already fixes the parameter and result types, so annotating repeats them and lets them drift as the code changes. Use the expression form `func x = <expr>`:
+
+```motoko
+todos.find(func todo = todo.id == targetId);            // CORRECT
+todos.find(func(todo : Types.Todo) : Bool { todo.id == targetId }); // WRONG: annotated
+```
+
+This is about **argument position only**. A named declaration still carries its full signature, and a lambda bound on its own has nothing to infer from — `let f = func x = x > 1` fails with M0103 (`cannot infer type of variable`).
+
+```motoko
+public func toView(t : Types.Todo) : Types.TodoView { ... }; // annotated, as always
+```
+
+When the types are not obvious to a reader, or a generic cannot be inferred, say it **on the call** rather than on the lambda — it reads better and keeps one source of truth:
+
+```motoko
+photos.map(func p = { id = p.id; url = p.url.toText() }); // inferred — preferred
+photos.map<PhotoInternal, Photo>(func p = { ... });       // when M0098 demands it
+```
+
+Add `<In, Out>` only when the compiler actually reports M0098; adding it when inference already succeeded is M0223 (redundant type instantiation).
+
+The one exception is a callback that must return `async`. There `: async ()` is load-bearing — it is what makes the body async, and there is no unannotated form (`func() = async { ... }` does not work either). Without it the lambda infers `() -> ()` and the call fails with M0096:
+
+```motoko
+Timer.recurringTimer<system>(#seconds(3600), func() : async () { cleanup() });
+```
 
 ```motoko
 // Toggle a mutable field by finding the record and mutating the var field.
-switch (todos.find(func(todo : Types.Todo) : Bool { todo.id == targetId })) {
+switch (todos.find(func todo = todo.id == targetId)) {
   case (?todo) {
     todo.completed := not todo.completed;
     ?toView(todo);
@@ -401,7 +470,7 @@ For delete-style operations that return whether a record was removed, prefer a `
 ```motoko
 let doubled = numbers.map(func x = x * 2).filter(func x = x > 10);
 let sum = scores.filter(func s = s > 15).foldLeft(0, func(acc, s) = acc + s);
-switch (numbers.find(func(n : Nat) : Bool { n > 5 })) {
+switch (numbers.find(func n = n > 5)) {
   case (?found) { /* use */ };
   case null {};
 };
@@ -414,18 +483,18 @@ switch (numbers.find(func(n : Nat) : Bool { n > 5 })) {
 
 ```motoko
 let all = todos.toArray();
-let sorted = all.sort(func(a : Types.Todo, b : Types.Todo) : { #less; #equal; #greater } {
+let sorted = all.sort(func (a, b) =
   if (a.createdAt > b.createdAt) { #less }
   else if (a.createdAt < b.createdAt) { #greater }
   else { #equal }
-});
-sorted.map<Types.Todo, Types.TodoView>(func(todo) {
-  { id = todo.id; text = todo.text; completed = todo.completed; createdAt = todo.createdAt }
+);
+sorted.map(func todo = {
+  id = todo.id; text = todo.text; completed = todo.completed; createdAt = todo.createdAt
 });
 
 // WRONG: `.sort(...)` returns an array, so this is not a valid statement.
-all.sort(func(a, b) { Int.compare(b.createdAt, a.createdAt) });
-all.map<Types.Todo, Types.TodoView>(func(todo) { ... });
+all.sort(func (a, b) = Int.compare(b.createdAt, a.createdAt));
+all.map(func todo = { ... });
 ```
 
 ### `contains` vs `find`
@@ -435,9 +504,9 @@ all.map<Types.Todo, Types.TodoView>(func(todo) { ... });
 - `[T]` arrays have no `contains` at all — use `.indexOf(element) != null` or `.any(func x = x == element)` for membership.
 
 ```motoko
-numbers.contains(3); // implicit Nat.equal
-friends.contains(Principal.equal, p); // explicit equality
-todos.find(func(todo : Types.Todo) : Bool { todo.id == targetId }); // returns ?Todo
+numbers.contains(3); // equal inferred from the imported Nat
+friends.contains(p); // likewise from Principal — passing Principal.equal here is M0237
+todos.find(func todo = todo.id == targetId); // returns ?Todo
 // WRONG: friends.contains(func(f) { f == p })  → M0096/M0103
 
 ```
@@ -451,16 +520,43 @@ let term = searchTerm.toLower();
 textValue.toLower().contains(#text term)
 ```
 
-### Explicit Type Instantiation
+### Joining Text
 
-When `.map()` transforms to a **different** type, provide type parameters explicitly (M0098 without):
+`join` takes the **iterator as its receiver and the separator as its argument** — easy to invert. Use dot notation; the module form is an M0236 violation that `mops check --fix` rewrites for you.
 
 ```motoko
-let photos = internalPhotos.map<PhotoInternal, Photo>(
-  func(p) { { id = p.id; url = p.url; uploadedBy = p.uploadedBy.toText() } }
-);
-
+["a", "b"].values().join(", ");     // CORRECT → "a, b"
+Text.join(["a", "b"].values(), ", "); // WRONG (M0236)
 ```
+
+Note the receiver is an **iterator**, not an array: call `.values()` on an array first.
+
+### Variant Tag Arguments
+
+Always parenthesize a variant tag's argument. A tag binds only to the atom immediately after it, tighter than any operator, so an unparenthesized argument silently loses everything past the first term:
+
+```motoko
+#tag(n + 1) // CORRECT
+#tag n + 1  // WRONG: parses as (#tag n) + 1 → M0060, operator is not defined for operand types
+```
+
+### Explicit Type Instantiation
+
+Let inference work first. With unannotated lambdas the compiler resolves `.map()` to a different type on its own, so write the plain call:
+
+```motoko
+let photos = internalPhotos.map(
+  func p = { id = p.id; url = p.url; uploadedBy = p.uploadedBy.toText() }
+);
+```
+
+Add explicit type parameters **only** when the compiler reports M0098 (`no best choice for type parameter`):
+
+```motoko
+let photos = internalPhotos.map<PhotoInternal, Photo>(func p = { ... });
+```
+
+Adding them when inference already succeeded is a warning of its own — M0223, redundant type instantiation — which `mops check --fix` strips. Annotating the lambda instead of instantiating the call is always wrong.
 
 ### Function Literals as Arguments
 
@@ -517,19 +613,19 @@ Avoid `Nat` subtraction unless the compiler can prove the result is non-negative
 
 ```motoko
 // Unwrap with trap when null means something is wrong
-let user = users.find(func(u : User) : Bool { u.id == caller })
+let user = users.find(func u = u.id == caller)
   ?? Runtime.trap("User not found");
 
 // Default when absence is fine
-let label = optLabel ?? "(untitled)";
+let caption = optLabel ?? "(untitled)"; // not `label` — reserved word
 
 // Only return ?T when absence is a normal, expected outcome
 public query func findUserByName(name : Text) : async ?User {
-  users.find(func(u : User) : Bool { u.name == name });
+  users.find(func u = u.name == name);
 };
 
 // Keep switch when the Some arm maps / mutates / has side effects
-switch (todos.find(func(todo : Types.Todo) : Bool { todo.id == targetId })) {
+switch (todos.find(func todo = todo.id == targetId)) {
   case (?todo) {
     todo.completed := not todo.completed;
     ?toView(todo);
@@ -663,9 +759,18 @@ Attaching cycles to an inter-canister call (`await (with cycles = ...) <call>`) 
 | `M0255` stable signature downgrade                     | Chain or migrations config removed | Restore it — enhanced migration is one-way; load `troubleshooting-motoko-migrations` |
 | `shared function has non-shared parameter/return type` | Mutable type in API          | Return `[T]` not `List<T>`, no `var` fields |
 | `send capability required`                             | Async in non-async           | Add `<system>` capability                   |
-| `unexpected token '<name>'` at an identifier declaration | Reserved word used as an identifier | Rename the identifier consistently across its contract and callers |
-| `unexpected token 'break'`                             | `break` reserved             | Use helper function with early return       |
+| `unexpected token '<name>'` at an identifier declaration | Reserved word used as an identifier | Rename it consistently across its contract and callers; see [references/reserved-keywords.md](references/reserved-keywords.md) |
 | `unexpected token 'public'` after a function           | Missing declaration `;`      | End function declarations with `};`         |
+| `M0219` implicitly transient                           | Actor not persistent         | Write `persistent actor`; see [references/project-setup.md](references/project-setup.md) |
+| `M0220` actor should be declared `persistent`          | Actor not persistent         | Write `persistent actor`; see [references/project-setup.md](references/project-setup.md) |
+| `M0218` redundant `stable` keyword                     | `stable` under EOP           | Remove `stable` — a plain `let`/`var` is already stable |
+| `M0064` misplaced `'!'`                                | `!` outside an option block  | Wrap in `do ? { ... }`                      |
+| `M0145` `does not cover value`                         | Non-exhaustive switch        | Add the missing cases or a `case _`         |
+| `M0060` operator not defined for `{#tag : T}`          | Unparenthesized variant tag  | `#tag(x)`, never `#tag x`                   |
+| `M0060` operator not defined, on `==`                  | `==` on a record with a `var` field (not shared) | Use an `equal` function instead |
+| `M0230` cannot determine implicit argument `compare`   | Record/variant key with no findable `compare` | Add `compare` to the type's module; or `import` the module for a primitive key |
+| `M0070` expected object type, produces `Nat`           | Receiver `.equal`/`.compare` on a number | Use `==` or `Nat.equal(a, b)`   |
+| `M0096` actor cannot produce expected type `()`        | Declaration after the actor  | The actor must be the last declaration in the file |
 | `field compare does not exist` on Time                 | No Time.compare              | Use `Int.compare`                           |
 | `unexpected token ';'` in function call                | Semicolon after func literal | Remove `;` before `)`                       |
 | `unbound variable X`                                   | Missing import               | `import X "mo:core/X"`                      |
@@ -701,13 +806,17 @@ Attaching cycles to an inter-canister call (`await (with cycles = ...) <call>`) 
 8. Iterator chaining to avoid intermediate collections
 9. Record spread `{ self with ... }` for immutable records; mutate or rebuild records that contain `var` fields
 10. No inline initializers on stable actor fields — initial values come from the migration chain
+11. Inline `func` arguments carry no type annotations (except `: async ()` on async callbacks); instantiate the call instead, and only when the compiler reports M0098
 
 ## Additional References
 
-- **Control flow**: [references/control-flow.md](references/control-flow.md) — `??`, switch statements, loops, `break` / `continue`
+- **Control flow**: [references/control-flow.md](references/control-flow.md) — `??`, `do ? { ... }` option chaining, switch statements, loops, `break` / `continue`
+- **Reserved keywords**: [references/reserved-keywords.md](references/reserved-keywords.md) — full list to check identifiers against
+- **Equality & comparison**: [references/equality.md](references/equality.md) — which types support receiver `.equal`, and when `==` differs from `equal`
 - **Type conversions**: [references/type-conversions.md](references/type-conversions.md) — Nat/Int size conversions
+- **Project setup**: [references/project-setup.md](references/project-setup.md) — one-time `[moc] args` flags. Skip this if your platform manages `mops.toml`
 - **Actor migrations**: Load `migrating-motoko-actors` when upgrading canisters or changing actor state shape
 - **Migration failures**: Load `troubleshooting-motoko-migrations` for unexplained compatibility diagnostics, frozen migration files, or converted legacy projects
 - **API signatures**: [api-reference.md](references/api-reference.md) — complete function signatures
-- **Complete examples**: [references/examples.md](references/examples.md) — full working code samples
+- **Complete examples**: [examples.md](references/examples.md) — full working code samples
 - **mops tooling**: Load `mops-cli` for `mops.toml` configuration, dependency management, and `mops check`/`mops build`/toolchain setup

--- a/skills/writing-motoko/references/control-flow.md
+++ b/skills/writing-motoko/references/control-flow.md
@@ -1,6 +1,6 @@
 # Control Flow
 
-Reference for Motoko control flow patterns. Load when you need `??`, switch, or loop syntax.
+Reference for Motoko control flow patterns. Load when you need `??`, `do ?`, switch, or loop syntax.
 
 ## Null Coalesce (`??`) — prefer this for `?T`
 
@@ -26,6 +26,30 @@ let rec = opt ?? ({ x = 0 });
 ```
 
 Do **not** use `??` when the `?v` arm transforms the value, runs side effects, or matches variants — keep `switch` for those.
+
+## Option Chaining (`do ? { ... }`)
+
+Inside a `do ? { ... }` block, postfix `!` unwraps an option. If any `!` hits `null`, the **whole block** short-circuits to `null`. Use it when several lookups must all succeed and you want one combined result — `??` only handles a single option at a time.
+
+```motoko
+// Every step must succeed; any null makes cityOf return null
+func cityOf(id : Text) : ?Text {
+  do ? { users.get(id)!.city! }
+};
+
+// `!` composes with ordinary computation inside the block
+func nameAndCity(id : Text) : ?Text {
+  do ? { nick.get(id)! # " of " # cityOf(id)! }
+};
+```
+
+`!` is only legal inside `do ? { ... }`. Using it anywhere else is an error:
+
+```text
+type error [M0064], misplaced '!' (no enclosing 'do ? { ... }' expression)
+```
+
+Reach for `do ?` over nested `switch`es when unwrapping several options; reach for `??` when there is one option and a default.
 
 ## Switch Statements
 

--- a/skills/writing-motoko/references/equality.md
+++ b/skills/writing-motoko/references/equality.md
@@ -1,0 +1,92 @@
+# Equality and Comparison
+
+Load when choosing between `==`, `equal`, and `compare`, or when a `.equal(...)` call fails with M0070.
+
+## `==` vs `equal`
+
+**Default to `equal` / `compare`. Use `==` only for the primitives that have no receiver form** — `Nat`, `Int`, `Float`, and the sized int types, where `a == b` is shorter than `Nat.equal(a, b)` and needs no import.
+
+`==` is compiler-generated structural equality, and it only exists for **shared** types. That is the catch: a single `var` field takes a record out of shared, and `==` stops compiling:
+
+```motoko
+type Todo = { id : Nat; var completed : Bool };
+a == b
+// type error [M0060], operator is not defined for operand types
+```
+
+Internal state records routinely have `var` fields, so code written around `==` breaks the moment a field becomes mutable. `equal`/`compare` functions do not have that failure mode, which is why they are the default even where `==` would work today.
+
+`equal` and `compare` are also what **collections** take, as implicit arguments: `Map`, `Set`, `contains`, and the collection-level `equal`/`compare` helpers. The compiler infers them, so you rarely name them:
+
+```motoko
+let map = Map.empty<Nat, Text>(); // compare resolved at add/get, from the imported Nat
+numbers.contains(3);              // likewise Nat.equal
+```
+
+Inference finds `equal`/`compare` in the module imported for the element type, so the import is what makes it work — without `import Nat`, you get M0230. Passing the module's own function explicitly is redundant and warns:
+
+```motoko
+friends.contains(p);                  // CORRECT
+friends.contains(Principal.equal, p); // WRONG (M0237)
+```
+
+Name a function only when you want **different** behaviour from the module default — a case-insensitive match, a reversed order:
+
+```motoko
+names.contains(func (x, y) = x.toLower() == y.toLower(), q);
+```
+
+## Which types allow receiver `.equal` / `.compare`
+
+The general dot-notation rule applies: a receiver call works only when the module declares the function with a `self` parameter. `Text.equal` is `(self : Text, other : Text)`, so `a.equal(b)` resolves. `Nat.equal` is `(x : Nat, y : Nat)` — no `self`, so it does **not**.
+
+| Type | `a.equal(b)` | `a.compare(b)` | Module form |
+|---|---|---|---|
+| `Text`, `Principal`, `Bool`, `Char`, `Blob` | yes | yes | also fine |
+| `Order` | yes | **no such function** | `Order.equal(a, b)` only |
+| `Nat`, `Int`, `Float` | **no** | **no** | `Nat.equal(a, b)` |
+| `Nat8`…`Nat64`, `Int8`…`Int64` | **no** | **no** | `Nat64.equal(a, b)` |
+
+`mo:core/Order` has no `compare` in any form — `Order.compare(a, b)` is M0072 (`field compare does not exist`), not just a missing receiver.
+
+Calling the receiver form on a numeric type fails:
+
+```motoko
+myNat.equal(other)   // WRONG
+// type error [M0070], expected object type, but expression produces type Nat
+
+Nat.equal(myNat, other)  // CORRECT — or just: myNat == other
+```
+
+This is the one place where "always use dot notation" does not hold, and it is worth remembering: numeric types **do** support other receiver methods (`myNat.toText()` is correct), just not `equal` and `compare`.
+
+## Your own records, tuples, and variants
+
+Nothing is derived for them. A record or variant used as a `Map`/`Set` key needs a `compare` the compiler can find, or you get:
+
+```text
+type error [M0230], Cannot determine implicit argument `compare`
+```
+
+**Record `compare` must be an explicit function.** There is no sensible default — which field dominates, and in what direction, is a decision only you can make. Write it out and be deliberate about the tie-breaking:
+
+```motoko
+module Point {
+  public func compare(a : Point, b : Point) : Order.Order {
+    switch (Nat.compare(a.x, b.x)) {
+      case (#equal) { Nat.compare(a.y, b.y) }; // x first, then y
+      case other { other };
+    }
+  };
+};
+```
+
+Put it in the module named after the type and inference will find it, exactly as it finds `Nat.compare`.
+
+**Custom variants need both `equal` and `compare` written out.** `mo:core` types are the exception — `Result` already ships them:
+
+```motoko
+a.equal(b, Nat.equal, Text.equal); // Result.equal, sub-functions for Ok and Err
+```
+
+For a one-off equality check on an immutable record, tuple, or variant, `==` still works and is fine — the guidance above is about the functions collections need, and about not building on `==` for types whose fields may become `var`.

--- a/skills/writing-motoko/references/examples.md
+++ b/skills/writing-motoko/references/examples.md
@@ -387,8 +387,8 @@ module {
 
   public func migration(_ : OldActor) : NewActor {
     {
-      users = List.empty<User>();
-      posts = List.empty<Post>();
+      users = List.empty();
+      posts = List.empty();
       state = { var nextPostId = 0 };
     };
   };
@@ -728,7 +728,7 @@ module {
 
   public func migration(_ : OldActor) : NewActor {
     {
-      todos = List.empty<TodoItem>();
+      todos = List.empty();
       var nextId = 0;
     };
   };

--- a/skills/writing-motoko/references/project-setup.md
+++ b/skills/writing-motoko/references/project-setup.md
@@ -1,0 +1,39 @@
+# Project Setup: Compiler Flags
+
+**Read this only when you are setting up a Motoko project yourself.** These are one-time `mops.toml` settings, not something to revisit while writing code.
+
+**If your platform manages `mops.toml` for you, skip this file entirely** — do not inspect, add, or change `[moc] args`. The flags below are already set on your behalf, and editing them is not yours to do. This is the normal case for hosted platforms; it is only self-managed projects that need anything here.
+
+## Persistence
+
+Enhanced orthogonal persistence is `moc`'s default, so a top-level `let`/`var` in an actor is stable without the `stable` keyword. What is **not** default is letting a plain `actor { ... }` be persistent:
+
+```toml
+[moc]
+args = ["--default-persistent-actors"]
+```
+
+Every actor example in this skill assumes that flag. Without it a plain `actor` fails to compile, with one of two errors depending on whether it holds state:
+
+```text
+// actor { var count = 0 }
+type error [M0219], this declaration is currently implicitly transient, please declare it explicitly `transient`
+
+// actor { public func f() : async Nat { 1 } }  — no stable declaration to complain about
+type error [M0220], this actor or actor class should be declared `persistent`
+```
+
+If you cannot set the flag, write `persistent actor { ... }` instead — same semantics, declared per actor. (`persistent` is transitional; actors become persistent-by-default in a future major `moc` release.) `--default-persistent-actors` is not listed in `moc --help`, but it is supported.
+
+## Style warnings
+
+The style rules this skill enforces are compiler warnings that are **off by default**. Enabling them makes `moc` flag violations for you, and `mops check --fix` then auto-corrects all three:
+
+```toml
+[moc]
+args = ["--default-persistent-actors", "-W", "M0236,M0237,M0223"]
+```
+
+`M0236` non-dot-notation calls, `M0237` redundant explicit implicit arguments, `M0223` redundant type instantiation.
+
+Without `-W` in `[moc] args` these never fire, so `mops check --fix` has nothing to correct — the rules still hold, you just have to follow them unaided.

--- a/skills/writing-motoko/references/reserved-keywords.md
+++ b/skills/writing-motoko/references/reserved-keywords.md
@@ -1,0 +1,36 @@
+# Reserved Keywords
+
+Motoko's reserved words. **None** of these may be used as an identifier — not as a variable, parameter, function, type, field, or label name. Check a name against this list before declaring it, especially when a domain term happens to collide (`query`, `label`, `system`, `object`, `class`, `type`, and `in` are the ones that bite most often).
+
+```text
+actor        and          assert       async        await
+break        case         catch        class        composite
+continue     debug        debug_show   do           else
+false        finally      flexible     for          from_candid
+func         if           ignore       implicit     import
+in           include      label        let          loop
+mixin        module       not          null         object
+or           persistent   private      public       query
+return       shared       stable       switch       system
+throw        to_candid    transient    true         try
+type         var          while        with
+```
+
+`async*`, `await*`, and `await?` are also reserved. They cannot collide with an identifier anyway, since `*` and `?` are not identifier characters.
+
+Using a reserved word as an identifier is a parse error at the declaration:
+
+```text
+syntax error [M0001], unexpected token '<name>', expected one of token or <phrase> sequence: ...
+```
+
+Rename the colliding term rather than relying on position or inferred meaning — there is no escaping or quoting mechanism. Conventional renames: `query` → `request` / `searchTerm`, `label` → `caption` / `tag`, `type` → `kind` / `category`, `object` → `item` / `entity`, `class` → `group` / `kind`.
+
+## Not reserved
+
+These read like keywords but are ordinary identifiers in Motoko — several are Candid keywords rather than Motoko ones, which is the usual source of confusion:
+
+```text
+blob    bool    char    int     nat     opt     record  service
+struct  variant vec     enum    match   state   result  status
+```


### PR DESCRIPTION
## Summary

Syncs `writing-motoko` from upstream `caffeinelabs/skills` `6173cbc` → `9274f9b`. `migrating-motoko-actors` and `troubleshooting-motoko-migrations` share the same pinned commit but had **no content changes** this round — only their `Commit`/`Last synced` fields in `.claude/upstream.md` were bumped.

Key changes to `writing-motoko`:
- **Inline `func` arguments never carry type annotations** (`func x = expr`, not `func(x : T) : R { expr }`) — the biggest cross-cutting change, touching most code examples in the skill. Explicit generics belong on the **call** (`.map<In, Out>(...)`), only when the compiler reports M0098, never on the lambda.
- **`do ? { ... }` option chaining** — new construct for combining several independent option lookups (postfix `!`, whole block short-circuits to `null` on any `null`).
- **`Text.join`** parameter order (iterator receiver, separator argument) and **variant tag argument parenthesization** — new pitfalls.
- **Prefer `equal`/`compare` over `==`** — `==` is structural equality for **shared** types only; a `var` field breaks it (M0060). New `references/equality.md`.
- **`Map`/`Set` implicit `compare`** now explained as resolved from the **imported module for the key type** (M0230 if missing), not just "compiler infers it".
- Three new reference files: `references/equality.md`, `references/project-setup.md` (EOP flag / M0219/M0220 / style-warning flags), `references/reserved-keywords.md` (full list).
- Error table: added M0219/M0220/M0218/M0064/M0145/M0060/M0230/M0070/M0096(actor-last); **removed** the stale `unexpected token 'break'` row.
- mops v3 lockfile wording (`mops install` self-heals, `mops verify`, `mops cache clean` — mirrors the `mops-cli` v3.1.0 sync in #358).

Owned sections preserved: frontmatter (bumped `compatibility` to add `mops >= 3.0.0`), the `mops-cli` doc-link rewrite, `## Additional References` rename + `mops tooling` bullet, and `references/` path rewrites for `api-reference.md`/`examples.md`.

Closes #356

## Upstream issue cross-check (as requested)

While syncing, cross-checked every open icskills-filed issue against this upstream repo:

- **[caffeinelabs/skills#6](https://github.com/caffeinelabs/skills/issues/6)** (stale `unexpected token 'break'` row) — ✅ fully fixed (row removed). **Closed.**
- **[caffeinelabs/skills#3](https://github.com/caffeinelabs/skills/issues/3)** (dropped general Motoko content) — ✅ nearly everything landed (EOP flag/project-setup.md, M0220/M0218/M0064/M0145 rows, Text.join/variant-tag/lambda-annotation pitfalls, reserved-keywords.md, equality.md, `do ?`). Commented asking whether the one remaining item (`M0141`) is a real diagnostic worth a row, or superseded by the new M0096 "actor must be last" guidance — left open pending their answer.
- **[caffeinelabs/skills#5](https://github.com/caffeinelabs/skills/issues/5)** (copy-paste correctness) — partially fixed: the `break` self-contradiction (item 2) was already resolved; the truncated `Principal.fromActor` signature and the three-expressions-on-one-line example (items 1, 3) are still present. Commented with current status, left open.
- **[caffeinelabs/skills#4](https://github.com/caffeinelabs/skills/issues/4)** (migration model reversal) — not touched by this sync at all (confirmed `migrating-motoko-actors` had zero upstream changes). No comment needed; still fully open.
- Filed **[caffeinelabs/skills#8](https://github.com/caffeinelabs/skills/issues/8)**: the new "Build feedback" section reintroduces Caffeine-platform-specific framing (`CAFFEINE_VERBOSE`, "Hosted Caffeine sandboxes") that #1/#2 previously asked to keep out of this generic skill — referenced that precedent and asked for the same treatment. Synced the section verbatim in the meantime per our "flag upstream, don't patch locally" policy for non-owned body content.

## Evals

Updated 2 existing cases affected by the sync and added 4 new cases for the biggest new pitfalls. All run with baseline per contributing guidelines (one eval was rewritten mid-review after the first version proved not discriminating enough — see notes below).

<details>
<summary>Eval results (with-skill vs baseline)</summary>

**Actor with Map collection** (updated — dropped an M0141 reference no longer supported by the skill's content)
WITH 7/7 | WITHOUT 5/7 — baseline explicitly passes `Nat.compare` instead of relying on inferred comparator

**Null coalesce for unwrap-or-trap** (updated — now also checks the shorthand-lambda rewrite)
WITH 3/4 | WITHOUT 1/4 — baseline doesn't even use `??`

**Inline func arguments: instantiate the call, not the lambda** (new; rewritten once — the first version, a trivial `.filter` predicate, wasn't discriminating since the baseline also got it right)
WITH 3/3 | WITHOUT 1/3 — baseline annotates the lambda instead of instantiating the call

**do ? option chaining for multiple lookups** (new; rewritten once — the first version could be solved with a single `switch`, so it didn't actually require `do ?`)
WITH 3/3 | WITHOUT 2/3 — baseline uses a switch on a tuple of the two options instead of `do ?`

**Prefer equal/compare over == on records with var fields** (new)
WITH 4/4 | WITHOUT 3/4 — baseline invents nonexistent terminology ("equality type") instead of "shared type"/M0060

**Enabling persistent actors without a managed platform** (new)
WITH 3/4 | WITHOUT 1/4 — baseline hallucinates a nonexistent `[toolchain] moc = "--enhanced-orthogonal-persistence"` setting

</details>