### PR TITLE
feat(autoupgrade-icp-cli): new skill for keeping icp and ic-wasm current

### DIFF
--- a/evaluations/autoupgrade-icp-cli.json
+++ b/evaluations/autoupgrade-icp-cli.json
@@ -1,0 +1,81 @@
+{
+  "skill": "autoupgrade-icp-cli",
+  "description": "Evaluation cases for the autoupgrade-icp-cli skill. Tests whether agents set the hook up correctly (ask for a mode, fetch the published script, merge settings.json, raise the timeout for auto mode) and whether they diagnose toolchain-version problems the way the skill describes: channel-correct upgrade commands, ic-wasm skew, and a shadowed second copy on PATH.",
+  "output_evals": [
+    {
+      "name": "Setup plan and settings.json entry",
+      "prompt": "I want every Claude Code session in this project to check whether my icp CLI is out of date. Describe the exact steps you'd take and show the .claude/settings.json entry you'd add. Don't run anything or edit files.",
+      "expected_behaviors": [
+        "Asks the user (or explicitly offers the choice) whether the hook should only notify or should upgrade automatically, rather than silently picking one",
+        "Registers a SessionStart hook whose command runs the script, e.g. `bash .claude/upgrade-icp-cli.sh`",
+        "Says the script is downloaded from https://skills.internetcomputer.org/.well-known/skills/autoupgrade-icp-cli/scripts/upgrade-icp-cli.sh rather than hand-written",
+        "Says an existing .claude/settings.json must be merged (preserving other keys/hooks) and the entry not duplicated, never overwritten",
+        "Mentions the user will be asked to approve/trust the new hook before it runs automatically",
+        "Does NOT invent a settings.json schema — the entry nests under hooks.SessionStart with a hooks array of {type: command, command: ...}"
+      ]
+    },
+    {
+      "name": "Auto mode needs a raised hook timeout",
+      "prompt": "Set my SessionStart hook to actually install the new icp version automatically instead of just telling me about it. Just show me the final hook JSON and note anything I should watch out for.",
+      "expected_behaviors": [
+        "Uses the auto mode flag on the command (e.g. `--mode auto`)",
+        "Raises the hook timeout above the 60 second default (e.g. \"timeout\": 300), because downloading and installing a CLI binary can exceed it",
+        "Explains the risk of auto mode: a CLI upgrade can change build behaviour mid-project",
+        "Does NOT claim the upgrade runs in the background — the hook blocks session start while it runs"
+      ]
+    },
+    {
+      "name": "Channel-correct upgrade command",
+      "prompt": "I installed icp a while ago with the curl shell installer from the icp-cli releases page, not with npm. icp --version says 1.2.0 and there's a newer one. What's the single command to upgrade it? Just the command and one line of why.",
+      "expected_behaviors": [
+        "Gives `icp-cli-update` (the updater the shell installer places on PATH) as the upgrade command",
+        "Does NOT tell the user to run `npm install -g @icp-sdk/icp-cli@latest`, which would install a second copy from a different channel",
+        "Explains that the upgrade command depends on the channel the CLI was installed from"
+      ]
+    },
+    {
+      "name": "ic-wasm version skew after upgrading icp",
+      "prompt": "I just upgraded icp to the latest version with npm. Now `icp build` fails inside the @dfinity/motoko recipe with a metadata/optimization error, and nothing in my project changed. What should I check first? Keep it brief.",
+      "expected_behaviors": [
+        "Points at ic-wasm being left behind while icp moved forward, since the official recipes invoke ic-wasm during every build",
+        "Tells the user to check `ic-wasm --version` and upgrade it (e.g. `npm install -g @icp-sdk/ic-wasm@latest`)",
+        "Does NOT send the user straight into debugging their Motoko code or recipe config as the first step"
+      ]
+    },
+    {
+      "name": "Upgrade ran but the version did not move",
+      "prompt": "I ran `npm install -g @icp-sdk/icp-cli@latest`, it finished with no errors, but `icp --version` still prints the old version. What's going on? Just the diagnosis and how to confirm it.",
+      "expected_behaviors": [
+        "Identifies that a second copy of icp from a different install channel is earlier on PATH and shadowing the npm one (commonly ~/.cargo/bin/icp from the shell installer)",
+        "Suggests resolving the actual binary being used, e.g. `command -v icp` / `which icp` (and following the symlink) to see which copy wins",
+        "Says upgrading through one channel will never move a copy installed through another — remove one, or upgrade the one that is actually on PATH",
+        "Does NOT blame the npm cache or recommend reinstalling npm as the primary explanation"
+      ]
+    }
+  ],
+  "trigger_evals": {
+    "description": "Queries to test whether the skill activates correctly. 'should_trigger' queries should cause the skill to load; 'should_not_trigger' queries should NOT activate this skill.",
+    "should_trigger": [
+      "Can you make this project always use the latest icp CLI?",
+      "Set up a hook so I stop working with an outdated icp version",
+      "I keep forgetting to update icp-cli. Automate it for me.",
+      "How do I upgrade the ICP CLI to the newest release?",
+      "My icp is on 1.2.0 and the latest is 1.5.0 — what's the upgrade command?",
+      "Install something that keeps icp and ic-wasm current at the start of every session",
+      "I ran npm install -g @icp-sdk/icp-cli@latest but icp --version hasn't changed",
+      "Is my ic-wasm too old for the version of icp I'm running?",
+      "Add automatic ICP toolchain updates to .claude/settings.json"
+    ],
+    "should_not_trigger": [
+      "Upgrade my canister without wiping its state — I think I need icp deploy --mode upgrade",
+      "Bump the @dfinity/motoko recipe in my icp.yaml to the latest version",
+      "Keep my Internet Computer skills in .claude/skills up to date automatically",
+      "Update the moc compiler version in my mops.toml toolchain section",
+      "My icp deploy is failing with a build error in the rust recipe",
+      "What's the latest version of @icp-sdk/core I should depend on in my frontend?",
+      "Write a GitHub Actions workflow that deploys my canister on every push to main",
+      "How do I upgrade a canister's Wasm module on mainnet without losing stable memory?",
+      "Add a SessionStart hook that runs my test suite before I start working"
+    ]
+  }
+}

