### PR TITLE
docs(internet-identity): alternative origins cap is 100, not 10

### DIFF
--- a/evaluations/internet-identity.json
+++ b/evaluations/internet-identity.json
@@ -178,6 +178,15 @@
         "States the consequence is losing the WHOLE document, not just the logo, because the logo URL's same-origin shape is part of document validation",
         "Recommends a relative URL such as /logo.png"
       ]
+    },
+    {
+      "name": "Adversarial: maximum number of alternative origins",
+      "prompt": "One IC frontend canister, and I want about 40 white-label custom domains to all share the same Internet Identity principals via derivationOrigin. Can one ii-alternative-origins file cover all 40? Answer in 3 sentences max and state the exact maximum number of entries allowed. No setup steps, no DNS.",
+      "expected_behaviors": [
+        "States the maximum is 100 alternative origins",
+        "Does NOT claim the limit is 10",
+        "Confirms roughly 40 domains fit within the limit in a single ii-alternative-origins file"
+      ]
     }
   ],
   "trigger_evals": {

--- a/evaluations/internet-identity.json
+++ b/evaluations/internet-identity.json
@@ -181,11 +181,11 @@
     },
     {
       "name": "Adversarial: maximum number of alternative origins",
-      "prompt": "One IC frontend canister, and I want about 40 white-label custom domains to all share the same Internet Identity principals via derivationOrigin. Can one ii-alternative-origins file cover all 40? Answer in 3 sentences max and state the exact maximum number of entries allowed. No setup steps, no DNS.",
+      "prompt": "My IC frontend lists white-label custom domains in ii-alternative-origins and the list keeps growing. State the exact maximum number of entries allowed, and say what happens to sign-in if I push the file past that maximum. 3 sentences max, no setup steps, no DNS.",
       "expected_behaviors": [
         "States the maximum is 100 alternative origins",
-        "Does NOT claim the limit is 10",
-        "Confirms roughly 40 domains fit within the limit in a single ii-alternative-origins file"
+        "Says exceeding the cap invalidates the ENTIRE list — every alternative origin stops authenticating, not just the entries past the limit",
+        "Does NOT describe the over-cap behavior as truncation, ignoring the extras, or only the excess entries failing"
       ]
     }
   ],

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -175,7 +175,7 @@ const authClient = new AuthClient({
 
 A maximum of **100** alternative origins can be listed. Entries are origins — no trailing slashes and no paths.
 
-The cap was **10** until II `release-2026-08-21` ([internet-identity#4261](https://github.com/dfinity/internet-identity/pull/4261)) and is 100 from that release on. Older docs, blog posts, and model priors still say 10 — do not carry that number over. Going over the cap is not a truncation: II rejects the entire list with `has too many entries: To prevent misuse at most 100 alternative origins are allowed`, so **every** alternative origin stops authenticating, not just the ones past the limit.
+Going over the cap is not a truncation: II rejects the entire list with `has too many entries: To prevent misuse at most 100 alternative origins are allowed`, so **every** alternative origin stops authenticating, not just the ones past the limit.
 
 **3. With `@dfinity/static-site`, add a `_headers` block.** `.well-known/` is uploaded automatically, but this file has no extension, so its media type is not `application/json`, and the certified-assets canister sets no CORS header by default. II needs both:
 

--- a/skills/internet-identity/SKILL.md
+++ b/skills/internet-identity/SKILL.md
@@ -173,7 +173,9 @@ const authClient = new AuthClient({
 { "alternativeOrigins": ["https://shop.example.com"] }
 ```
 
-A maximum of 10 alternative origins can be listed. Entries are origins — no trailing slashes and no paths.
+A maximum of **100** alternative origins can be listed. Entries are origins — no trailing slashes and no paths.
+
+The cap was **10** until II `release-2026-08-21` ([internet-identity#4261](https://github.com/dfinity/internet-identity/pull/4261)) and is 100 from that release on. Older docs, blog posts, and model priors still say 10 — do not carry that number over. Going over the cap is not a truncation: II rejects the entire list with `has too many entries: To prevent misuse at most 100 alternative origins are allowed`, so **every** alternative origin stops authenticating, not just the ones past the limit.
 
 **3. With `@dfinity/static-site`, add a `_headers` block.** `.well-known/` is uploaded automatically, but this file has no extension, so its media type is not `application/json`, and the certified-assets canister sets no CORS header by default. II needs both:
 


### PR DESCRIPTION
The skill stated a maximum of 10 alternative origins. Internet Identity's cap is 100.

## Verification

Checked against the II source rather than the reported number alone:

- `MAX_ALTERNATIVE_ORIGINS = 100` in `src/frontend/src/lib/utils/validateDerivationOrigin.ts`
- `docs/ii-spec.mdx` agrees — "No more than 100…", JSON schema `"maxItems": 100`
- Raised from 10 in [dfinity/internet-identity#4261](https://github.com/dfinity/internet-identity/pull/4261), shipped in `release-2026-08-21`
- Past the cap, the length check returns `{result: "invalid"}` for the whole document *before* the membership test — so all alternative origins fail, not just the extras

One claim was drafted and dropped: "entries must be unique." The spec's JSON schema carries `uniqueItems: true`, but `validateDerivationOrigin.ts` never enforces it — it only runs `includes()` on the normalized array. Stating it as a rule would be guidance the runtime does not back.

Nothing to file upstream — the II docs already say 100.

## Changes

- `skills/internet-identity/SKILL.md` — 10 → 100, plus the "rejects the entire list" consequence.
- `evaluations/internet-identity.json` — new adversarial case 19 covering the cap and the over-cap behavior.

The skill records the current cap and what happens past it, and no version history. A developer cannot be running an II release older than mainnet's, so the previous cap describes a state nobody can reach. The provenance above is here for review, not in the skill.

## Evals

Case 19 is new, so it is run with baseline. The other 18 cases were not re-run — none of them assert the origin count.

<details>
<summary>Eval 19 — WITH skill 3/3 · WITHOUT skill 2/3</summary>

```
WITH skill: 3/3 passed
  ✅ States the maximum is 100 alternative origins
  ✅ Says exceeding the cap invalidates the ENTIRE list — every alternative origin
     stops authenticating, not just the entries past the limit
  ✅ Does NOT describe the over-cap behavior as truncation, ignoring the extras,
     or only the excess entries failing

WITHOUT skill: 2/3 passed
  ❌ States the maximum is 100 alternative origins
     → The output states the maximum is 10 entries, not 100.
  ✅ Says exceeding the cap invalidates the ENTIRE list — …
  ✅ Does NOT describe the over-cap behavior as truncation — …
```
</details>

Read that delta honestly: **the number is the only thing that discriminates.** Baseline already knows that exceeding the cap invalidates the whole list — it just applies that correct behavior to the wrong limit. The over-cap sentence stays in the skill because it is accurate and cheap, not because it was measured as differentiating.

An earlier version of this case reported 0/3 → 3/3, which flattered the change. It counted one fact three times: "confirms ~40 domains fit" was derived from the prompt's own "about 40" rather than from the skill, and both it and "does NOT claim 10" are entailed by stating the cap is 100. Rewritten to probe two distinct facts, and the weaker number above is the real one.

`npm run validate` passes — 30 skills, warnings only.
