### PR TITLE
chore(mops-cli): sync upstream caffeinelabs/mops cli-v3.1.0 → cli-v3.2.0

### DIFF
--- a/.claude/upstream.md
+++ b/.claude/upstream.md
@@ -97,8 +97,8 @@ Upstream file paths and the tracking model (release-tag vs commit) are listed pe
 ## mops-cli
 
 - **Upstream:** https://github.com/caffeinelabs/mops
-- **Tag:** cli-v3.1.0
-- **Commit:** a4857f9609c3ec5dc45a2a807ebb88e8a856eec6
-- **Last synced:** 2026-08-24
+- **Tag:** cli-v3.2.0
+- **Commit:** 20b9a435096e4e61a7980532a5211716d743770b
+- **Last synced:** 2026-09-08
 - **Upstream file:** `.agents/skills/mops-cli/SKILL.md`
 - **icskills-owned sections:** none — body is 1:1 with upstream; only frontmatter differs

--- a/evaluations/mops-cli.json
+++ b/evaluations/mops-cli.json
@@ -202,6 +202,26 @@
         "Uses `mops bench --compare` to compare against saved results",
         "Does NOT invent a non-existent command or suggest a manual benchmarking harness"
       ]
+    },
+    {
+      "name": "Adversarial: edited applied migration caught at build, not check",
+      "prompt": "My `backend` canister has `check-limit = 5` on its migration chain and `[canisters.backend.check-stable].path` set. I edited a migration that was already applied in production to fix a typo in its type, and `mops check` passes. Am I safe to deploy? Just answer directly.",
+      "expected_behaviors": [
+        "Says no \u2014 a passing `mops check` is not sufficient here",
+        "Explains `mops build` compiles the full chain regardless of `check-limit`, and folds the deployed baseline via `--stable-baseline` when `check-stable.path` is set",
+        "Names `M0268` as the resulting error",
+        "Identifies editing an already-applied migration as the problem (the same applies to deleting or backdating one)"
+      ]
+    },
+    {
+      "name": "Strict migration diagnostics on moc 1.15.0+",
+      "prompt": "I'm on moc 1.15.1 with `[canisters.backend.migrations]` configured. My `main.mo` declares a stable field that none of my migrations produce. Will `mops check` warn or error, and would the answer differ on an older moc pin? Just answer directly.",
+      "expected_behaviors": [
+        "Says it errors, not just warns",
+        "Names `M0267` as the error, rather than only the `M0254` warning",
+        "Attributes the stricter behavior to moc 1.15.0+ \u2014 older moc pins get the warning-only, pre-1.15.0 check",
+        "Does NOT claim the stricter check is disabled or that `moc --stable-baseline` is buggy"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/mops-cli/SKILL.md
+++ b/skills/mops-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: mops-cli
 description: "Manage Motoko projects with the mops CLI — toolchain pinning, dependency management, type-checking, building, and linting. Use when working with mops.toml, mops.lock, running mops commands, adding/removing packages, pinning moc or lintoko versions, checking or building canisters, configuring moc flags, or setting up a new Motoko project."
 license: Apache-2.0
-compatibility: "mops >= 3.1.0"
+compatibility: "mops >= 3.2.0"
 metadata:
   title: Mops CLI
   category: Infrastructure
@@ -40,7 +40,7 @@ main = "src/backend/main.mo"
 
 [canisters.backend.migrations]
 chain = "src/backend/migrations"
-check-limit = 10   # optional — speeds up `mops check` when the chain gets long
+# check-limit = 10   # optional — speeds up `mops check` when the chain gets long
 
 [canisters.backend.check-stable]
 path = "deployed/backend.most"
@@ -48,8 +48,8 @@ path = "deployed/backend.most"
 [build]
 outputDir = "src/backend/dist"
 args = ["--release"]
-check-wasm = true    # optional: analyze final Wasm complexity
-check-deploy = true  # optional: verify fresh PocketIC installation after build
+# check-wasm = true    # optional: analyze final Wasm complexity
+# check-deploy = true  # optional: verify fresh PocketIC installation after build
 
 # Opt-in Wasm optimization (Binaryen wasm-opt) for build + bench
 [optimize]
@@ -133,7 +133,7 @@ Adding a package that is already declared in the other section **moves** it rath
 
 Primary correctness command — runs moc check, then check-stable (if configured), then lint (if lintoko is in toolchain).
 
-On moc 1.12.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. **Temporarily disabled** — `moc --stable-baseline` is buggy, so every pin runs the pre-1.12.0 check. Older moc pins and canisters without `[migrations]` are unaffected either way.
+On moc 1.15.0+, canisters with `[migrations]` get stricter upgrade diagnostics: a field the initial actor requires that no migration produces fails as an `M0267` error instead of only warning (`M0254`), and compat errors carry a source location. Older moc pins and canisters without `[migrations]` are unaffected either way.
 
 The `check-stable` baseline is always a `.most` file — as `[canisters.<name>.check-stable].path` or as the `mops check-stable <baseline.most>` argument. A `.mo` source is rejected. See [`mops deployed`](#mops-deployed) for where the baseline comes from — that differs between a fresh project and an already-deployed canister.
 
@@ -221,7 +221,7 @@ After `mops check --fix` (or `mops check <canister>`) confirms the chain compile
 
 Use `mops build --check-deploy`, or set `[build].check-deploy = true` for every build, to install each built Wasm on a fresh PocketIC canister and catch module validation, initialization, and installation failures. Requires `[toolchain] pocket-ic` (a version from `9.0.0` up, or a local binary path) — or set `MOPS_POCKET_IC_URL` to an already-running PocketIC server (the pin is then ignored). Unpinned with no URL, the build errors naming `mops toolchain use pocket-ic 15.0.0`. Use `--no-check-deploy` to skip configured validation once. The command uses each canister's `initArg`, or `()` when omitted. Set `wasmMemoryLimit` to a positive integer byte limit on a canister to check deployment under that limit. PocketIC errors are reported as provided by the client, and installation failures are collected across canisters. Before installation, Mops runs `moc --stable-compatible` from a temporary empty-actor `.most` to each generated `.most`. If moc reports incompatibility, Mops emits `MOPS-CHECK-DEPLOY-SKIPPED` with the compiler diagnostic and does not check that canister on fresh PocketIC. Eligible siblings are still checked; validate the skipped upgrade against representative baseline state.
 
-`check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` is unaffected by `check-limit`. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
+`check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` is unaffected by `check-limit`; it compiles the full chain, and when `[canisters.<name>.check-stable].path` is set it also folds the deployed baseline via `--stable-baseline`, so an applied migration edited, deleted, or backdated since deploy fails the build with `M0268` — the backstop for when `check-limit` trims that migration out of the folded `mops check`. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
 
 Override `check-limit` for a single run with `--no-check-limit` (`mops check`, `mops check-stable`, `mops lint`) — e.g. `mops check --fix --no-check-limit` to autofix older, normally-trimmed migrations. On `mops check` and `mops check-stable`, `--no-check-limit` also suppresses the pending-migration warning.
 


### PR DESCRIPTION
## Summary

Syncs `mops-cli` from `caffeinelabs/mops` `cli-v3.1.0` → `cli-v3.2.0`. No icskills-owned sections for this skill, so the body is applied verbatim; only `compatibility` changed in frontmatter (`mops >= 3.2.0`).

Two substantive changes:

- **Stricter `[migrations]` diagnostics move to moc `1.15.0+` and are live again.** `moc --stable-baseline` was fixed, so the "**Temporarily disabled**" caveat is gone — a stable field no migration produces now fails as `M0267` instead of only warning (`M0254`). This reverses what the skill previously told agents.
- **New `M0268` build backstop.** `mops build` compiles the full chain regardless of `check-limit`, and folds the deployed baseline via `--stable-baseline` when `[canisters.<name>.check-stable].path` is set — so an applied migration edited, deleted, or backdated since deploy fails the build. Relevant because `check-limit` can trim that same migration out of `mops check`, which then passes.

Also: the minimal `mops.toml` now comments out `check-limit`, `check-wasm` and `check-deploy`. That is the fix for [caffeinelabs/mops#793](https://github.com/caffeinelabs/mops/issues/793), which we filed on 2026-08-24 — it was closed upstream the same day, and `cli-v3.2.0` is the first tagged release carrying it. Upstream went one step further than requested and commented out `check-limit` too.

Closes #375

## Filed upstream

Two defects found while verifying this sync. Neither is blocking — both are in non-owned body content, so any fix flows back on the next release.

- [caffeinelabs/mops#807](https://github.com/caffeinelabs/mops/issues/807) — the minimal `mops.toml` pins `moc = "1.7.0"` / `lintoko = "0.10.0"` (current: `1.15.1` / `0.11.0`). This release's own new sentence tells the reader moc `1.15.0+` is where migration diagnostics get strict, so the starter config now hands agents a pin eight minor versions below the threshold the same document documents. Same class as #793.
- [caffeinelabs/skills#13](https://github.com/caffeinelabs/skills/issues/13) — `troubleshooting-motoko-migrations`' error table covers `M0250`/`M0254`/`M0267`/`M0255` but not `M0268`, whose cause and fix no existing row implies. Verified absent at that repo's HEAD, and verified real in moc (`error_codes.ml:274`, `test/fail/em-baseline-history-mismatch.mo`).

## Evals

Two new cases for the two new facts. Existing cases 13 (`--no-check-limit`) and 19 (`--check-deploy`) still hold — nothing they assert changed — so they were not re-run. Description untouched, so no trigger evals.

<details>
<summary>Eval results (with-skill vs baseline)</summary>

**21. Adversarial: edited applied migration caught at build, not check** (new)
WITH 4/4 | WITHOUT 2/4 — baseline correctly says "not safe" and spots the edited migration, but never mentions `mops build`, its full-chain compilation, `--stable-baseline`, or the `M0268` code

**22. Strict migration diagnostics on moc 1.15.0+** (new)
WITH 4/4 | WITHOUT 2/4 — baseline gets "errors, not warns" but names no diagnostic codes, and on the version question invents that older moc pins would fail to parse migration syntax entirely rather than running the warning-only check

</details>

First run of case 22 scored 3/4 with skill: the prompt asked for a direct warn-or-error answer, so the model had no reason to discuss older pins. Rescoped the prompt to ask whether the answer differs on an older moc pin rather than weakening the expected behavior.