--- a/skills/autoupgrade-icp-cli/SKILL.md
+++ b/skills/autoupgrade-icp-cli/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: autoupgrade-icp-cli
+description: One-time installer that keeps a project's Internet Computer CLI toolchain current. Sets up a SessionStart hook plus a script that compares the installed `icp` and `ic-wasm` against the latest release and either reports the upgrade or applies it, using whichever channel each tool was installed from (npm, Homebrew, or the shell installer). Use when a user wants to install, bootstrap, or enable automatic icp-cli / ic-wasm updates, asks to stop running an outdated `icp`, asks how to upgrade or check the version of the ICP CLI, or pastes the link to this skill. This is a one-time setup action, not ongoing IC knowledge. Do NOT use for writing icp.yaml, deploying canisters, or other icp-cli usage questions — load `icp-cli` for those.
+license: Apache-2.0
+compatibility: "curl, bash; network access to github.com (and formulae.brew.sh for Homebrew installs)"
+metadata:
+  title: Automatically Upgrade the ICP CLI
+  category: Infrastructure
+---
+
+# Set up automatic `icp` CLI upgrades
+
+This skill installs a small amount of project configuration so that **every new
+Claude Code session checks whether `icp` and `ic-wasm` are current** — and, if the
+user wants, upgrades them before any work starts.
+
+It is a **one-time installer**. After you complete the steps below, the user never
+needs this link again — the installed `SessionStart` hook does the work from then on.
+
+Both tools are covered because they ship as a pair (`npm install -g @icp-sdk/icp-cli
+@icp-sdk/ic-wasm`) and the official recipes (`@dfinity/motoko`, `@dfinity/rust`,
+`@dfinity/static-site`, `@dfinity/asset-canister`) call `ic-wasm` during every build.
+An `ic-wasm` left behind while `icp` moves forward produces build failures that look
+like recipe bugs, so upgrading only one of them is the worse default.
+
+## Why this beats the CLI's own update check
+
+`icp` already has a built-in check (`icp settings update-check`), and it is worth
+leaving enabled — but it only speaks when the user runs an `icp` command, and by then
+the agent has already chosen which commands to write. This hook runs **before** the
+session's first prompt, so:
+
+- The version lands in Claude's context up front, so it can pick flags and recipe
+  versions that exist in the installed CLI instead of discovering the mismatch from a
+  failed command.
+- `ic-wasm` is checked too, which the built-in check does not cover.
+- The upgrade command matches the channel the tool was **actually** installed from,
+  and in auto mode it is applied rather than printed.
+
+## What you will create
+
+1. `.claude/upgrade-icp-cli.sh` — the version-check script.
+2. A `SessionStart` hook in `.claude/settings.json` that runs it.
+3. An immediate first run, so the user sees the current state right away.
+
+## Step 1 — Ask the user which mode they want
+
+This is the one decision the installer cannot make for the user, so ask before writing
+anything. A CLI upgrade can change build behaviour mid-project, and some teams pin the
+toolchain deliberately:
+
+> "Two options for how the hook behaves when a newer version exists:
+> **notify** — it prints the versions and the exact upgrade command, and nothing is
+> installed until you run it. **auto** — it runs that upgrade itself at session start.
+> Which do you want? You can switch later by editing one flag in the hook."
+
+Default to **notify** if the user has no preference — it is the reversible choice, and
+switching to auto later is a one-word edit.
+
+Also tell the user what adding a hook means:
+
+> "I'm adding a `SessionStart` hook that runs `.claude/upgrade-icp-cli.sh`. Claude Code
+> will ask you to approve/trust it before it runs automatically."
+
+Do **not** attempt to bypass that approval.
+
+## Step 2 — Check prerequisites
+
+The script needs `curl` (virtually always present) and at least one of the two tools
+installed — it reports on what is there and never installs a tool the user does not
+already have:
+
+```bash
+command -v curl    >/dev/null 2>&1 && echo "curl: ok"    || echo "curl: MISSING"
+icp --version      2>/dev/null     || echo "icp: not installed"
+ic-wasm --version  2>/dev/null     || echo "ic-wasm: not installed"
+```
+
+If either tool is missing, mention the install command
+(`npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`) but do not run it unprompted —
+installing a toolchain is a different decision from keeping one current.
+
+Note that no `jq` is needed here (unlike `autosync-ic-skills`); the script parses
+versions with POSIX tools only.
+
+## Step 3 — Download the script
+
+The script is published as a file alongside this skill, so fetch it verbatim rather
+than transcribing it — that guarantees byte-exact content and keeps the channel
+detection correct as it is updated upstream:
+
+```bash
+mkdir -p .claude
+curl -fsSL https://skills.internetcomputer.org/.well-known/skills/autoupgrade-icp-cli/scripts/upgrade-icp-cli.sh \
+  -o .claude/upgrade-icp-cli.sh
+```
+
+Do **not** hand-write or paraphrase it.
+
+## Step 4 — Register the SessionStart hook (idempotently)
+
+Add a `SessionStart` hook to `.claude/settings.json`.
+
+- If `.claude/settings.json` does **not** exist, create it with the content below.
+- If it **does** exist, **merge** — preserve all existing keys, hooks, and permissions.
+  Only add the `SessionStart` entry, and **only if an equivalent
+  `bash .claude/upgrade-icp-cli.sh` command is not already present** (do not create a
+  duplicate). Parse the existing JSON, insert into the `hooks.SessionStart` array, and
+  write it back; never blindly overwrite the file.
+
+**Notify mode** (the default):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash .claude/upgrade-icp-cli.sh --mode notify" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Auto mode** — same entry with `--mode auto`, plus a raised `timeout`. Installing a
+CLI binary can take well over the default 60 s hook timeout on a slow connection, and
+a timed-out upgrade leaves the tool half-installed:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash .claude/upgrade-icp-cli.sh --mode auto", "timeout": 300 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Switching modes later is just editing that `--mode` flag (and adding or dropping the
+`timeout`).
+
+Whenever you hand someone an auto-mode hook, say the thing that makes it a real
+choice: it upgrades the build toolchain **while a project is open**, so a session can
+start against a different `icp` than the last one ended with. That is exactly what
+some teams want and exactly what others pin against.
+
+## Step 5 — Run it once now
+
+```bash
+bash .claude/upgrade-icp-cli.sh --mode notify   # or --mode auto, matching the hook
+```
+
+Run it with the same mode you registered, so the user sees exactly what the hook will
+do. When both tools are current the script prints nothing and exits 0 — silence is the
+success case, not a failure.
+
+A hand-run always checks the network; the hook does not (see the throttle below), so
+this is also the command to reach for whenever someone wants an answer *now*.
+
+## Step 6 — Verify and report
+
+- Confirm `.claude/upgrade-icp-cli.sh` exists and the hook entry is in
+  `.claude/settings.json` exactly once.
+- Report the versions the run found, whether anything was upgraded, and which mode is
+  now installed.
+- Remind the user they will be prompted to trust the hook before it auto-runs next
+  session.
+- If the project commits `.claude/`, add `.claude/.icp-upgrade-check` to `.gitignore` —
+  it is a per-machine timestamp, not shared configuration.
+
+## How the script decides what to run
+
+It resolves each binary through its symlinks and reads the install channel off the
+path, because the upgrade command is different for each and guessing wrong leaves two
+copies of the CLI on `PATH` shadowing each other:
+
+| Where the binary resolves to | Channel | Upgrade command | Latest version read from |
+|---|---|---|---|
+| `…/node_modules/@icp-sdk/…` | npm | `npm install -g <pkg>@latest` | GitHub release tag |
+| `…/Cellar/…` | Homebrew | `brew upgrade <formula>` | `formulae.brew.sh` API |
+| a cargo-dist receipt in `~/.config/<app>/` | shell installer | `icp-cli-update` / `ic-wasm-update` | GitHub release tag |
+| anything else | unknown | *(none — reports the release URL instead)* | GitHub release tag |
+
+Homebrew is asked for its own formula version rather than the GitHub tag: the formula
+can trail a release by a day or two, and nagging about a version `brew upgrade` cannot
+yet install is pure noise.
+
+The GitHub lookup follows the `/releases/latest` redirect instead of calling the API,
+so it needs no token and cannot hit the 60-requests-per-hour anonymous rate limit —
+which a hook that fires on every session start otherwise would.
+
+## Behaviour worth knowing
+
+- **Silent when there is nothing to say.** Output appears only when a tool is behind,
+  missing, or an upgrade failed. A `SessionStart` hook's plain stdout reaches Claude as
+  context but is never shown to the user, so the script emits one JSON object instead:
+  `systemMessage` (rendered to the user as a system notice) and `additionalContext`
+  (given to Claude). Run from a terminal it prints plain text. Diagnostics go to stderr
+  and are not displayed either way.
+- **Never fails the session.** Network failures, an unreachable registry, or a failed
+  package manager all exit 0 with a note. A broken upgrade must not block work.
+- **Throttled, because the hook blocks session start.** The two version probes cost
+  roughly a second, which is too much to pay on every session, so a check that reached
+  a release feed is stamped in `.claude/.icp-upgrade-check` and not repeated for 6
+  hours — a throttled run costs about 10 ms. Releases land every few weeks, so this
+  loses nothing. Override with `ICP_UPGRADE_CHECK_INTERVAL=<seconds>` (`0` disables the
+  throttle entirely), and bypass it once with `--force`. A run from a terminal always
+  checks. A failed probe is deliberately not stamped, so an offline session retries at
+  the next one instead of going quiet for six hours.
+- **Never installs what is absent.** A missing tool is reported with its install
+  command, even in auto mode — installing a toolchain the user never had is a
+  different decision from upgrading one they did.
+- **Never sudo.** If the global npm prefix is not writable, auto mode reports
+  `sudo npm install -g …` rather than running it; a password prompt inside a hook has
+  no terminal to type into and would hang session start.
+- **Pre-releases are not downgraded.** A `1.6.0-beta.1` install compares as `1.6.0`,
+  so running a beta does not produce an upgrade nag back to the release.
+- **Shadowed installs are caught.** If an upgrade succeeds but `PATH` still resolves to
+  the old version, the script says so — that means a second copy of the tool (commonly
+  an npm global under `nvm` plus a shell-installer copy in `~/.cargo/bin`) is winning
+  on `PATH`, and upgrading one will never fix the other.
+
+## What this does *not* upgrade
+
+The hook manages the two CLI binaries only. These are pinned per project and stay the
+user's call:
+
+- **Recipe versions** in `icp.yaml` (`@dfinity/motoko@v5.0.0` and friends) — a newer
+  `icp` does not change them. Load `icp-cli` for the recipe table and how to bump one.
+- **The Motoko toolchain** (`moc`, `mops`, and the `[toolchain]` pin in `mops.toml`) —
+  load `mops-cli`.
+
+Upgrading the CLI mid-project can change build output, so if a build starts failing
+right after an auto upgrade, check the [icp-cli release
+notes](https://github.com/dfinity/icp-cli/releases) before assuming the project broke.
+
+## Additional References
+
+- **`icp-cli`** — using the CLI itself: `icp.yaml`, recipes, environments, deployment.
+- **`mops-cli`** — the Motoko toolchain and its own version pinning.
+- **`autosync-ic-skills`** — the companion installer that keeps the IC *skills* in
+  `.claude/skills/` current. The two are independent; installing both is common.

--- a/skills/autoupgrade-icp-cli/SKILL.md
+++ b/skills/autoupgrade-icp-cli/SKILL.md
@@ -10,84 +10,52 @@ metadata:
 
 # Set up automatic `icp` CLI upgrades
 
-This skill installs a small amount of project configuration so that **every new
-Claude Code session checks whether `icp` and `ic-wasm` are current** — and, if the
-user wants, upgrades them before any work starts.
+A **one-time installer**: it adds a `SessionStart` hook that checks whether `icp` and
+`ic-wasm` are current and — if the user wants — upgrades them before work starts. Once
+these steps are done the user never needs this skill again.
 
-It is a **one-time installer**. After you complete the steps below, the user never
-needs this link again — the installed `SessionStart` hook does the work from then on.
+`ic-wasm` is covered alongside `icp` because the official recipes (`@dfinity/motoko`,
+`@dfinity/rust`, `@dfinity/static-site`, `@dfinity/asset-canister`) invoke it on every
+build. An `ic-wasm` left behind while `icp` moves forward produces build failures that
+read as recipe bugs, so upgrading only one of the pair is the worse default.
 
-Both tools are covered because they ship as a pair (`npm install -g @icp-sdk/icp-cli
-@icp-sdk/ic-wasm`) and the official recipes (`@dfinity/motoko`, `@dfinity/rust`,
-`@dfinity/static-site`, `@dfinity/asset-canister`) call `ic-wasm` during every build.
-An `ic-wasm` left behind while `icp` moves forward produces build failures that look
-like recipe bugs, so upgrading only one of them is the worse default.
-
-## Why this beats the CLI's own update check
-
-`icp` already has a built-in check (`icp settings update-check`), and it is worth
-leaving enabled — but it only speaks when the user runs an `icp` command, and by then
-the agent has already chosen which commands to write. This hook runs **before** the
-session's first prompt, so:
-
-- The version lands in Claude's context up front, so it can pick flags and recipe
-  versions that exist in the installed CLI instead of discovering the mismatch from a
-  failed command.
-- `ic-wasm` is checked too, which the built-in check does not cover.
-- The upgrade command matches the channel the tool was **actually** installed from,
-  and in auto mode it is applied rather than printed.
-
-## What you will create
-
-1. `.claude/upgrade-icp-cli.sh` — the version-check script.
-2. A `SessionStart` hook in `.claude/settings.json` that runs it.
-3. An immediate first run, so the user sees the current state right away.
+`icp` has its own check (`icp settings update-check`) that is worth leaving on, but it
+only speaks once the user runs an `icp` command — by which point the agent has already
+chosen what to write. This hook runs before the session's first prompt, so the version
+reaches Claude's context up front, and it covers `ic-wasm` too.
 
 ## Step 1 — Ask the user which mode they want
 
-This is the one decision the installer cannot make for the user, so ask before writing
-anything. A CLI upgrade can change build behaviour mid-project, and some teams pin the
-toolchain deliberately:
+The installer cannot make this call for the user, so ask before writing anything:
 
 > "Two options for how the hook behaves when a newer version exists:
 > **notify** — it prints the versions and the exact upgrade command, and nothing is
 > installed until you run it. **auto** — it runs that upgrade itself at session start.
 > Which do you want? You can switch later by editing one flag in the hook."
 
-Default to **notify** if the user has no preference — it is the reversible choice, and
-switching to auto later is a one-word edit.
+Default to **notify** if the user has no preference — it is the reversible choice.
 
-Also tell the user what adding a hook means:
+Also tell them what adding a hook means, and do not attempt to bypass the approval:
 
 > "I'm adding a `SessionStart` hook that runs `.claude/upgrade-icp-cli.sh`. Claude Code
 > will ask you to approve/trust it before it runs automatically."
 
-Do **not** attempt to bypass that approval.
-
 ## Step 2 — Check prerequisites
 
-The script needs `curl` (virtually always present) and at least one of the two tools
-installed — it reports on what is there and never installs a tool the user does not
-already have:
-
 ```bash
-command -v curl    >/dev/null 2>&1 && echo "curl: ok"    || echo "curl: MISSING"
-icp --version      2>/dev/null     || echo "icp: not installed"
-ic-wasm --version  2>/dev/null     || echo "ic-wasm: not installed"
+command -v curl   >/dev/null 2>&1 && echo "curl: ok" || echo "curl: MISSING"
+icp --version     2>/dev/null     || echo "icp: not installed"
+ic-wasm --version 2>/dev/null     || echo "ic-wasm: not installed"
 ```
 
 If either tool is missing, mention the install command
 (`npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`) but do not run it unprompted —
 installing a toolchain is a different decision from keeping one current.
 
-Note that no `jq` is needed here (unlike `autosync-ic-skills`); the script parses
-versions with POSIX tools only.
-
 ## Step 3 — Download the script
 
-The script is published as a file alongside this skill, so fetch it verbatim rather
-than transcribing it — that guarantees byte-exact content and keeps the channel
-detection correct as it is updated upstream:
+Fetch the published script verbatim rather than transcribing it, so the channel
+detection stays correct as it is updated upstream:
 
 ```bash
 mkdir -p .claude
@@ -99,14 +67,10 @@ Do **not** hand-write or paraphrase it.
 
 ## Step 4 — Register the SessionStart hook (idempotently)
 
-Add a `SessionStart` hook to `.claude/settings.json`.
-
-- If `.claude/settings.json` does **not** exist, create it with the content below.
-- If it **does** exist, **merge** — preserve all existing keys, hooks, and permissions.
-  Only add the `SessionStart` entry, and **only if an equivalent
-  `bash .claude/upgrade-icp-cli.sh` command is not already present** (do not create a
-  duplicate). Parse the existing JSON, insert into the `hooks.SessionStart` array, and
-  write it back; never blindly overwrite the file.
+If `.claude/settings.json` does not exist, create it with the content below. If it
+does, **merge**: preserve every existing key, hook, and permission, add the
+`SessionStart` entry only if an equivalent `bash .claude/upgrade-icp-cli.sh` command is
+not already there, and write the parsed JSON back. Never overwrite the file.
 
 **Notify mode** (the default):
 
@@ -124,9 +88,9 @@ Add a `SessionStart` hook to `.claude/settings.json`.
 }
 ```
 
-**Auto mode** — same entry with `--mode auto`, plus a raised `timeout`. Installing a
-CLI binary can take well over the default 60 s hook timeout on a slow connection, and
-a timed-out upgrade leaves the tool half-installed:
+**Auto mode** — same entry with `--mode auto`, plus a raised `timeout`, because
+installing a CLI binary can exceed the default 60 s and a timed-out install leaves the
+tool half-written:
 
 ```json
 {
@@ -142,102 +106,68 @@ a timed-out upgrade leaves the tool half-installed:
 }
 ```
 
-Switching modes later is just editing that `--mode` flag (and adding or dropping the
-`timeout`).
-
 Whenever you hand someone an auto-mode hook, say the thing that makes it a real
-choice: it upgrades the build toolchain **while a project is open**, so a session can
-start against a different `icp` than the last one ended with. That is exactly what
-some teams want and exactly what others pin against.
+choice: it upgrades the build toolchain **while a project is open** and blocks session
+start while it runs, so a session can begin against a different `icp` than the last one
+ended with — which can change build behaviour and output for a project that built fine
+yesterday. That is what some teams want and what others pin against.
 
-## Step 5 — Run it once now
+## Step 5 — Run it once, verify, report
 
 ```bash
 bash .claude/upgrade-icp-cli.sh --mode notify   # or --mode auto, matching the hook
 ```
 
-Run it with the same mode you registered, so the user sees exactly what the hook will
-do. When both tools are current the script prints nothing and exits 0 — silence is the
-success case, not a failure.
+Silence means both tools are current — that is the success case, not a failure. A
+hand-run always checks the network; the hook throttles (below), so this is also the
+command for whenever someone wants an answer now.
 
-A hand-run always checks the network; the hook does not (see the throttle below), so
-this is also the command to reach for whenever someone wants an answer *now*.
-
-## Step 6 — Verify and report
-
-- Confirm `.claude/upgrade-icp-cli.sh` exists and the hook entry is in
-  `.claude/settings.json` exactly once.
-- Report the versions the run found, whether anything was upgraded, and which mode is
-  now installed.
-- Remind the user they will be prompted to trust the hook before it auto-runs next
-  session.
-- If the project commits `.claude/`, add `.claude/.icp-upgrade-check` to `.gitignore` —
-  it is a per-machine timestamp, not shared configuration.
+Then confirm the hook entry appears exactly once, report the versions found and
+whether anything was upgraded, and remind the user of the trust prompt. If the project
+commits `.claude/`, add `.claude/.icp-upgrade-check` to `.gitignore` — it is a
+per-machine timestamp, not shared configuration.
 
 ## How the script decides what to run
 
 It resolves each binary through its symlinks and reads the install channel off the
-path, because the upgrade command is different for each and guessing wrong leaves two
+path, because the upgrade command differs per channel and guessing wrong leaves two
 copies of the CLI on `PATH` shadowing each other:
 
-| Where the binary resolves to | Channel | Upgrade command | Latest version read from |
-|---|---|---|---|
-| `…/node_modules/@icp-sdk/…` | npm | `npm install -g <pkg>@latest` | GitHub release tag |
-| `…/Cellar/…` | Homebrew | `brew upgrade <formula>` | `formulae.brew.sh` API |
-| a cargo-dist receipt in `~/.config/<app>/` | shell installer | `icp-cli-update` / `ic-wasm-update` | GitHub release tag |
-| anything else | unknown | *(none — reports the release URL instead)* | GitHub release tag |
+| Where the binary resolves to | Channel | Upgrade command (`icp` / `ic-wasm`) |
+|---|---|---|
+| `…/node_modules/@icp-sdk/…` | npm | `npm install -g @icp-sdk/icp-cli@latest` / `npm install -g @icp-sdk/ic-wasm@latest` |
+| `…/Cellar/…` | Homebrew | `brew upgrade icp-cli` / `brew upgrade ic-wasm` |
+| a cargo-dist receipt in `~/.config/<app>/` | shell installer | `icp-cli-update` / `ic-wasm-update` |
+| anything else | unknown | *(none — reports the release URL instead)* |
 
-Homebrew is asked for its own formula version rather than the GitHub tag: the formula
-can trail a release by a day or two, and nagging about a version `brew upgrade` cannot
-yet install is pure noise.
+That last row is deliberate: an unrecognised install is reported, never guessed at.
 
-The GitHub lookup follows the `/releases/latest` redirect instead of calling the API,
-so it needs no token and cannot hit the 60-requests-per-hour anonymous rate limit —
-which a hook that fires on every session start otherwise would.
+Two consequences worth passing on to users:
 
-## Behaviour worth knowing
+- **A shadowed install never moves.** If an upgrade succeeds but `PATH` still resolves
+  to the old version, a second copy from another channel is winning — commonly an npm
+  global under `nvm` alongside a shell-installer copy in `~/.cargo/bin`. Upgrading one
+  channel can never touch the other's copy; resolve the binary (`command -v icp`) to
+  see which wins, then remove one or upgrade the one actually on `PATH`.
+- **Auto mode never runs `sudo`.** A non-writable npm prefix is reported as a `sudo …`
+  command instead, since a password prompt inside a hook has no terminal to answer it.
 
-- **Silent when there is nothing to say.** Output appears only when a tool is behind,
-  missing, or an upgrade failed. A `SessionStart` hook's plain stdout reaches Claude as
-  context but is never shown to the user, so the script emits one JSON object instead:
-  `systemMessage` (rendered to the user as a system notice) and `additionalContext`
-  (given to Claude). Run from a terminal it prints plain text. Diagnostics go to stderr
-  and are not displayed either way.
-- **Never fails the session.** Network failures, an unreachable registry, or a failed
-  package manager all exit 0 with a note. A broken upgrade must not block work.
-- **Throttled, because the hook blocks session start.** The two version probes cost
-  roughly a second, which is too much to pay on every session, so a check that reached
-  a release feed is stamped in `.claude/.icp-upgrade-check` and not repeated for 6
-  hours — a throttled run costs about 10 ms. Releases land every few weeks, so this
-  loses nothing. Override with `ICP_UPGRADE_CHECK_INTERVAL=<seconds>` (`0` disables the
-  throttle entirely), and bypass it once with `--force`. A run from a terminal always
-  checks. A failed probe is deliberately not stamped, so an offline session retries at
-  the next one instead of going quiet for six hours.
-- **Never installs what is absent.** A missing tool is reported with its install
-  command, even in auto mode — installing a toolchain the user never had is a
-  different decision from upgrading one they did.
-- **Never sudo.** If the global npm prefix is not writable, auto mode reports
-  `sudo npm install -g …` rather than running it; a password prompt inside a hook has
-  no terminal to type into and would hang session start.
-- **Pre-releases are not downgraded.** A `1.6.0-beta.1` install compares as `1.6.0`,
-  so running a beta does not produce an upgrade nag back to the release.
-- **Shadowed installs are caught.** If an upgrade succeeds but `PATH` still resolves to
-  the old version, the script says so — that means a second copy of the tool (commonly
-  an npm global under `nvm` plus a shell-installer copy in `~/.cargo/bin`) is winning
-  on `PATH`, and upgrading one will never fix the other.
+## Throttling
+
+A check that reached a release feed is stamped in `.claude/.icp-upgrade-check` and not
+repeated for 6 hours, so the hook costs ~10 ms on most session starts instead of ~1 s.
+Override with `ICP_UPGRADE_CHECK_INTERVAL=<seconds>` (`0` disables it) or bypass once
+with `--force`; a run from a terminal always checks. A failed probe is not stamped, so
+an offline session retries at the next one.
 
 ## What this does *not* upgrade
 
-The hook manages the two CLI binaries only. These are pinned per project and stay the
-user's call:
+The hook manages the two CLI binaries only. Recipe versions in `icp.yaml`
+(`@dfinity/motoko@v5.0.0` and friends) and the Motoko toolchain (`moc`, `mops`, the
+`[toolchain]` pin in `mops.toml`) are pinned per project and stay the user's call —
+load `icp-cli` and `mops-cli` respectively for those.
 
-- **Recipe versions** in `icp.yaml` (`@dfinity/motoko@v5.0.0` and friends) — a newer
-  `icp` does not change them. Load `icp-cli` for the recipe table and how to bump one.
-- **The Motoko toolchain** (`moc`, `mops`, and the `[toolchain]` pin in `mops.toml`) —
-  load `mops-cli`.
-
-Upgrading the CLI mid-project can change build output, so if a build starts failing
-right after an auto upgrade, check the [icp-cli release
+If a build starts failing right after an auto upgrade, check the [icp-cli release
 notes](https://github.com/dfinity/icp-cli/releases) before assuming the project broke.
 
 ## Additional References

--- a/skills/autoupgrade-icp-cli/scripts/upgrade-icp-cli.sh
+++ b/skills/autoupgrade-icp-cli/scripts/upgrade-icp-cli.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# upgrade-icp-cli.sh — keep the `icp` CLI and `ic-wasm` current.
+#
+# Checks the installed version of each tool against the latest release and
+# either reports what is available (notify mode, the default) or upgrades it
+# through the channel it was actually installed from (auto mode).
+#
+# Modes:
+#   notify  print what is out of date and the exact upgrade command  (default)
+#   auto    run that upgrade command
+#
+#   ICP_UPGRADE_MODE=auto|notify        or  --mode auto|notify
+#
+# The version probes cost about a second, which is a lot to pay at every single
+# session start, so a successful check is stamped and not repeated for
+# ICP_UPGRADE_CHECK_INTERVAL seconds (default 6h; 0 disables the throttle).
+# --force, and any run from a terminal, check anyway.
+#
+# Design notes:
+#   - Needs only curl and POSIX tools. No jq: the version probes are a GitHub
+#     redirect and one small Homebrew JSON field, both readable with grep/awk.
+#   - Never installs a tool that is not already present, and never upgrades a
+#     tool it cannot identify the install channel for — guessing there would
+#     leave two copies of the CLI on PATH shadowing each other.
+#   - Exits 0 on every failure path. This runs at session start; a network
+#     blip or a locked package manager must not block the session.
+set -euo pipefail
+
+MODE="${ICP_UPGRADE_MODE:-notify}"
+INTERVAL="${ICP_UPGRADE_CHECK_INTERVAL:-21600}"
+FORCE=0
+# A human ran this by hand: answer them rather than the stamp.
+if [ -t 1 ]; then FORCE=1; fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode) MODE="${2:-notify}"; shift 2 ;;
+    --mode=*) MODE="${1#--mode=}"; shift ;;
+    --force) FORCE=1; shift ;;
+    *) shift ;;
+  esac
+done
+case "$MODE" in
+  auto|notify) ;;
+  *) echo "[autoupgrade-icp-cli] unknown mode '$MODE' — using notify" >&2; MODE=notify ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[autoupgrade-icp-cli] 'curl' not found — cannot check for updates" >&2
+  exit 0
+fi
+
+# --- Throttle. The stamp holds the epoch second of the last check that actually
+#     reached a release feed, so an offline run retries next session instead of
+#     going quiet for the whole interval. ---
+STAMP="${CLAUDE_PROJECT_DIR:-.}/.claude/.icp-upgrade-check"
+CHECKED_OK=0
+case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=21600 ;; esac
+if [ "$FORCE" -eq 0 ] && [ "$INTERVAL" -gt 0 ] && [ -f "$STAMP" ]; then
+  last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  now="$(date +%s 2>/dev/null || echo 0)"
+  if [ "$now" -gt 0 ] && [ $((now - last)) -lt "$INTERVAL" ]; then
+    exit 0
+  fi
+fi
+
+NOTES=""   # lines to surface to the user, joined with \n at the end
+# Notes end up inside a JSON string, so drop the two characters that would
+# break it. Nothing this script reports legitimately contains either.
+note() {
+  line="$(printf '%s' "$1" | tr -d '"\\' | tr '\n' ' ')"
+  NOTES="${NOTES:+$NOTES\\n}$line"
+}
+
+# --- Resolve a symlink chain without readlink -f (absent on older macOS). ---
+resolve_path() {
+  p="$1"; n=0
+  while [ -L "$p" ] && [ "$n" -lt 20 ]; do
+    t="$(readlink "$p")"
+    case "$t" in
+      /*) p="$t" ;;
+      *)  p="$(dirname "$p")/$t" ;;
+    esac
+    n=$((n + 1))
+  done
+  printf '%s\n' "$p"
+}
+
+# --- True when $1 is an older version than $2. Compares dot-separated numeric
+#     components; a pre-release suffix (1.6.0-beta.1) compares as its release
+#     (1.6.0), so running a beta never nags you back down to the release. ---
+version_lt() {
+  awk -v a="$1" -v b="$2" '
+    function norm(v) { sub(/^v/, "", v); sub(/[-+].*$/, "", v); return v }
+    BEGIN {
+      na = split(norm(a), A, "."); nb = split(norm(b), B, ".")
+      n = (na > nb ? na : nb)
+      for (i = 1; i <= n; i++) {
+        x = (i <= na ? A[i] + 0 : 0); y = (i <= nb ? B[i] + 0 : 0)
+        if (x < y) exit 0
+        if (x > y) exit 1
+      }
+      exit 1
+    }'
+}
+
+# --- Installed version. Both tools print "<name> <version>" to stdout. ---
+installed_version() {
+  command -v "$1" >/dev/null 2>&1 || return 1
+  "$1" --version 2>/dev/null | awk 'NR==1 {print $2}'
+}
+
+# --- Which channel a tool came from, inferred from where its binary really
+#     lives. This decides the upgrade command, so an unrecognised location
+#     stays "unknown" rather than being guessed at. ---
+detect_channel() {   # $1 = binary name, $2 = cargo-dist app name
+  bin="$(command -v "$1" 2>/dev/null)" || return 1
+  real="$(resolve_path "$bin")"
+  case "$real" in
+    */node_modules/@icp-sdk/*) printf 'npm\n'; return 0 ;;
+    */Cellar/*)                printf 'brew\n'; return 0 ;;
+  esac
+  # The shell installer (cargo-dist) leaves a receipt naming the install it owns.
+  if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/$2/$2-receipt.json" ]; then
+    printf 'shell\n'; return 0
+  fi
+  printf 'unknown\n'
+}
+
+# --- Latest version per channel. npm and the shell installer both track the
+#     GitHub release, and its /releases/latest URL redirects to the tag — one
+#     HEAD request, no API token and no rate limit. Homebrew is asked
+#     separately because its formula can trail the release by a day or two,
+#     and nagging about a version `brew upgrade` cannot yet install is noise. ---
+latest_from_github() {   # $1 = repo (dfinity/icp-cli)
+  url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' --max-time 10 \
+    "https://github.com/$1/releases/latest" 2>/dev/null)" || return 1
+  case "$url" in
+    */releases/tag/*) v="${url##*/tag/}"; printf '%s\n' "${v#v}" ;;
+    *) return 1 ;;
+  esac
+}
+
+latest_from_brew() {     # $1 = formula name
+  curl -fsSL --max-time 10 "https://formulae.brew.sh/api/formula/$1.json" 2>/dev/null |
+    grep -o '"stable":"[^"]*"' | head -1 | cut -d'"' -f4
+}
+
+# --- Run an upgrade, keeping its chatter off stdout: stdout carries the hook's
+#     JSON and nothing else. ---
+run_upgrade() {
+  if "$@" >&2 2>&1; then return 0; fi
+  return 1
+}
+
+# --- One tool, end to end. ---
+check_tool() {           # $1 = binary  $2 = cargo-dist app / brew formula  $3 = npm package  $4 = repo
+  bin="$1"; app="$2"; pkg="$3"; repo="$4"
+
+  if ! current="$(installed_version "$bin")" || [ -z "$current" ]; then
+    # Absent, or present but not answering --version. Installing something the
+    # user never had is not an upgrade, so say so instead of acting.
+    if command -v "$bin" >/dev/null 2>&1; then
+      echo "[autoupgrade-icp-cli] '$bin' did not report a version — skipping" >&2
+    else
+      note "$bin is not installed. Install it with: npm install -g $pkg"
+    fi
+    return 0
+  fi
+
+  channel="$(detect_channel "$bin" "$app")"
+
+  if [ "$channel" = "brew" ]; then
+    latest="$(latest_from_brew "$app" || true)"
+  else
+    latest="$(latest_from_github "$repo" || true)"
+  fi
+  if [ -z "$latest" ]; then
+    echo "[autoupgrade-icp-cli] could not determine the latest $bin version — skipping" >&2
+    return 0
+  fi
+  CHECKED_OK=1
+
+  version_lt "$current" "$latest" || return 0
+
+  case "$channel" in
+    npm)
+      cmd_desc="npm install -g $pkg@latest"
+      set -- npm install -g "$pkg@latest"
+      # A global prefix owned by root turns the upgrade into a sudo password
+      # prompt with nothing to type into it, which would hang session start.
+      root="$(npm root -g 2>/dev/null || true)"
+      if [ -n "$root" ] && [ ! -w "$root" ]; then
+        note "$bin $current -> $latest available. Run: sudo $cmd_desc (the global npm prefix is not writable, so this is not upgraded automatically)"
+        return 0
+      fi
+      ;;
+    brew)
+      cmd_desc="brew upgrade $app"
+      set -- brew upgrade "$app"
+      ;;
+    shell)
+      if command -v "$app-update" >/dev/null 2>&1; then
+        cmd_desc="$app-update"
+        set -- "$app-update"
+      else
+        note "$bin $current -> $latest available. Re-run the installer: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/$repo/releases/latest/download/$app-installer.sh | sh"
+        return 0
+      fi
+      ;;
+    *)
+      note "$bin $current -> $latest available, but its install channel is unrecognised ($(command -v "$bin")). Upgrade it the way you installed it: https://github.com/$repo/releases/latest"
+      return 0
+      ;;
+  esac
+
+  if [ "$MODE" != "auto" ]; then
+    note "$bin $current -> $latest available. Run: $cmd_desc"
+    return 0
+  fi
+
+  if run_upgrade "$@"; then
+    new="$(installed_version "$bin" || true)"
+    if [ -n "$new" ] && ! version_lt "$new" "$latest"; then
+      note "$bin upgraded $current -> $new"
+    else
+      # The command succeeded but the binary on PATH did not move. Usually a
+      # second copy from another channel is shadowing the one just upgraded.
+      note "$bin: ran '$cmd_desc' but PATH still resolves to ${new:-$current}. Check for a second copy of $bin on PATH."
+    fi
+  else
+    note "$bin $current -> $latest available. '$cmd_desc' failed — run it manually to see why."
+  fi
+}
+
+check_tool icp     icp-cli @icp-sdk/icp-cli dfinity/icp-cli
+check_tool ic-wasm ic-wasm @icp-sdk/ic-wasm dfinity/ic-wasm
+
+# Only stamp a check that actually saw a release feed.
+if [ "$CHECKED_OK" -eq 1 ] && [ "$INTERVAL" -gt 0 ]; then
+  mkdir -p "$(dirname "$STAMP")" 2>/dev/null &&
+    date +%s > "$STAMP" 2>/dev/null || true
+fi
+
+[ -n "$NOTES" ] || exit 0
+
+# --- Report. On a terminal a human is reading, so print plain text. Under a
+#     SessionStart hook, plain stdout only reaches Claude and is never shown to
+#     the user, so emit one JSON object instead:
+#       systemMessage      -> shown to the USER as a system notice
+#       additionalContext  -> given to Claude, so it knows the CLI version it
+#                             is about to generate commands for
+if [ -t 1 ]; then
+  printf '[autoupgrade-icp-cli]\n%b\n' "$NOTES"
+else
+  printf '{"systemMessage":"[autoupgrade-icp-cli]\\n%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"icp toolchain status: %s"}}\n' \
+    "$NOTES" "$NOTES"
+fi


