### PR TITLE
feat(icp-cli): document ICP_HOME isolation for parallel agents

### DIFF
--- a/evaluations/icp-cli.json
+++ b/evaluations/icp-cli.json
@@ -301,6 +301,18 @@
         "Explains that the default host resolution uses the page origin on known gateway hosts (ic0.app/icp0.io/localhost) and falls back to https://icp-api.io elsewhere, so custom domains work even though they do not serve /api/v2",
         "Does NOT set host to window.location.origin (conditionally or unconditionally)"
       ]
+    },
+    {
+      "name": "Parallel agents sharing global CLI state (ICP_HOME)",
+      "prompt": "I'm running several coding agents against the same icp-cli repo in separate git worktrees and they keep blocking each other on icp commands and stepping on each other's identity. How do I isolate them? Just the environment setup and identity commands, no deploy walkthrough.",
+      "expected_behaviors": [
+        "Sets ICP_HOME to a per-worktree/per-agent directory to isolate global CLI state",
+        "Sets the managed local network gateway.port to 0 so each worktree gets a free port",
+        "Warns that the OS keyring is shared across ICP_HOME values, so identity names collide between agents",
+        "Recommends 'icp identity new <name> --storage plaintext' for the per-agent identity",
+        "Does NOT claim that ICP_HOME alone isolates keyring-stored identities",
+        "Mentions that a fresh ICP_HOME re-downloads the package cache (recipes, network launcher)"
+      ]
     }
   ],
   "trigger_evals": {

--- a/skills/agent-web-identity/SKILL.md
+++ b/skills/agent-web-identity/SKILL.md
@@ -177,6 +177,13 @@ match the principal the app shows the user when they are signed in to
   — there is no flag to shorten it.
 - Never export, print, or log the identity's key material; leave it in the
   CLI's default keyring storage.
+- Give the identity a name unique to this session. The keyring entry holding
+  the session key is keyed by service `icp-cli` plus the identity name, and
+  that key is shared across the whole OS user — setting `ICP_HOME` does not
+  isolate it. Two concurrent agents that link a web identity under the same
+  name overwrite each other's session key. Prefix with the agent and app
+  (e.g. `claude-oisy-<short-id>`); see "Parallel agents and worktrees" in the
+  `icp-cli` skill for the wider isolation picture.
 - Keep output to the minimum. When a step succeeds, don't echo command output
   or narrate progress — surface only what needs the user: the sign-in URL,
   confirmation requests, errors, and the final verified principal.

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -178,7 +178,7 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
     ```bash
     icp network stop --project-root-override /path/to/other-project
     ```
-    To run both networks at once instead of stopping one — e.g. parallel git worktrees — set `gateway.port: 0` so each gets a free port. See "Parallel local networks (git worktrees)" under How It Works.
+    To run both networks at once instead of stopping one — e.g. parallel git worktrees — set `gateway.port: 0` so each gets a free port. See "Parallel agents and worktrees" under How It Works.
 
     **Scenario B — a non-icp service holds the port.** Configure an alternate port in `icp.yaml` and read the actual URLs dynamically via `icp network status --json` rather than hardcoding localhost:8000:
     ```yaml
@@ -291,7 +291,9 @@ environments:
         freezing_threshold: 7776000
 ```
 
-### Parallel local networks (git worktrees)
+### Parallel agents and worktrees
+
+#### Isolating the gateway port
 
 Local networks are project-local — keyed by project root (Pitfall 9). Separate git worktrees of the same repo are separate project roots, so each worktree can run its own independent local network. This lets multiple agents or branches build and deploy in parallel without interfering. The only obstacle is the gateway port: every worktree defaults to `8000`, so the second `icp network start` fails with a port conflict.
 
@@ -316,6 +318,27 @@ icp network status --json | jq -r '.gateway_url'   # http://localhost:58157/
 ```
 
 Never hardcode `localhost:8000` when using `port: 0` — the port changes on every start, so read `gateway_url` (or `api_url`) from `icp network status --json` each time. To target a specific worktree's network from outside its directory, pass the global `--project-root-override <path>` flag (e.g. `icp network status --json --project-root-override /path/to/worktree`).
+
+#### Isolating global CLI state (`ICP_HOME`)
+
+Project-local networks isolate *per-project* state only. Identities, settings, and the downloaded package cache are **global** — one directory per OS user, at `~/.local/share/icp-cli/` (Linux), `~/Library/Application Support/org.dfinity.icp-cli/` (macOS), or `%APPDATA%\icp-cli\data\` (Windows). Each of `identity/`, `settings/`, and `pkg/` inside it is guarded by a blocking advisory lock (`.lock`), so concurrent `icp` invocations touching the same one **serialize** — they wait for the lock, they do not fail. Several agents building at once contend on the package cache lock while recipes or the network launcher download.
+
+`ICP_HOME` overrides that directory, giving each agent its own copy:
+
+```bash
+export ICP_HOME=/path/to/worktree/.icp-home
+icp identity new dev --storage plaintext
+icp deploy
+```
+
+Caveats, in the order they bite:
+
+- **The OS keyring is still shared.** Keyring entries are keyed by service `icp-cli` plus the identity name — `ICP_HOME` is not part of the key. Two isolated homes that each run `icp identity new dev` (keyring is the default storage) write the same entry and overwrite one another. Pass `--storage plaintext` so the key lands at `$ICP_HOME/identity/keys/<name>.pem` and the isolation is real. The same applies to `icp identity import` and `icp identity link web`, whose session key also defaults to the keyring. Plaintext keys are for throwaway local and CI identities only — never for an identity that controls mainnet canisters or holds value (Pitfall 20).
+- **A fresh home is empty.** No identities, no settings, no cache. The default identity is anonymous, which managed local networks seed automatically but which is unusable on mainnet.
+- **The package cache is re-downloaded per home.** `pkg/` holds the network launcher and every recipe, and reaches hundreds of MB. Seed a new home by copying a warm `pkg/` into it, or point all homes at one shared launcher binary with `ICP_CLI_NETWORK_LAUNCHER_PATH=/path/to/icp-cli-network-launcher`.
+- **`ICP_HOME` must be set for every `icp` invocation** in that agent's session, not just the first. A command that misses it silently falls back to the shared default home and a different default identity.
+
+Reach for this only when agents actually contend. Separate worktrees that share one identity set and tolerate serialized cache access do not need it.
 
 ### Install Modes
 

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -354,12 +354,9 @@ icp deploy --mode reinstall   # Clear all state (dangerous)
 
 ```bash
 icp project bundle --output my-app.icp      # gzipped tar; --output accepts any path
-
-mkdir app && tar -xzf my-app.icp -C app     # deploy from a bundle: extract, then deploy
-cd app && icp deploy -e <environment>       # no build toolchain needed — steps are prebuilt
 ```
 
-For what the archive contains, the conditions that make bundling fail, and uploading a package to a Caffeine cloud engine, read `references/bundling.md`.
+For how to deploy from a bundle, what the archive contains, the conditions that make bundling fail, and uploading a package to a Caffeine cloud engine, see `references/bundling.md`.
 
 ## Configuration
 

--- a/skills/icp-cli/SKILL.md
+++ b/skills/icp-cli/SKILL.md
@@ -350,34 +350,16 @@ icp deploy --mode reinstall   # Clear all state (dangerous)
 
 ### Bundling a project into an `.icp` package (experimental)
 
-`icp project bundle` (icp-cli >= 0.3.0) packages a project into a self-contained deployable archive. **This is an experimental feature, intentionally hidden from help output** — `icp --help` and `icp project --help` do not list it, but the command exists and works. Do not conclude it doesn't exist because help omits it, and do not suggest it proactively — use it only when the user explicitly asks to bundle an app or produce an `.icp` package.
+`icp project bundle` packages a project into a self-contained deployable archive (icp-cli >= 0.3.0). **This is an experimental feature, intentionally hidden from help output** — `icp --help` and `icp project --help` do not list it, but the command exists and works. Do not conclude it doesn't exist because help omits it, and do not suggest it proactively — use it only when the user explicitly asks to bundle an app or produce an `.icp` package.
 
 ```bash
-icp project bundle --output my-app.icp
+icp project bundle --output my-app.icp      # gzipped tar; --output accepts any path
+
+mkdir app && tar -xzf my-app.icp -C app     # deploy from a bundle: extract, then deploy
+cd app && icp deploy -e <environment>       # no build toolchain needed — steps are prebuilt
 ```
 
-The output is a gzipped tar archive; `--output` accepts any path (`my-app.icp` and `bundle.tar.gz` are both common). The bundle contains the built WASMs and a rewritten `icp.yaml`:
-
-- All canisters are built first; each canister's build steps are replaced with a prebuilt step referencing the bundled WASM (`canisters/<name>.wasm`), pinned by sha256.
-- Plugin sync steps (e.g. the asset canister's upload plugin) are preserved — the plugin WASM and its `dirs`/`files` inputs are copied into the archive.
-- Network and environment manifests referenced by path are inlined; `init_args` files are copied into the archive.
-- An optional `icp_appmanifest.yaml` (app metadata) is included, with its `screenshots` paths relocated into the archive.
-
-To deploy from a bundle, extract it and run `icp deploy` from the extracted directory — no build toolchain (Rust, mops, npm) is required because every build step is prebuilt:
-
-```bash
-mkdir app && tar -xzf my-app.icp -C app
-cd app && icp deploy -e <environment>
-```
-
-An `.icp` package can also be uploaded to a Caffeine cloud engine via the console's App Center ("Upload a custom app") — see the `deploy-to-cloud-engine` skill.
-
-Bundling fails when:
-
-- A canister has a `script` sync step — only `plugin` sync steps can be replayed from a bundle (`canister 'X' has a script sync step, which is not supported in bundles`).
-- Any synced directory, plugin file, `init_args` file, or screenshot resolves outside the project directory.
-- The `--output` path is inside a directory the bundle would sync (the partial archive would include itself).
-- A managed network defines a bind mount with an absolute host path — bundles require relative paths for portability.
+For what the archive contains, the conditions that make bundling fail, and uploading a package to a Caffeine cloud engine, read `references/bundling.md`.
 
 ## Configuration
 
@@ -505,6 +487,7 @@ For the complete CLI and configuration schema, consult the [icp-cli documentatio
 For detailed guides on specific topics, consult these reference files when needed:
 
 - **`references/binding-generation.md`** — TypeScript binding generation with `@icp-sdk/bindgen` (Vite plugin, CLI, actor setup)
+- **`references/bundling.md`** — `icp project bundle` in full: archive contents, the four conditions that make bundling fail, and uploading an `.icp` package to a Caffeine cloud engine
 - **`references/canister-env-vars.md`** — reading `PUBLIC_CANISTER_ID:<name>` from canister code at runtime (Motoko/Rust examples, lazy-read pattern)
 - **`references/dev-server.md`** — Vite dev server configuration to simulate the `ic_env` cookie locally. Important: wrap `getDevServerConfig()` in a `command === "serve"` guard so it only runs during `vite dev`, not `vite build`.
 - **`references/dfx-migration.md`** — Complete dfx → icp migration guide (command mapping, config mapping, identity/canister ID migration, frontend package migration, post-migration verification checklist)

--- a/skills/icp-cli/references/bundling.md
+++ b/skills/icp-cli/references/bundling.md
@@ -1,0 +1,30 @@
+# Bundling a Project into an `.icp` Package (experimental)
+
+`icp project bundle` (icp-cli >= 0.3.0) packages a project into a self-contained deployable archive. **This is an experimental feature, intentionally hidden from help output** — `icp --help` and `icp project --help` do not list it, but the command exists and works. Do not conclude it doesn't exist because help omits it, and do not suggest it proactively — use it only when the user explicitly asks to bundle an app or produce an `.icp` package.
+
+```bash
+icp project bundle --output my-app.icp
+```
+
+The output is a gzipped tar archive; `--output` accepts any path (`my-app.icp` and `bundle.tar.gz` are both common). The bundle contains the built WASMs and a rewritten `icp.yaml`:
+
+- All canisters are built first; each canister's build steps are replaced with a prebuilt step referencing the bundled WASM (`canisters/<name>.wasm`), pinned by sha256.
+- Plugin sync steps (e.g. the asset canister's upload plugin) are preserved — the plugin WASM and its `dirs`/`files` inputs are copied into the archive.
+- Network and environment manifests referenced by path are inlined; `init_args` files are copied into the archive.
+- An optional `icp_appmanifest.yaml` (app metadata) is included, with its `screenshots` paths relocated into the archive.
+
+To deploy from a bundle, extract it and run `icp deploy` from the extracted directory — no build toolchain (Rust, mops, npm) is required because every build step is prebuilt:
+
+```bash
+mkdir app && tar -xzf my-app.icp -C app
+cd app && icp deploy -e <environment>
+```
+
+An `.icp` package can also be uploaded to a Caffeine cloud engine via the console's App Center ("Upload a custom app") — see the `deploy-to-cloud-engine` skill.
+
+Bundling fails when:
+
+- A canister has a `script` sync step — only `plugin` sync steps can be replayed from a bundle (`canister 'X' has a script sync step, which is not supported in bundles`).
+- Any synced directory, plugin file, `init_args` file, or screenshot resolves outside the project directory.
+- The `--output` path is inside a directory the bundle would sync (the partial archive would include itself).
+- A managed network defines a bind mount with an absolute host path — bundles require relative paths for portability.


### PR DESCRIPTION
## Problem

`icp-cli` isolates *per-project* state by project root, and the skill already documents how to run parallel local networks across git worktrees. But identities, settings, and the downloaded package cache are **global** — one directory per OS user — and each of `identity/`, `settings/`, and `pkg/` is guarded by a blocking advisory lock. Several agents running `icp` at once serialize on those locks even in separate worktrees, and share one identity set.

`ICP_HOME` fixes this, but it has caveats that are not documented anywhere — upstream's [environment variables reference](https://github.com/dfinity/icp-cli/blob/main/docs/reference/environment-variables.md#icp_home) lists the variable only as "keep data in a specific location / share via a synced folder / isolate for testing".

The sharpest caveat: **`ICP_HOME` does not isolate the OS keyring.** Keyring entries are keyed by service `icp-cli` plus the identity name, with the home path playing no part, so two isolated homes that each run `icp identity new dev` (keyring is the default storage) overwrite each other's key. `--storage plaintext` is what makes the isolation real.

## Verification

Everything below was checked against `icp 1.2.0` and upstream source, not inferred:

| Claim | Evidence |
|---|---|
| `ICP_HOME` sets `{identity,pkg,settings,telemetry}` | ran the CLI against a fresh home, `find` showed exactly those |
| Each of those has its own `.lock` | `$ICP_HOME/{identity,pkg,settings}/.lock` created on first use |
| Locks are blocking advisory `flock`s, not fail-fast | [`crates/icp/src/fs/lock.rs`](https://github.com/dfinity/icp-cli/blob/main/crates/icp/src/fs/lock.rs) → `file.lock()` / `lock_shared()` inside `spawn_blocking` |
| Plaintext keys stay inside the home | `$ICP_HOME/identity/keys/<name>.pem` |
| Keyring entries are global per OS user | `const SERVICE_NAME = "icp-cli"` / `Entry::new(SERVICE_NAME, &identity_name)` in `crates/icp/src/identity/key.rs` |
| A fresh home re-downloads a lot | the existing default `pkg/` on this machine is 405 MB |
| `--storage plaintext\|keyring\|password` on `new`, `import`, `link web` | `icp identity <cmd> --help` |

## Changes

- **`skills/icp-cli/SKILL.md`** — renamed `### Parallel local networks (git worktrees)` to `### Parallel agents and worktrees` and split it into two subsections. The existing gateway-port content is unchanged under `#### Isolating the gateway port`; the new `#### Isolating global CLI state (ICP_HOME)` covers the lock behaviour, the `ICP_HOME` setup, and the four caveats (shared keyring, empty fresh home, re-downloaded cache, must be set on every invocation). The in-body cross-reference at Pitfall 18 was updated to the new heading.
- **`skills/agent-web-identity/SKILL.md`** — one bullet in `## Security Rules for Agents`: the session key for a web-linked identity goes to the same shared keyring, so identity names must be unique per session and `ICP_HOME` will not save you. Reinforces the existing agent-prefixed-name guidance rather than replacing it.
- **`evaluations/icp-cli.json`** — one new output eval case.

- **`skills/icp-cli/references/bundling.md`** (new) — `SKILL.md` crossed the advisory 500-line threshold, so the `icp project bundle` detail moved out. It is the right section to move: the skill already says not to suggest it proactively, so its detail is opt-in reading. The body keeps the command and the experimental/hidden-from-`--help` warning; archive contents, the four failure conditions, the deploy-from-bundle flow, and the cloud engine upload live in the reference. Body is now 482 lines.

No new pitfall was added: the pitfall list guards against things agents write unprompted, and an agent will not invent `ICP_HOME` on its own. These failure modes only bite someone already using it, so they belong next to the instructions.

## Evals

New case run with baseline. The baseline run is a good illustration of the problem — without the skill the model invents an `ICP_CONFIG_ROOT` variable, suggests overriding `HOME` wholesale, and then explicitly makes the false isolation claim the case is written to catch.

<details>
<summary><code>node scripts/evaluate-skills.js icp-cli --eval 29</code> — WITH 6/6 | WITHOUT 0/6</summary>

```
━━━ Parallel agents sharing global CLI state (ICP_HOME) ━━━

  WITH skill: 6/6 passed
    ✅ Sets ICP_HOME to a per-worktree/per-agent directory to isolate global CLI state
    ✅ Sets the managed local network gateway.port to 0 so each worktree gets a free port
    ✅ Warns that the OS keyring is shared across ICP_HOME values, so identity names collide between agents
    ✅ Recommends 'icp identity new <name> --storage plaintext' for the per-agent identity
    ✅ Does NOT claim that ICP_HOME alone isolates keyring-stored identities
    ✅ Mentions that a fresh ICP_HOME re-downloads the package cache (recipes, network launcher)

  WITHOUT skill: 0/6 passed
    ❌ Sets ICP_HOME to a per-worktree/per-agent directory to isolate global CLI state
       → The output never mentions ICP_HOME; it recommends overriding HOME wholesale and only
         speculatively guesses at an 'ICP_CONFIG_ROOT'-style variable without confirming or naming it.
    ❌ Sets the managed local network gateway.port to 0 so each worktree gets a free port
       → The output only vaguely suggests `icp start --host 127.0.0.1:0` as an unconfirmed guess and
         never mentions a gateway.port configuration setting.
    ❌ Warns that the OS keyring is shared across ICP_HOME values, so identity names collide between agents
       → There is no mention of the OS keyring or any warning about identity name collisions across
         isolated config roots.
    ❌ Recommends 'icp identity new <name> --storage plaintext' for the per-agent identity
       → The output recommends `icp identity new agent-1-identity` with no --storage plaintext flag or
         any mention of storage backend.
    ❌ Does NOT claim that ICP_HOME alone isolates keyring-stored identities
       → The output explicitly claims that overriding HOME causes identities and the active-identity
         pointer to 'end up in agent-1's private tree instead of the shared one,' asserting full
         isolation of identities via the home/config-root override, which is the false claim this
         behavior says to avoid.
    ❌ Mentions that a fresh ICP_HOME re-downloads the package cache (recipes, network launcher)
       → No mention of package cache, recipes, or network launcher re-download costs anywhere in the output.

━━━ Summary ━━━
  Output evals:
    Parallel agents sharing global CLI state (ICP_HOME): WITH 6/6 | WITHOUT 0/6
```

</details>

Existing case 21 (*Parallel local networks across git worktrees*) is scoped to the port problem only and covers content this PR left byte-identical, so it was not re-run.

## Validation

`npm run validate` — 31 skills validated, all passed. `icp-cli` is down to 1 warning; the 500-line warning this PR briefly introduced is cleared by the `references/bundling.md` split. The body remains over the advisory token guideline (7973 vs recommended 5000), as it was before this PR.

### Are `references/` files actually reached?

Moving content out of `SKILL.md` raises a fair question this repo has not tested: `scripts/evaluate-skills.js` passes only `SKILL.md` as the system prompt, so reference content is exercised only if the model follows a pointer. Coverage of all five `references/*.md` files rests on that.

It holds, at least here. With the deploy-from-bundle commands removed from the body so the case genuinely depends on the pointer, the eval reads the file and still scores 4/4:

<details>
<summary><code>node scripts/evaluate-skills.js icp-cli --eval 26 --no-baseline</code> — pointer followed</summary>

```
━━━ Adversarial: bundling a project into an .icp package ━━━

  Running WITH skill...
  Tool calls: 1
    → Read: .../skills/icp-cli/references/bundling.md
  Judging WITH skill...

  WITH skill: 4/4 passed
    ✅ Uses `icp project bundle --output <path>` as the bundling command
    ✅ Notes the command is experimental and hidden from `icp --help` output but works
    ✅ Deploys by extracting the archive (tar -xzf) and running `icp deploy` from the extracted directory
    ✅ Does NOT invent commands like `icp bundle`, `icp package`, or `dfx` equivalents
```

</details>

Behavior 3 passes from the reference, not from a copy left behind in the body. Tested with both an imperative pointer and the repo's declarative house style (`For …, see references/bundling.md`); the file is read either way, so the house-style phrasing is what shipped.

These are single runs against a non-deterministic runner, so the claim is "references are reachable in this harness," not "references are always read."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