### PR DESCRIPTION
## What

A new skill, `autoupgrade-icp-cli` — the CLI counterpart to `autosync-ic-skills`. It is a one-time installer: it registers a `SessionStart` hook plus `.claude/upgrade-icp-cli.sh`, which compares the installed `icp` and `ic-wasm` against the latest release and either reports the upgrade (**notify**, the default) or applies it (**auto**).

The installer asks the user which mode they want rather than picking one, because auto mode upgrades the build toolchain while a project is open — what some teams want and what others pin against.

`ic-wasm` is covered alongside `icp` because the official recipes (`@dfinity/motoko`, `@dfinity/rust`, `@dfinity/static-site`, `@dfinity/asset-canister`) invoke it on every build. Upgrading only one of the pair produces build failures that read as recipe bugs.

## Why not just `icp settings update-check`

The built-in check is worth leaving on, but it only speaks once the user runs an `icp` command — by which point the agent has already chosen what to write. This hook runs before the session's first prompt, so the version reaches Claude's context up front; it also covers `ic-wasm`, which the built-in check does not.

## How the script works

It resolves each binary through its symlinks and reads the install channel off the path, because the upgrade command differs per channel and guessing wrong leaves two copies of the CLI on `PATH` shadowing each other:

| Binary resolves to | Channel | Upgrade command | Latest version from |
|---|---|---|---|
| `…/node_modules/@icp-sdk/…` | npm | `npm install -g <pkg>@latest` | GitHub release tag |
| `…/Cellar/…` | Homebrew | `brew upgrade <formula>` | `formulae.brew.sh` API |
| cargo-dist receipt in `~/.config/<app>/` | shell installer | `icp-cli-update` / `ic-wasm-update` | GitHub release tag |
| anything else | unknown | *(none — reports the release URL)* | GitHub release tag |

- **curl and POSIX tools only** — no `jq` (unlike the autosync script). The GitHub probe follows the `/releases/latest` redirect rather than calling the API, so it needs no token and cannot hit the 60-requests-per-hour anonymous limit that a per-session hook would otherwise reach. Homebrew is asked for its own formula version because the formula can trail a release by a day or two.
- **Throttled** — a check that reached a release feed is stamped in `.claude/.icp-upgrade-check` and not repeated for 6h (`ICP_UPGRADE_CHECK_INTERVAL`, `--force`, and any run from a terminal override it). Measured: ~1.1 s for a real check, ~10 ms throttled. A failed probe is deliberately not stamped, so an offline session retries at the next one.
- **Safe by construction** — never installs an absent tool (even in auto mode), never runs `sudo` (a non-writable npm prefix is reported instead, since a password prompt inside a hook has no terminal), detects when an upgrade succeeded but `PATH` still resolves to the old copy, and exits 0 on every failure path.
- For auto mode the skill registers the hook with `"timeout": 300`, since installing a CLI binary can exceed the 60 s hook default and a timed-out install leaves the tool half-written.

Verified against real installs on this machine: `icp` 1.2.0 from the shell installer (shell channel, `icp-cli-update`) and `ic-wasm` 0.9.11 from npm (npm channel) — two different channels for the two tools, each detected and given the right command. The offline, up-to-date, missing-tool, unknown-channel, non-writable-prefix, and shadowed-install paths were each exercised with stubs; `version_lt` has 9 cases covering pre-releases and multi-digit components.

## Evals

`evaluations/autoupgrade-icp-cli.json` — 5 output evals, 18 trigger queries.

**Output: 19/20 with skill vs 9/20 baseline. Triggers: 18/18.**

Eval 2 initially scored 3/4 — the agent produced a correct auto-mode hook but never mentioned that it changes the build toolchain mid-project. That risk was only stated in Step 1 and in a later section, not where the hook JSON is written; moving it next to the auto-mode block fixed it (re-run below: 4/4).

<details>
<summary>Full eval output</summary>

```
Evaluating skill: autoupgrade-icp-cli
Output cases: Setup plan and settings.json entry, Auto mode needs a raised hook timeout, Channel-correct upgrade command, ic-wasm version skew after upgrading icp, Upgrade ran but the version did not move

━━━ Setup plan and settings.json entry ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 6/6 passed
    ✅ Asks the user whether the hook should only notify or upgrade automatically
    ✅ Registers a SessionStart hook whose command runs the script
    ✅ Says the script is downloaded from the specified URL rather than hand-written
    ✅ Says an existing settings.json must be merged and not duplicated/overwritten
    ✅ Mentions the user will be asked to approve/trust the new hook
    ✅ Does not invent a settings.json schema — nests under hooks.SessionStart with hooks array of {type, command}

  WITHOUT skill: 2/6 passed
    ❌ Asks whether hook should only notify or upgrade automatically
       → The output unilaterally designs a notify-only warning script without presenting or asking about an auto-upgrade alternative.
    ✅ Registers a SessionStart hook whose command runs the script
    ❌ Says the script is downloaded from the skills.internetcomputer.org URL rather than hand-written
       → The output explicitly instructs writing a custom hand-written shell script and never mentions downloading from that or any URL.
    ❌ Says existing settings.json must be merged, preserving other keys/hooks, not duplicated/overwritten
       → The output shows a standalone JSON entry with no mention of merging with or preserving an existing settings.json file.
    ❌ Mentions user will be asked to approve/trust the new hook before it runs automatically
       → There is no mention anywhere of a trust/approval prompt for the new hook.
    ✅ Does not invent a settings.json schema

━━━ Auto mode needs a raised hook timeout ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 3/4 passed
    ✅ Uses the auto mode flag on the command (e.g. `--mode auto`)
    ✅ Raises the hook timeout above the 60 second default (e.g. "timeout": 300)
    ❌ Explains the risk of auto mode: a CLI upgrade can change build behaviour mid-project
       → The caveats cover silent execution, no prompt, sudo avoidance, shadowed PATH installs, pre-release handling, and swallowed network errors, but never mention that auto-upgrading icp/ic-wasm mid-session could change build/toolchain behavior for the current project.
    ✅ Does NOT claim the upgrade runs in the background — the hook blocks session start while it runs

  WITHOUT skill: 1/4 passed
    ❌ Uses the auto mode flag on the command (e.g. `--mode auto`)
       → The assistant produced no hook JSON at all, only a request for file access.
    ❌ Raises the hook timeout above the 60 second default (e.g. "timeout": 300)
       → No JSON or timeout value was ever presented.
    ❌ Explains the risk of auto mode: a CLI upgrade can change build behaviour mid-project
       → The output contains no discussion of risks since no solution was produced.
    ✅ Does NOT claim the upgrade runs in the background — the hook blocks session start while it runs

━━━ Channel-correct upgrade command ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 3/3 passed
    ✅ Gives `icp-cli-update` as the upgrade command
    ✅ Does NOT tell the user to run `npm install -g @icp-sdk/icp-cli@latest`
    ✅ Explains that the upgrade command depends on the channel the CLI was installed from

  WITHOUT skill: 2/3 passed
    ❌ Gives `icp-cli-update` (the updater the shell installer places on PATH) as the upgrade command
       → The output recommends re-running the curl install script instead of the `icp-cli-update` binary.
    ✅ Does NOT tell the user to run `npm install -g @icp-sdk/icp-cli@latest`, which would install a second copy from a different channel
    ✅ Explains that the upgrade command depends on the channel the CLI was installed from

━━━ ic-wasm version skew after upgrading icp ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 3/3 passed
    ✅ Points at ic-wasm being left behind while icp moved forward, since the official recipes invoke ic-wasm during every build
    ✅ Tells the user to check `ic-wasm --version` and upgrade it (e.g. `npm install -g @icp-sdk/ic-wasm@latest`)
    ✅ Does NOT send the user straight into debugging their Motoko code or recipe config as the first step

  WITHOUT skill: 1/3 passed
    ❌ Points at ic-wasm being left behind while icp moved forward, since the official recipes invoke ic-wasm during every build
       → The output vaguely gestures at stale cached moc/ic-wasm binaries causing version skew, but never clearly identifies the specific mechanism that ic-wasm is a separately-versioned tool that doesn't get updated when icp is upgraded via npm.
    ❌ Tells the user to check `ic-wasm --version` and upgrade it (e.g. `npm install -g @icp-sdk/ic-wasm@latest`)
       → The output never suggests running `ic-wasm --version` or gives any explicit upgrade command for ic-wasm; it only suggests generically clearing caches and rebuilding.
    ✅ Does NOT send the user straight into debugging their Motoko code or recipe config as the first step

━━━ Upgrade ran but the version did not move ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 4/4 passed
    ✅ Identifies that a second copy of icp from a different install channel is earlier on PATH and shadowing the npm one (commonly ~/.cargo/bin/icp from the shell installer)
    ✅ Suggests resolving the actual binary being used, e.g. `command -v icp` / `which icp` (and following the symlink) to see which copy wins
    ✅ Says upgrading through one channel will never move a copy installed through another — remove one, or upgrade the one that is actually on PATH
    ✅ Does NOT blame the npm cache or recommend reinstalling npm as the primary explanation

  WITHOUT skill: 3/4 passed
    ✅ Identifies that a second copy of icp from a different install channel is earlier on PATH and shadowing the npm one (commonly ~/.cargo/bin/icp from the shell installer)
    ✅ Suggests resolving the actual binary being used, e.g. `command -v icp` / `which icp` (and following the symlink) to see which copy wins
    ❌ Says upgrading through one channel will never move a copy installed through another — remove one, or upgrade the one that is actually on PATH
       → The output offers PATH reordering, removing the cargo copy, or aliasing as fixes, but never states the underlying principle that an npm upgrade can never touch a cargo-installed binary.
    ✅ Does NOT blame the npm cache or recommend reinstalling npm as the primary explanation

━━━ Trigger Evals ━━━

  Running trigger evaluation...

  Should trigger: 9/9 correct
    ✅ "Can you make this project always use the latest icp CLI?"
    ✅ "Set up a hook so I stop working with an outdated icp version"
    ✅ "I keep forgetting to update icp-cli. Automate it for me."
    ✅ "How do I upgrade the ICP CLI to the newest release?"
    ✅ "My icp is on 1.2.0 and the latest is 1.5.0 — what's the upgrade command?"
    ✅ "Install something that keeps icp and ic-wasm current at the start of every session"
    ✅ "I ran npm install -g @icp-sdk/icp-cli@latest but icp --version hasn't changed"
    ✅ "Is my ic-wasm too old for the version of icp I'm running?"
    ✅ "Add automatic ICP toolchain updates to .claude/settings.json"

  Should NOT trigger: 9/9 correct
    ✅ "Upgrade my canister without wiping its state — I think I need icp deploy --mode upgrade"
    ✅ "Bump the @dfinity/motoko recipe in my icp.yaml to the latest version"
    ✅ "Keep my Internet Computer skills in .claude/skills up to date automatically"
    ✅ "Update the moc compiler version in my mops.toml toolchain section"
    ✅ "My icp deploy is failing with a build error in the rust recipe"
    ✅ "What's the latest version of @icp-sdk/core I should depend on in my frontend?"
    ✅ "Write a GitHub Actions workflow that deploys my canister on every push to main"
    ✅ "How do I upgrade a canister's Wasm module on mainnet without losing stable memory?"
    ✅ "Add a SessionStart hook that runs my test suite before I start working"

━━━ Summary ━━━

  Output evals:
    Setup plan and settings.json entry: WITH 6/6 | WITHOUT 2/6
    Auto mode needs a raised hook timeout: WITH 3/4 | WITHOUT 1/4
    Channel-correct upgrade command: WITH 3/3 | WITHOUT 2/3
    ic-wasm version skew after upgrading icp: WITH 3/3 | WITHOUT 1/3
    Upgrade ran but the version did not move: WITH 4/4 | WITHOUT 3/4
  Trigger evals: should-trigger 9/9 | should-not-trigger 9/9

Full results saved to: /home/raymond/dev/icskills/evaluations/results/autoupgrade-icp-cli-2026-09-11T15-31-18-804Z.json
```

</details>

<details>
<summary>Eval 2 re-run after the fix</summary>

```
Evaluating skill: autoupgrade-icp-cli
Output cases: Auto mode needs a raised hook timeout

━━━ Auto mode needs a raised hook timeout ━━━

  Running WITH skill...
  Running WITHOUT skill...
  Judging WITH skill...
  Judging WITHOUT skill...

  WITH skill: 4/4 passed
    ✅ Uses the auto mode flag on the command (e.g. `--mode auto`)
    ✅ Raises the hook timeout above the 60 second default (e.g. "timeout": 300)
    ✅ Explains the risk of auto mode: a CLI upgrade can change build behaviour mid-project
    ✅ Does NOT claim the upgrade runs in the background

  WITHOUT skill: 1/4 passed
    ❌ Uses the auto mode flag on the command (e.g. `--mode auto`)
       → The assistant never produced any hook command or JSON at all, only asked for file access permission.
    ❌ Raises the hook timeout above the 60 second default (e.g. "timeout": 300)
       → No hook JSON or timeout value was output; the assistant stopped at a permission request.
    ❌ Explains the risk of auto mode: a CLI upgrade can change build behaviour mid-project
       → No risk explanation was given since the task was not completed.
    ✅ Does NOT claim the upgrade runs in the background

━━━ Summary ━━━

  Output evals:
    Auto mode needs a raised hook timeout: WITH 4/4 | WITHOUT 1/4

Full results saved to: /home/raymond/dev/icskills/evaluations/results/autoupgrade-icp-cli-2026-09-11T15-33-26-242Z.json
```

</details>

## Checks

- `npm run validate` — passes (0 errors; the 3 repo-wide warnings are pre-existing missing-eval files for other skills)
- `npm run build` — passes; the skill and `scripts/upgrade-icp-cli.sh` are published under `.well-known/skills/autoupgrade-icp-cli/`, so the URL the skill tells agents to curl resolves once this is deployed
- `skill-validator score evaluate --provider claude-cli` — **4.50/5** (clarity 4, actionability 5, token efficiency 4, scope discipline 5, directive precision 5, novelty 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
